### PR TITLE
Correct name of the inspecktor-gadget binary in installation step

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ $ sudo cp inspektor-gadget/inspektor-gadget /usr/local/bin/kubectl-gadget
 Install Inspektor Gadget on Kubernetes:
 
 ```
-$ inspektor-gadget deploy | kubectl apply -f -
+$ kubectl gadget deploy | kubectl apply -f -
 ```
 
 [Read the detailed install instructions](Documentation/install.md)


### PR DESCRIPTION
Incorrect - `inspektor-gadget deploy | kubectl apply -f`
Correct - `kubectl gadget deploy | kubectl apply -f`
Correct - `kubectl-gadget deploy | kubectl apply -f`

Signed-off-by: Imran Pochi <imran@kinvolk.io>