### PR TITLE
Add gadget bindsnoop

### DIFF
--- a/Documentation/demo-bindsnoop.md
+++ b/Documentation/demo-bindsnoop.md
@@ -1,0 +1,29 @@
+# Inspektor Gadget demo: the "bindsnoop" gadget
+
+The bindsnoop gadget traces the kernel function performing socket binding and
+print socket options set before the system call invocation that might impact
+bind behavior and bound interface.
+
+It comes from the [bcc bindsnoop
+tool](https://github.com/iovisor/bcc/blob/master/tools/bindsnoop_example.txt)
+and displays the same output.
+
+In one terminal, start the bindsnoop gadget:
+```
+$ inspektor-gadget bindsnoop --label run=nginx-app
+```
+
+In another terminal, start nginx:
+```
+$ kubectl run --generator=run-pod/v1 --image=nginx nginx-app --port=80
+pod/nginx-app created
+```
+
+When nginx starts, it binds on the TCP port 80. Inspektor Gadget will detect it
+and display the following output:
+
+```
+[ 1] Tracing binds ... Hit Ctrl-C to end
+[ 1]      PID COMM         PROT ADDR            PORT   OPTS IF
+[ 1]    18411 nginx        TCP  0.0.0.0            80 ...R.  0
+```

--- a/Documentation/demo-bindsnoop.md
+++ b/Documentation/demo-bindsnoop.md
@@ -1,10 +1,7 @@
 # Inspektor Gadget demo: the "bindsnoop" gadget
 
-The bindsnoop gadget traces the kernel function performing socket binding and
-print socket options set before the system call invocation that might impact
-bind behavior and bound interface.
-
-It comes from the [bcc bindsnoop
+bindsnoop reports socket options set before the bind call that would impact
+this system call behavior. It comes from the [bcc bindsnoop
 tool](https://github.com/iovisor/bcc/blob/master/tools/bindsnoop_example.txt)
 and displays the same output.
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Usage:
   kubectl gadget [command]
 
 Available Commands:
+  bindsnoop    Trace bind
   capabilities Suggest Security Capabilities for securityContext
   deploy       Deploy Inspektor Gadget on the worker nodes
   execsnoop    Trace new processes
@@ -34,6 +35,7 @@ Use "kubectl gadget [command] --help" for more information about a command.
 
 Inspektor Gadget is a kubectl plugin. It can also be invoked with `kubectl gadget`.
 
+- [Demo: the "bindsnoop" gadget](Documentation/demo-bindsnoop.md)
 - [Demo: the "execsnoop" gadget](Documentation/demo-execsnoop.md) – watch it [as GIF](Documentation/demos/demo-execsnoop-gifterminal.gif)
 - [Demo: the "opensnoop" gadget](Documentation/demo-opensnoop.md) – watch it [as GIF](Documentation/demos/demo-opensnoop-gifterminal.gif)
 - [Demo: the "traceloop" gadget](Documentation/demo-traceloop.md) – watch it [as GIF](Documentation/demos/demo-traceloop-gifterminal.gif)

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Not all gadgets currently work everywhere.
 | capabilities |       ✔️      |                |          |     |
 | execsnoop    |       ✔️      |                |          |     |
 | opensnoop    |       ✔️      |                |          |     |
+| bindsnoop    |       ✔️      |                |          |     |
 | tcpconnect   |       ✔️      |                |          |     |
 | tcptop       |       ✔️      |                |          |     |
 

--- a/cmd/inspektor-gadget/cmd/bcck8s.go
+++ b/cmd/inspektor-gadget/cmd/bcck8s.go
@@ -51,7 +51,7 @@ var tcptopCmd = &cobra.Command{
 	PersistentPreRunE: doesKubeconfigExist,
 }
 
-var hintsNetworkCmd = &cobra.Command{
+var tcpconnectCmd = &cobra.Command{
 	Use:               "tcpconnect",
 	Short:             "Suggest Kubernetes Network Policies",
 	Run:               bccCmd("tcpconnect", "/opt/bcck8s/tcpconnect"),
@@ -76,7 +76,14 @@ var (
 )
 
 func init() {
-	commands := []*cobra.Command{execsnoopCmd, opensnoopCmd, bindsnoopCmd, tcptopCmd, hintsNetworkCmd, capabilitiesCmd}
+	commands := []*cobra.Command{
+		execsnoopCmd,
+		opensnoopCmd,
+		bindsnoopCmd,
+		tcptopCmd,
+		tcpconnectCmd,
+		capabilitiesCmd,
+	}
 	args := []string{"label", "node", "namespace", "podname"}
 	vars := []*string{&labelParam, &nodeParam, &namespaceParam, &podnameParam}
 	for _, command := range commands {

--- a/cmd/inspektor-gadget/cmd/bcck8s.go
+++ b/cmd/inspektor-gadget/cmd/bcck8s.go
@@ -26,35 +26,42 @@ import (
 var execsnoopCmd = &cobra.Command{
 	Use:               "execsnoop",
 	Short:             "Trace new processes",
-	Run:               bccCmd("execsnoop", "execsnoop-ig"),
+	Run:               bccCmd("execsnoop", "/opt/bcck8s/execsnoop-ig"),
 	PersistentPreRunE: doesKubeconfigExist,
 }
 
 var opensnoopCmd = &cobra.Command{
 	Use:               "opensnoop",
 	Short:             "Trace files",
-	Run:               bccCmd("opensnoop", "opensnoop-ig"),
+	Run:               bccCmd("opensnoop", "/opt/bcck8s/opensnoop-ig"),
+	PersistentPreRunE: doesKubeconfigExist,
+}
+
+var bindsnoopCmd = &cobra.Command{
+	Use:               "bindsnoop",
+	Short:             "Trace bind",
+	Run:               bccCmd("opensnoop", "/usr/share/bcc/tools/bindsnoop"),
 	PersistentPreRunE: doesKubeconfigExist,
 }
 
 var tcptopCmd = &cobra.Command{
 	Use:               "tcptop",
 	Short:             "Show the TCP traffic in a pod",
-	Run:               bccCmd("tcptop", "tcptop-edge"),
+	Run:               bccCmd("tcptop", "/opt/bcck8s/tcptop-edge"),
 	PersistentPreRunE: doesKubeconfigExist,
 }
 
 var hintsNetworkCmd = &cobra.Command{
 	Use:               "tcpconnect",
 	Short:             "Suggest Kubernetes Network Policies",
-	Run:               bccCmd("tcpconnect", "tcpconnect"),
+	Run:               bccCmd("tcpconnect", "/opt/bcck8s/tcpconnect"),
 	PersistentPreRunE: doesKubeconfigExist,
 }
 
 var capabilitiesCmd = &cobra.Command{
 	Use:               "capabilities",
 	Short:             "Suggest Security Capabilities for securityContext",
-	Run:               bccCmd("capabilities", "capable-edge"),
+	Run:               bccCmd("capabilities", "/opt/bcck8s/capable-edge"),
 	PersistentPreRunE: doesKubeconfigExist,
 }
 
@@ -69,7 +76,7 @@ var (
 )
 
 func init() {
-	commands := []*cobra.Command{execsnoopCmd, opensnoopCmd, tcptopCmd, hintsNetworkCmd, capabilitiesCmd}
+	commands := []*cobra.Command{execsnoopCmd, opensnoopCmd, bindsnoopCmd, tcptopCmd, hintsNetworkCmd, capabilitiesCmd}
 	args := []string{"label", "node", "namespace", "podname"}
 	vars := []*string{&labelParam, &nodeParam, &namespaceParam, &podnameParam}
 	for _, command := range commands {

--- a/cmd/inspektor-gadget/cmd/bcck8s.go
+++ b/cmd/inspektor-gadget/cmd/bcck8s.go
@@ -39,7 +39,7 @@ var opensnoopCmd = &cobra.Command{
 
 var bindsnoopCmd = &cobra.Command{
 	Use:               "bindsnoop",
-	Short:             "Trace bind",
+	Short:             "Trace IPv4 and IPv6 bind() system calls",
 	Run:               bccCmd("opensnoop", "/usr/share/bcc/tools/bindsnoop"),
 	PersistentPreRunE: doesKubeconfigExist,
 }

--- a/gadget-ds/bcc.Dockerfile
+++ b/gadget-ds/bcc.Dockerfile
@@ -2,7 +2,8 @@
 #
 #   git clone https://github.com/iovisor/bcc.git
 #   cd bcc
-#   docker build -t kinvolk/bcc:snapshot-20191221-git-8174c0ae5541 -f ./Dockerfile.ubuntu .
+#   TAG="snapshot-$(date +%Y%m%d)-$(git describe --tags --always)"
+#   docker build -t kinvolk/bcc:${TAG} -f ./Dockerfile.ubuntu .
 #
 # Then, use this Dockerfile with:
 #
@@ -10,7 +11,7 @@
 #   make docker-bcc/build
 #   make docker-bcc/push
 
-FROM kinvolk/bcc:snapshot-20191221-git-8174c0ae5541 as packages
+FROM kinvolk/bcc:snapshot-20200220-v0.13.0-2-g12eafe87 as packages
 
 FROM ubuntu:bionic
 

--- a/gadget-ds/files/bcck8s/bcc-wrapper.sh
+++ b/gadget-ds/files/bcck8s/bcc-wrapper.sh
@@ -85,4 +85,4 @@ CGROUPMAP=$BPFDIR/gadget/cgroupidset-$TRACERID
 
 export TERM=xterm-256color
 export PYTHONUNBUFFERED=TRUE
-exec /opt/bcck8s/$GADGET --cgroupmap $CGROUPMAP "$@"
+exec $GADGET --cgroupmap $CGROUPMAP "$@"


### PR DESCRIPTION
```
$ inspektor-gadget tcpbind --label run=nginx-app
Node numbers: 0 = ip-10-0-1-49 1 = ip-10-0-15-182 2 = ip-10-0-19-78
[ 1] Tracing binds ... Hit Ctrl-C to end
[ 1]   PID COMM         IP ADDR            PORT   OPTS IF
[ 2] Tracing binds ... Hit Ctrl-C to end
[ 2]   PID COMM         IP ADDR            PORT   OPTS IF
[ 0] Tracing binds ... Hit Ctrl-C to end
[ 0]   PID COMM         IP ADDR            PORT   OPTS IF
[ 1]  6991 nginx        4  0.0.0.0            80 ...R.  0
```
The nginx line is printed when starting nginx:
```
$ kubectl run --image=nginx nginx-app --port=80
kubectl run --generator=deployment/apps.v1 is DEPRECATED and will be removed in a future version. Use kubectl run --generator=run-pod/v1 or kubectl create instead.
deployment.apps/nginx-app created
```

Fixes https://github.com/kinvolk/inspektor-gadget/issues/34
