### PR TITLE
Add Network Policy Advisor gadget

### DIFF
--- a/Documentation/demo-network-policy.md
+++ b/Documentation/demo-network-policy.md
@@ -1,0 +1,88 @@
+# Inspektor Gadget demo: the "network-policy" gadget
+
+network-policy monitors the network activity in the specified namespaces and
+record the list of new TCP connections in a file. This file can then be used to
+generate Kubernetes network policies.
+
+We will run this demo in the demo namespace:
+
+```
+$ kubectl create ns demo
+namespace/demo created
+$ kubectl apply -f Documentation/examples/disable-psp-demo.yaml
+clusterrole.rbac.authorization.k8s.io/disable-psp-demo created
+clusterrolebinding.rbac.authorization.k8s.io/disable-psp-demo created
+```
+
+In one terminal, start the network-policy gadget:
+
+```
+$ inspektor-gadget network-policy monitor --namespaces demo --output ./networktrace.log
+```
+
+In another terminal, deploy [GoogleCloudPlatform/microservices-demo](https://github.com/GoogleCloudPlatform/microservices-demo/blob/master/release/kubernetes-manifests.yaml) in the demo namespace:
+```
+$ wget -O network-policy-demo.yaml https://raw.githubusercontent.com/GoogleCloudPlatform/microservices-demo/ccff406cdcd3e043b432fe99b4038d1b4699c702/release/kubernetes-manifests.yaml
+$ kubectl apply -f network-policy-demo.yaml -n demo
+```
+
+Once the demo is deployed and running correctly, we can see all the pods in the
+demo namespace:
+
+```
+$ kubectl get pod -n demo
+NAME                                     READY   STATUS    RESTARTS   AGE
+adservice-58c85c77d8-k5667               1/1     Running   0          44s
+cartservice-579bdd6865-2wcbk             0/1     Running   1          45s
+checkoutservice-66d68cbdd-smp6w          1/1     Running   0          46s
+currencyservice-65dd85f486-62vld         1/1     Running   0          45s
+emailservice-84c98657cb-lqwfz            0/1     Running   2          46s
+frontend-788f7bdc86-q56rw                0/1     Running   1          46s
+loadgenerator-7699dc7d4b-j6vq6           1/1     Running   1          45s
+paymentservice-5c54c9887b-prz7n          1/1     Running   0          45s
+productcatalogservice-7df777f796-29lmz   1/1     Running   0          45s
+recommendationservice-89547cff8-xf4mv    0/1     Running   1          46s
+redis-cart-5f59546cdd-6rq8f              0/1     Running   2          44s
+shippingservice-778db496dd-mhdk5         1/1     Running   0          45s
+```
+
+At this point, let's stop the recording with Ctrl-C, and generate the
+Kubernetes network policies:
+
+```
+$ inspektor-gadget network-policy report --input ./networktrace.log > network-policy.yaml
+```
+
+Example for the cartservice: it can receive connections from the frontend and can initiate connections to redis-cart.
+
+```
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  creationTimestamp: null
+  name: cartservice-network
+  namespace: demo
+spec:
+  egress:
+  - ports:
+    - port: 6379
+      protocol: TCP
+    to:
+    - podSelector:
+        matchLabels:
+          app: redis-cart
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          app: frontend
+    ports:
+    - port: 7070
+      protocol: TCP
+  podSelector:
+    matchLabels:
+      app: cartservice
+  policyTypes:
+  - Ingress
+  - Egress
+```

--- a/Documentation/examples/disable-psp-demo.yaml
+++ b/Documentation/examples/disable-psp-demo.yaml
@@ -1,0 +1,26 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: disable-psp-demo
+rules:
+- apiGroups:
+  - policy
+  resources:
+  - podsecuritypolicies
+  resourceNames:
+  - privileged
+  verbs:
+  - use
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+    name: disable-psp-demo
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: demo
+roleRef:
+   apiGroup: rbac.authorization.k8s.io
+   kind: ClusterRole
+   name: disable-psp-demo

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ LDFLAGS := "-X github.com/kinvolk/inspektor-gadget/cmd/inspektor-gadget/cmd.vers
 build: gadget-container-deps build-ig
 
 .PHONY: gadget-container-deps
-gadget-container-deps: ocihookgadget gadgettracermanager
+gadget-container-deps: ocihookgadget gadgettracermanager networkpolicyadvisor
 
 .PHONY: build-ig
 build-ig:
@@ -39,6 +39,17 @@ ocihookgadget:
 	GO111MODULE=on CGO_ENABLED=1 GOOS=linux go build \
 		-o gadget-ds/bin/ocihookgadget \
 		cmd/ocihookgadget/main.go
+
+.PHONY: networkpolicyadvisor
+networkpolicyadvisor:
+	mkdir -p gadget-ds/bin
+	GO111MODULE=on CGO_ENABLED=1 GOOS=linux go build \
+		-o gadget-ds/bin/networkpolicyadvisor \
+		cmd/networkpolicyadvisor/main.go
+
+.PHONY: networkpolicyadvisor/push
+networkpolicyadvisor/push: networkpolicyadvisor
+	for POD in `kubectl get pod -n kube-system -l k8s-app=gadget -o=jsonpath='{.items[*].metadata.name}'` ; do kubectl cp ./gadget-ds/bin/networkpolicyadvisor -n kube-system $$POD:/bin/ ; done
 
 .PHONY: install-user
 install-user: build-ig

--- a/README.md
+++ b/README.md
@@ -15,16 +15,18 @@ Usage:
   kubectl gadget [command]
 
 Available Commands:
-  bindsnoop    Trace bind
-  capabilities Suggest Security Capabilities for securityContext
-  deploy       Deploy Inspektor Gadget on the worker nodes
-  execsnoop    Trace new processes
-  help         Help about any command
-  opensnoop    Trace files
-  tcpconnect   Suggest Kubernetes Network Policies
-  tcptop       Show the TCP traffic in a pod
-  traceloop    Get strace-like logs of a pod from the past
-  version      Show version
+  bindsnoop      Trace IPv4 and IPv6 bind() system calls
+  capabilities   Suggest Security Capabilities for securityContext
+  deploy         Deploy Inspektor Gadget on the worker nodes
+  execsnoop      Trace new processes
+  help           Help about any command
+  network-policy Generate network policies based on recorded network activity
+  opensnoop      Trace files
+  tcpconnect     Suggest Kubernetes Network Policies
+  tcptop         Show the TCP traffic in a pod
+  tcptracer      trace tcp connect, accept and close
+  traceloop      Get strace-like logs of a pod from the past
+  version        Show version
 
 Flags:
   -h, --help                help for kubectl-gadget
@@ -42,6 +44,7 @@ Inspektor Gadget is a kubectl plugin. It can also be invoked with `kubectl gadge
 - [Demo: the "capabilities" gadget](Documentation/demo-capabilities.md) – watch is [as GIF](Documentation/demos/demo-capabilities-gifterminal.gif)
 - [Demo: the "tcptop" gadget](Documentation/demo-tcptop.md) – watch it [as GIF](Documentation/demos/demo-tcptop-gifterminal.gif)
 - [Demo: the "tcpconnect" gadget](Documentation/demo-tcpconnect.md) — watch it [as GIF](Documentation/demos/demo-tcpconnect-gifterminal.gif)
+- [Demo: the "network-policy" gadget](Documentation/demo-network-policy.md)
 
 As preview for the above demos, here is the `opensnoop` demo:
 
@@ -62,15 +65,17 @@ programs are and how Inspektor Gadget uses them is briefly explained here:
 
 Not all gadgets currently work everywhere.
 
-| Gadget       | Flatcar Edge | Flatcar Stable | Minikube | GKE |
-|--------------|:------------:|:--------------:|:--------:|:---:|
-| traceloop    |       ✔️      |        ✔️       |     ✔️    |  ✔️  |
-| capabilities |       ✔️      |                |          |     |
-| execsnoop    |       ✔️      |                |          |     |
-| opensnoop    |       ✔️      |                |          |     |
-| bindsnoop    |       ✔️      |                |          |     |
-| tcpconnect   |       ✔️      |                |          |     |
-| tcptop       |       ✔️      |                |          |     |
+| Gadget            | Flatcar Edge | Flatcar Stable | Minikube | GKE |
+|-------------------|:------------:|:--------------:|:--------:|:---:|
+| traceloop         |       ✔️      |        ✔️       |     ✔️    |  ✔️  |
+| network-policy    |       ✔️      |        ✔️       |     ✔️    |  ✔️  |
+| tcptracer         |       ✔️      |                |          |     |
+| tcpconnect        |       ✔️      |                |          |     |
+| tcptop            |       ✔️      |                |          |     |
+| execsnoop         |       ✔️      |                |          |     |
+| opensnoop         |       ✔️      |                |          |     |
+| bindsnoop         |       ✔️      |                |          |     |
+| capabilities      |       ✔️      |                |          |     |
 
 Inspektor Gadget needs some recent Linux features and modifications in Kubernetes present in [Flatcar Linux Edge](https://kinvolk.io/blog/2019/05/introducing-the-flatcar-linux-edge-channel/) and [Lokomotive](https://kinvolk.io/blog/2019/05/driving-kubernetes-forward-with-lokomotive/). [More details in the detailed install instructions](Documentation/install.md)
 

--- a/cmd/inspektor-gadget/cmd/bcck8s.go
+++ b/cmd/inspektor-gadget/cmd/bcck8s.go
@@ -214,7 +214,7 @@ func bccCmd(subCommand, bccScript string) func(*cobra.Command, []string) {
 			go func(nodeName string, id string) {
 				postOut := postProcess{nodeName, " " + id, os.Stdout, false /* see FIXME in Writer() */, &firstLinePrinted, failure}
 				postErr := postProcess{nodeName, "E" + id, os.Stderr, false, &firstLinePrinted, failure}
-				cmd := fmt.Sprintf("exec /opt/bcck8s/bcc-wrapper.sh --tracerid %s --gadget %s %s %s %s -- %s %s",
+				cmd := fmt.Sprintf("exec /opt/bcck8s/bcc-wrapper.sh --flatcaredgeonly --tracerid %s --gadget %s %s %s %s -- %s %s",
 					tracerId, bccScript, labelFilter, namespaceFilter, podnameFilter, stackArg, verboseArg)
 				var err error
 				if subCommand != "tcptop" {

--- a/cmd/inspektor-gadget/cmd/bcck8s.go
+++ b/cmd/inspektor-gadget/cmd/bcck8s.go
@@ -54,7 +54,14 @@ var tcptopCmd = &cobra.Command{
 var tcpconnectCmd = &cobra.Command{
 	Use:               "tcpconnect",
 	Short:             "Suggest Kubernetes Network Policies",
-	Run:               bccCmd("tcpconnect", "/opt/bcck8s/tcpconnect"),
+	Run:               bccCmd("tcpconnect", "/usr/share/bcc/tools/tcpconnect"),
+	PersistentPreRunE: doesKubeconfigExist,
+}
+
+var tcptracerCmd = &cobra.Command{
+	Use:               "tcptracer",
+	Short:             "trace tcp connect, accept and close",
+	Run:               bccCmd("tcptracer", "/usr/share/bcc/tools/tcptracer"),
 	PersistentPreRunE: doesKubeconfigExist,
 }
 
@@ -82,6 +89,7 @@ func init() {
 		bindsnoopCmd,
 		tcptopCmd,
 		tcpconnectCmd,
+		tcptracerCmd,
 		capabilitiesCmd,
 	}
 	args := []string{"label", "node", "namespace", "podname"}

--- a/cmd/inspektor-gadget/cmd/networkpolicyadvisor.go
+++ b/cmd/inspektor-gadget/cmd/networkpolicyadvisor.go
@@ -101,7 +101,7 @@ func runNetworkPolicyMonitor(cmd *cobra.Command, args []string) {
 	}
 	nodes, err := client.CoreV1().Nodes().List(listOptions)
 	if err != nil {
-		contextLogger.Fatalf("Error in listing nodes: %q", err)
+		contextLogger.Fatalf("Error listing nodes: %q", err)
 	}
 
 	namespaceFilter := fmt.Sprintf("--namespace %q", namespaces)

--- a/cmd/inspektor-gadget/cmd/networkpolicyadvisor.go
+++ b/cmd/inspektor-gadget/cmd/networkpolicyadvisor.go
@@ -1,0 +1,155 @@
+package cmd
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
+
+	"github.com/kinvolk/inspektor-gadget/pkg/k8sutil"
+	"github.com/kinvolk/inspektor-gadget/pkg/networkpolicy"
+)
+
+var networkPolicyCmd = &cobra.Command{
+	Use:   "network-policy",
+	Short: "Generate network policies based on recorded network activity",
+}
+
+var networkPolicyMonitorCmd = &cobra.Command{
+	Use:   "monitor",
+	Short: "Monitor the network traffic",
+	Run:   runNetworkPolicyMonitor,
+}
+
+var networkPolicyReportCmd = &cobra.Command{
+	Use:   "report",
+	Short: "Report network policies",
+	RunE:  runNetworkPolicyReport,
+}
+
+var (
+	inputFileName  string
+	outputFileName string
+	namespaces     string
+)
+
+func init() {
+	networkPolicyCmd.PersistentFlags().String(
+		"input",
+		"",
+		"recorded network activity file")
+	viper.BindPFlag("input", networkPolicyCmd.PersistentFlags().Lookup("input"))
+
+	rootCmd.AddCommand(networkPolicyCmd)
+
+	networkPolicyCmd.AddCommand(networkPolicyMonitorCmd)
+	networkPolicyMonitorCmd.PersistentFlags().StringVarP(&outputFileName, "output", "", "-", "File name output")
+	networkPolicyMonitorCmd.PersistentFlags().StringVarP(&namespaces, "namespaces", "", "default", "Comma-separated list of namespaces to monitor")
+
+	networkPolicyCmd.AddCommand(networkPolicyReportCmd)
+	networkPolicyReportCmd.PersistentFlags().StringVarP(&inputFileName, "input", "", "-", "File name input")
+}
+
+type traceCollector struct {
+	writer *bufio.Writer
+}
+
+func (t traceCollector) Write(p []byte) (n int, err error) {
+	n, err = t.writer.Write(p)
+	if err != nil {
+		return
+	}
+	err = t.writer.Flush()
+	return
+}
+
+func runNetworkPolicyMonitor(cmd *cobra.Command, args []string) {
+	contextLogger := log.WithFields(log.Fields{
+		"command": "inspektor-gadget network-policy monitor",
+		"args":    args,
+	})
+
+	var w *bufio.Writer
+	if outputFileName == "-" {
+		w = bufio.NewWriter(os.Stdout)
+	} else {
+		outputFile, err := os.Create(outputFileName)
+		if err != nil {
+			contextLogger.Fatalf("Error in creating file %q: %q", outputFileName, err)
+		}
+		defer outputFile.Close()
+		w = bufio.NewWriter(outputFile)
+	}
+
+	client, err := k8sutil.NewClientset(viper.GetString("kubeconfig"))
+	if err != nil {
+		contextLogger.Fatalf("Error in creating setting up Kubernetes client: %q", err)
+	}
+
+	var listOptions = metaV1.ListOptions{
+		LabelSelector: labels.Everything().String(),
+		FieldSelector: fields.Everything().String(),
+	}
+	nodes, err := client.CoreV1().Nodes().List(listOptions)
+	if err != nil {
+		contextLogger.Fatalf("Error in listing nodes: %q", err)
+	}
+
+	namespaceFilter := fmt.Sprintf("--namespace %q", namespaces)
+
+	sigs := make(chan os.Signal, 1)
+	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
+	failure := make(chan string)
+
+	for _, node := range nodes.Items {
+		go func(nodeName string) {
+			collector := traceCollector{w}
+			cmd := fmt.Sprintf("exec /opt/bcck8s/bcc-wrapper.sh --tracerid networkpolicyadvisor --nomanager --probecleanup --gadget /bin/networkpolicyadvisor -- %s",
+				namespaceFilter)
+			err := execPod(client, nodeName, cmd, collector, os.Stderr)
+			if fmt.Sprintf("%s", err) != "command terminated with exit code 137" {
+				failure <- fmt.Sprintf("Error in running command: %q\n", err)
+			}
+		}(node.Name)
+	}
+
+	select {
+	case <-sigs:
+	case e := <-failure:
+		fmt.Printf("Error detected: %q\n", e)
+	}
+
+	for _, node := range nodes.Items {
+		_, _, err := execPodCapture(client, node.Name,
+			fmt.Sprintf("exec /opt/bcck8s/bcc-wrapper.sh --tracerid networkpolicyadvisor --stop"))
+		if err != nil {
+			fmt.Printf("Error in running command: %q\n", err)
+		}
+	}
+}
+
+func runNetworkPolicyReport(cmd *cobra.Command, args []string) error {
+	if inputFileName == "" {
+		return fmt.Errorf("Parameter --input missing")
+	}
+
+	advisor := networkpolicy.NewAdvisor()
+	err := advisor.LoadFile(inputFileName)
+	if err != nil {
+		return err
+	}
+
+	advisor.GeneratePolicies()
+	advisor.PrintPolicies()
+
+	return err
+}

--- a/cmd/inspektor-gadget/cmd/networkpolicyadvisor.go
+++ b/cmd/inspektor-gadget/cmd/networkpolicyadvisor.go
@@ -92,7 +92,7 @@ func runNetworkPolicyMonitor(cmd *cobra.Command, args []string) {
 
 	client, err := k8sutil.NewClientset(viper.GetString("kubeconfig"))
 	if err != nil {
-		contextLogger.Fatalf("Error in creating setting up Kubernetes client: %q", err)
+		contextLogger.Fatalf("Error setting up Kubernetes client: %q", err)
 	}
 
 	var listOptions = metaV1.ListOptions{

--- a/cmd/inspektor-gadget/cmd/networkpolicyadvisor.go
+++ b/cmd/inspektor-gadget/cmd/networkpolicyadvisor.go
@@ -117,7 +117,7 @@ func runNetworkPolicyMonitor(cmd *cobra.Command, args []string) {
 				namespaceFilter)
 			err := execPod(client, nodeName, cmd, collector, os.Stderr)
 			if fmt.Sprintf("%s", err) != "command terminated with exit code 137" {
-				failure <- fmt.Sprintf("Error in running command: %q\n", err)
+				failure <- fmt.Sprintf("Error running command: %q\n", err)
 			}
 		}(node.Name)
 	}

--- a/cmd/inspektor-gadget/cmd/networkpolicyadvisor.go
+++ b/cmd/inspektor-gadget/cmd/networkpolicyadvisor.go
@@ -132,7 +132,7 @@ func runNetworkPolicyMonitor(cmd *cobra.Command, args []string) {
 		_, _, err := execPodCapture(client, node.Name,
 			fmt.Sprintf("exec /opt/bcck8s/bcc-wrapper.sh --tracerid networkpolicyadvisor --stop"))
 		if err != nil {
-			fmt.Printf("Error in running command: %q\n", err)
+			fmt.Printf("Error running command: %q\n", err)
 		}
 	}
 }

--- a/cmd/inspektor-gadget/cmd/networkpolicyadvisor.go
+++ b/cmd/inspektor-gadget/cmd/networkpolicyadvisor.go
@@ -84,7 +84,7 @@ func runNetworkPolicyMonitor(cmd *cobra.Command, args []string) {
 	} else {
 		outputFile, err := os.Create(outputFileName)
 		if err != nil {
-			contextLogger.Fatalf("Error in creating file %q: %q", outputFileName, err)
+			contextLogger.Fatalf("Error creating file %q: %q", outputFileName, err)
 		}
 		defer outputFile.Close()
 		w = bufio.NewWriter(outputFile)

--- a/cmd/networkpolicyadvisor/main.go
+++ b/cmd/networkpolicyadvisor/main.go
@@ -165,6 +165,7 @@ func main() {
 	}
 
 	t.Start()
+	fmt.Printf(`{"type":"ready"}` + "\n")
 
 	sig := make(chan os.Signal, 1)
 	signal.Notify(sig, os.Interrupt, os.Kill)

--- a/cmd/networkpolicyadvisor/main.go
+++ b/cmd/networkpolicyadvisor/main.go
@@ -1,0 +1,175 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"os/signal"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/weaveworks/tcptracer-bpf/pkg/tracer"
+
+	"github.com/kinvolk/inspektor-gadget/pkg/networkpolicy/types"
+)
+
+var (
+	cgroupmap     string
+	namespaceList string
+	namespaceSet  map[string]struct{}
+	kubeconfig    string
+)
+
+func init() {
+	flag.StringVar(&cgroupmap, "cgroupmap", "", "path to a BPF map containing a cgroup set")
+	flag.StringVar(&namespaceList, "namespace", "", "comma-separated list of namespaces")
+	flag.StringVar(&kubeconfig, "kubeconfig", "", "path to a kubeconfig")
+}
+
+type tcpEventTracer struct {
+	clientset *kubernetes.Clientset
+}
+
+func (t *tcpEventTracer) TCPEventV4(e tracer.TcpV4) {
+	if e.Type == tracer.EventFdInstall {
+		return
+	}
+	if e.Type == tracer.EventClose {
+		return
+	}
+
+	var event types.KubernetesConnectionEvent
+	event.Type = e.Type.String()
+	if e.Type == tracer.EventAccept {
+		event.Port = e.SPort
+	} else {
+		event.Port = e.DPort
+	}
+
+	event.Debug = fmt.Sprintf("%v cpu#%d %s %v %s %v:%v %v:%v %v\n",
+		e.Timestamp, e.CPU, e.Type, e.Pid, e.Comm, e.SAddr, e.SPort, e.DAddr, e.DPort, e.NetNS)
+
+	pods, err := t.clientset.CoreV1().Pods("").List(metav1.ListOptions{})
+	if err != nil {
+		fmt.Printf("Error: %s\n", err)
+		return
+	}
+	localPodIndex := -1
+	for i, pod := range pods.Items {
+		if pod.Status.PodIP == e.SAddr.String() {
+			if _, ok := namespaceSet[pod.Namespace]; ok {
+				localPodIndex = i
+				event.LocalPodNamespace = pod.Namespace
+				event.LocalPodName = pod.Name
+				event.LocalPodLabels = pod.Labels
+			}
+		}
+		if pod.Status.PodIP == e.DAddr.String() {
+			event.RemoteKind = "pod"
+			event.RemotePodNamespace = pod.Namespace
+			event.RemotePodName = pod.Name
+			event.RemotePodLabels = pod.Labels
+		}
+	}
+	if event.LocalPodName == "" {
+		return
+	}
+
+	/* When the pod belong to Deployment, ReplicaSet or DaemonSet, find the
+	 * shorter name without the random suffix. That will be used to
+	 * generate the network policy name. */
+	if pods.Items[localPodIndex].OwnerReferences != nil {
+		nameItems := strings.Split(event.LocalPodName, "-")
+		if len(nameItems) > 2 {
+			event.LocalPodOwner = strings.Join(nameItems[:len(nameItems)-2], "-")
+		}
+	}
+
+	if event.RemoteKind == "" {
+		svcs, err := t.clientset.CoreV1().Services("").List(metav1.ListOptions{})
+		if err != nil {
+			fmt.Printf("Error: %s\n", err)
+			return
+		}
+		for _, svc := range svcs.Items {
+			if svc.Spec.ClusterIP == e.DAddr.String() {
+				event.RemoteKind = "svc"
+				event.RemoteSvcNamespace = svc.Namespace
+				event.RemoteSvcName = svc.Name
+				event.RemoteSvcLabelSelector = svc.Spec.Selector
+				break
+			}
+		}
+	}
+	if event.RemoteKind == "" {
+		event.RemoteKind = "other"
+		event.RemoteOther = e.DAddr.String()
+	}
+
+	buf, err := json.Marshal(event)
+	if err != nil {
+		fmt.Printf("Error: %s\n", err)
+		return
+	}
+	fmt.Printf("%s\n", string(buf))
+}
+
+func (t *tcpEventTracer) TCPEventV6(e tracer.TcpV6) {
+	if e.Type == tracer.EventFdInstall {
+		return
+	}
+	if e.Type == tracer.EventClose {
+		return
+	}
+}
+
+func (t *tcpEventTracer) LostV4(count uint64) {
+	fmt.Printf("ERROR: lost %d events!\n", count)
+}
+
+func (t *tcpEventTracer) LostV6(count uint64) {
+	fmt.Printf("ERROR: lost %d events!\n", count)
+}
+
+func main() {
+	// Parse arguments
+	flag.Parse()
+	if flag.NArg() > 0 {
+		flag.PrintDefaults()
+		panic(fmt.Errorf("invalid command"))
+	}
+	namespaceSet = make(map[string]struct{})
+	for _, item := range strings.Split(namespaceList, ",") {
+		namespaceSet[item] = struct{}{}
+	}
+
+	// Connect to the API server
+	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+	if err != nil {
+		panic(err)
+	}
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		panic(err)
+	}
+
+	// Start the BPF tracer
+	t, err := tracer.NewTracer(&tcpEventTracer{clientset})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+
+	t.Start()
+
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, os.Interrupt, os.Kill)
+
+	<-sig
+	t.Stop()
+
+}

--- a/cmd/networkpolicyadvisor/main.go
+++ b/cmd/networkpolicyadvisor/main.go
@@ -171,5 +171,4 @@ func main() {
 
 	<-sig
 	t.Stop()
-
 }

--- a/gadget-ds/files/bcck8s/bcc-wrapper.sh
+++ b/gadget-ds/files/bcck8s/bcc-wrapper.sh
@@ -5,6 +5,7 @@ set -e
 CONTAINERINDEX=-1
 MANAGER=true
 PROBECLEANUP=false
+FLATCAREDGEONLY=false
 
 while [[ $# -gt 0 ]]
 do
@@ -18,6 +19,10 @@ case $key in
         ;;
     --stop)
         STOP=true
+        shift
+        ;;
+    --flatcaredgeonly)
+        FLATCAREDGEONLY=true
         shift
         ;;
     --nomanager)
@@ -67,14 +72,15 @@ done
 GADGETTRACERMANAGER=/bin/gadgettracermanager
 BPFDIR="${BPFDIR:-/sys/fs/bpf}"
 
-if ! grep -q '^ID=flatcar$' /host/etc/os-release > /dev/null ; then
-  echo "Gadget not available." >&2
-  exit 1
-fi
-
-if ! grep -q '^GROUP=edge$' /host/etc/flatcar/update.conf > /dev/null ; then
-  echo "Gadget not available." >&2
-  exit 1
+if [ "$FLATCAREDGEONLY" = "true" ] ; then
+  if ! grep -q '^ID=flatcar$' /host/etc/os-release > /dev/null ; then
+    echo "Gadget not available." >&2
+    exit 1
+  fi
+  if ! grep -q '^GROUP=edge$' /host/etc/flatcar/update.conf > /dev/null ; then
+    echo "Gadget not available." >&2
+    exit 1
+  fi
 fi
 
 PIDFILE=/run/bcc-wrapper-$TRACERID.pid

--- a/gadget-ds/gadget.Dockerfile
+++ b/gadget-ds/gadget.Dockerfile
@@ -18,6 +18,7 @@ COPY files/bcck8s /opt/bcck8s
 
 COPY bin/gadgettracermanager /bin/gadgettracermanager
 COPY bin/ocihookgadget /bin/ocihookgadget
+COPY bin/networkpolicyadvisor /bin/networkpolicyadvisor
 
 COPY --from=traceloop /bin/traceloop /bin/traceloop
 

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/spf13/cobra v0.0.3
 	github.com/spf13/viper v1.3.2
 	github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2
+	github.com/weaveworks/tcptracer-bpf v0.0.0-20190731111909-cd53e7c84bac
 	golang.org/x/net v0.0.0-20190311183353-d8887717615a
 	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4 // indirect
 	google.golang.org/grpc v1.25.1
@@ -18,6 +19,7 @@ require (
 	k8s.io/apimachinery v0.0.0-20190503221204-7a17edec881a
 	k8s.io/client-go v0.0.0-20190501104856-ef81ee0960bf
 	k8s.io/utils v0.0.0-20190506122338-8fab8cb257d5 // indirect
+	sigs.k8s.io/yaml v1.1.0
 )
 
 replace github.com/iovisor/gobpf => github.com/kinvolk/gobpf v0.0.0-20191127154002-f0f89e7c6fd1

--- a/go.sum
+++ b/go.sum
@@ -109,6 +109,8 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2 h1:b6uOv7YOFK0TYG7HtkIgExQo+2RdLuwRft63jn2HWj8=
 github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
+github.com/weaveworks/tcptracer-bpf v0.0.0-20190731111909-cd53e7c84bac h1:bE6+keem2eUQT2HcRwocyA9HtQs9o2ZU6mwEvA5AVeo=
+github.com/weaveworks/tcptracer-bpf v0.0.0-20190731111909-cd53e7c84bac/go.mod h1:vIed/thLU28ufcvDlpI1X5u+pPoI30rpjIbvvDWKjMk=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 golang.org/x/crypto v0.0.0-20181025213731-e84da0312774/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9 h1:mKdxBk7AujPs8kU4m80U72y/zjbZ3UcXC7dClwKbUI0=

--- a/pkg/networkpolicy/networkpolicy.go
+++ b/pkg/networkpolicy/networkpolicy.go
@@ -179,6 +179,9 @@ func (a *NetworkPolicyAdvisor) eventToRule(e types.KubernetesConnectionEvent) (p
 func (a *NetworkPolicyAdvisor) GeneratePolicies() {
 	eventsBySource := map[string][]types.KubernetesConnectionEvent{}
 	for _, e := range a.Events {
+		if e.Type != "connect" && e.Type != "accept" {
+			continue
+		}
 		key := a.localPodKey(e)
 		if _, ok := eventsBySource[key]; ok {
 			eventsBySource[key] = append(eventsBySource[key], e)

--- a/pkg/networkpolicy/networkpolicy.go
+++ b/pkg/networkpolicy/networkpolicy.go
@@ -1,0 +1,274 @@
+package networkpolicy
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"sort"
+	"strings"
+
+	v1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	k8syaml "sigs.k8s.io/yaml"
+
+	"github.com/kinvolk/inspektor-gadget/pkg/networkpolicy/types"
+)
+
+var defaultLabelsToIgnore = []string{
+	"controller-revision-hash",
+	"pod-template-generation",
+	"pod-template-hash",
+}
+
+type NetworkPolicyAdvisor struct {
+	Events []types.KubernetesConnectionEvent
+
+	LabelsToIgnore []string
+
+	Policies []networkingv1.NetworkPolicy
+}
+
+func NewAdvisor() *NetworkPolicyAdvisor {
+	return &NetworkPolicyAdvisor{
+		LabelsToIgnore: defaultLabelsToIgnore,
+	}
+}
+
+func (a *NetworkPolicyAdvisor) LoadFile(filename string) error {
+	buf, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return err
+	}
+
+	/* Try to read the file as an array */
+	events := []types.KubernetesConnectionEvent{}
+	err = json.Unmarshal(buf, &events)
+	if err == nil {
+		a.Events = events
+		return nil
+	}
+
+	/* If it fails, read by line */
+	events = nil
+	line := 0
+	scanner := bufio.NewScanner(bytes.NewReader(buf))
+	for scanner.Scan() {
+		event := types.KubernetesConnectionEvent{}
+		text := strings.TrimSpace(scanner.Text())
+		if len(text) == 0 {
+			continue
+		}
+		line++
+		err = json.Unmarshal([]byte(text), &event)
+		if err != nil {
+			return fmt.Errorf("cannot parse line %d: %s", line, err)
+		}
+		events = append(events, event)
+	}
+
+	if err := scanner.Err(); err != nil {
+		return err
+	}
+
+	a.Events = events
+
+	return nil
+}
+
+/* labelFilteredKeyList returns a sorted list of label keys but without the labels to
+ * ignore.
+ */
+func (a *NetworkPolicyAdvisor) labelFilteredKeyList(labels map[string]string) []string {
+	keys := make([]string, 0, len(labels))
+	for k := range labels {
+		found := false
+		for _, l := range a.LabelsToIgnore {
+			if l == k {
+				found = true
+				break
+			}
+		}
+		if found {
+			continue
+		}
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	return keys
+}
+
+func (a *NetworkPolicyAdvisor) labelFilter(labels map[string]string) map[string]string {
+	keys := a.labelFilteredKeyList(labels)
+	ret := map[string]string{}
+	for _, k := range keys {
+		ret[k] = labels[k]
+	}
+	return ret
+}
+
+/* labelKeyString returns a sorted list of labels in a single string.
+ * label1=value1,label2=value2
+ */
+func (a *NetworkPolicyAdvisor) labelKeyString(labels map[string]string) (ret string) {
+	keys := a.labelFilteredKeyList(labels)
+
+	first := true
+	for _, k := range keys {
+		sep := ","
+		if first {
+			sep = ""
+		}
+		first = false
+		ret += fmt.Sprintf("%s%s=%s", sep, k, labels[k])
+	}
+	return
+}
+
+/* localPodKey returns a key that can be used to group pods together:
+ * namespace:label1=value1,label2=value2
+ */
+func (a *NetworkPolicyAdvisor) localPodKey(e types.KubernetesConnectionEvent) (ret string) {
+	return e.LocalPodNamespace + ":" + a.labelKeyString(e.LocalPodLabels)
+}
+
+func (a *NetworkPolicyAdvisor) networkPeerKey(e types.KubernetesConnectionEvent) (ret string) {
+	if e.RemoteKind == "pod" {
+		ret = e.RemoteKind + ":" + e.RemotePodNamespace + ":" + a.labelKeyString(e.RemotePodLabels)
+	} else if e.RemoteKind == "svc" {
+		ret = e.RemoteKind + ":" + e.RemoteSvcNamespace + ":" + a.labelKeyString(e.RemoteSvcLabelSelector)
+	} else if e.RemoteKind == "other" {
+		ret = e.RemoteKind + ":" + e.RemoteOther
+	}
+	return ret + ":" + string(e.Port)
+}
+
+func (a *NetworkPolicyAdvisor) eventToRule(e types.KubernetesConnectionEvent) (ports []networkingv1.NetworkPolicyPort, peers []networkingv1.NetworkPolicyPeer) {
+	port := intstr.FromInt(int(e.Port))
+	protocol := v1.Protocol("TCP")
+	ports = []networkingv1.NetworkPolicyPort{
+		networkingv1.NetworkPolicyPort{
+			Port:     &port,
+			Protocol: &protocol,
+		},
+	}
+	// TODO: check if LocalPodNamespace != Remote*Namespace
+	if e.RemoteKind == "pod" {
+		peers = []networkingv1.NetworkPolicyPeer{
+			networkingv1.NetworkPolicyPeer{
+				PodSelector: &metav1.LabelSelector{MatchLabels: a.labelFilter(e.RemotePodLabels)},
+			},
+		}
+	} else if e.RemoteKind == "svc" {
+		peers = []networkingv1.NetworkPolicyPeer{
+			networkingv1.NetworkPolicyPeer{
+				PodSelector: &metav1.LabelSelector{MatchLabels: e.RemoteSvcLabelSelector},
+			},
+		}
+	} else if e.RemoteKind == "other" {
+		peers = []networkingv1.NetworkPolicyPeer{
+			networkingv1.NetworkPolicyPeer{
+				IPBlock: &networkingv1.IPBlock{
+					CIDR: e.RemoteOther + "/32",
+				},
+			},
+		}
+	} else {
+		panic("unknown event")
+	}
+	return
+}
+
+func (a *NetworkPolicyAdvisor) GeneratePolicies() {
+	eventsBySource := map[string][]types.KubernetesConnectionEvent{}
+	for _, e := range a.Events {
+		key := a.localPodKey(e)
+		if _, ok := eventsBySource[key]; ok {
+			eventsBySource[key] = append(eventsBySource[key], e)
+		} else {
+			eventsBySource[key] = []types.KubernetesConnectionEvent{e}
+		}
+	}
+
+	for _, events := range eventsBySource {
+		egressNetworkPeer := map[string][]types.KubernetesConnectionEvent{}
+		ingressNetworkPeer := map[string][]types.KubernetesConnectionEvent{}
+		for _, e := range events {
+			key := a.networkPeerKey(e)
+			if e.Type == "connect" {
+				if _, ok := egressNetworkPeer[key]; ok {
+					egressNetworkPeer[key] = append(egressNetworkPeer[key], e)
+				} else {
+					egressNetworkPeer[key] = []types.KubernetesConnectionEvent{e}
+				}
+			} else if e.Type == "accept" {
+				if _, ok := ingressNetworkPeer[key]; ok {
+					ingressNetworkPeer[key] = append(ingressNetworkPeer[key], e)
+				} else {
+					ingressNetworkPeer[key] = []types.KubernetesConnectionEvent{e}
+				}
+			}
+		}
+		egressPolicies := []networkingv1.NetworkPolicyEgressRule{}
+		for _, p := range egressNetworkPeer {
+			ports, peers := a.eventToRule(p[0])
+			rule := networkingv1.NetworkPolicyEgressRule{
+				Ports: ports,
+				To:    peers,
+			}
+			egressPolicies = append(egressPolicies, rule)
+		}
+		ingressPolicies := []networkingv1.NetworkPolicyIngressRule{}
+		for _, p := range ingressNetworkPeer {
+			ports, peers := a.eventToRule(p[0])
+			rule := networkingv1.NetworkPolicyIngressRule{
+				Ports: ports,
+				From:  peers,
+			}
+			ingressPolicies = append(ingressPolicies, rule)
+		}
+
+		name := events[0].LocalPodName
+		if events[0].LocalPodOwner != "" {
+			name = events[0].LocalPodOwner
+		}
+		name += "-network"
+		policy := networkingv1.NetworkPolicy{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "networking.k8s.io/v1",
+				Kind:       "NetworkPolicy",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: events[0].LocalPodNamespace,
+				Labels:    map[string]string{},
+			},
+			Spec: networkingv1.NetworkPolicySpec{
+				PodSelector: metav1.LabelSelector{MatchLabels: a.labelFilter(events[0].LocalPodLabels)},
+				PolicyTypes: []networkingv1.PolicyType{"Ingress", "Egress"},
+				Ingress:     ingressPolicies,
+				Egress:      egressPolicies,
+			},
+		}
+		a.Policies = append(a.Policies, policy)
+	}
+
+}
+
+func (a *NetworkPolicyAdvisor) PrintPolicies() {
+	for i, p := range a.Policies {
+		yamlOutput, err := k8syaml.Marshal(p)
+		if err != nil {
+			continue
+		}
+		sep := "---\n"
+		if i == len(a.Policies)-1 {
+			sep = ""
+		}
+		fmt.Printf("%s%s", string(yamlOutput), sep)
+	}
+}

--- a/pkg/networkpolicy/networkpolicy.go
+++ b/pkg/networkpolicy/networkpolicy.go
@@ -20,8 +20,8 @@ import (
 
 var defaultLabelsToIgnore = map[string]struct{}{
 	"controller-revision-hash": struct{}{},
-	"pod-template-generation": struct{}{},
-	"pod-template-hash": struct{}{},
+	"pod-template-generation":  struct{}{},
+	"pod-template-hash":        struct{}{},
 }
 
 type NetworkPolicyAdvisor struct {
@@ -197,14 +197,13 @@ func (a *NetworkPolicyAdvisor) GeneratePolicies() {
 					continue
 				}
 
-				egressNetworkPeer[key] = types.KubernetesConnectionEvent{e}
-
+				egressNetworkPeer[key] = e
 			} else if e.Type == "accept" {
 				if _, ok := ingressNetworkPeer[key]; ok {
 					continue
 				}
 
-				ingressNetworkPeer[key] = types.KubernetesConnectionEvent{e}
+				ingressNetworkPeer[key] = e
 			}
 		}
 		egressPolicies := []networkingv1.NetworkPolicyEgressRule{}

--- a/pkg/networkpolicy/networkpolicy.go
+++ b/pkg/networkpolicy/networkpolicy.go
@@ -117,13 +117,11 @@ func (a *NetworkPolicyAdvisor) labelFilter(labels map[string]string) map[string]
 func (a *NetworkPolicyAdvisor) labelKeyString(labels map[string]string) (ret string) {
 	keys := a.labelFilteredKeyList(labels)
 
-	first := true
-	for _, k := range keys {
+	for index, k := range keys {
 		sep := ","
-		if first {
+		if index == 0 {
 			sep = ""
 		}
-		first = false
 		ret += fmt.Sprintf("%s%s=%s", sep, k, labels[k])
 	}
 	return

--- a/pkg/networkpolicy/types/event.go
+++ b/pkg/networkpolicy/types/event.go
@@ -1,0 +1,32 @@
+package types
+
+type KubernetesConnectionEvent struct {
+	/* connect or accept */
+	Type string `json:"type"`
+
+	/* pod, svc or other */
+	RemoteKind string `json:"remote_kind"`
+
+	/* Port */
+	Port uint16 `json:"port"`
+
+	LocalPodNamespace string            `json:"local_pod_namespace"`
+	LocalPodName      string            `json:"local_pod_name"`
+	LocalPodOwner     string            `json:"local_pod_owner,omitempty"`
+	LocalPodLabels    map[string]string `json:"local_pod_labels"`
+
+	/* if RemoteKind = svc */
+	RemoteSvcNamespace     string            `json:"remote_svc_namespace,omitempty"`
+	RemoteSvcName          string            `json:"remote_svc_name,omitempty"`
+	RemoteSvcLabelSelector map[string]string `json:"remote_svc_label_selector,omitempty"`
+
+	/* if RemoteKind = pod */
+	RemotePodNamespace string            `json:"remote_pod_namespace,omitempty"`
+	RemotePodName      string            `json:"remote_pod_name,omitempty"`
+	RemotePodLabels    map[string]string `json:"remote_pod_labels,omitempty"`
+
+	/* if RemoteKind = other */
+	RemoteOther string `json:"remote_other,omitempty"`
+
+	Debug string `json:"debug,omitempty"`
+}

--- a/pkg/networkpolicy/types/event.go
+++ b/pkg/networkpolicy/types/event.go
@@ -1,7 +1,7 @@
 package types
 
 type KubernetesConnectionEvent struct {
-	/* connect or accept */
+	/* "ready", or "connect" or "accept" */
 	Type string `json:"type"`
 
 	/* pod, svc or other */


### PR DESCRIPTION
This uses https://github.com/weaveworks/tcptracer-bpf to know about new connections in the selected namespaces:

```
$ inspektor-gadget network-policy monitor --namespaces demo --output ./networktrace.log
```

While `inspektor-gadget` is running, I deploy a microservice application ([kubernetes-manifests.yaml](https://github.com/GoogleCloudPlatform/microservices-demo/blob/master/release/kubernetes-manifests.yaml)): 
```
kubectl apply -f kubernetes-manifests.yaml -n demo
```

When the microservice application runs, `inspektor-gadget` starts to detect TCP connections:

```
{"type":"connect","remote_kind":"svc","port":3550,"local_pod_namespace":"demo","local_pod_name":"frontend-788f7bdc86-mtc6r","local_pod_owner":"frontend","local_pod_labels":{"app":"frontend","pod-template-hash":"788f7bdc86"},"remote_svc_namespace":"demo","remote_svc_name":"productcatalogservice","remote_svc_label_selector":{"app":"productcatalogservice"},"debug":"5461138891424 cpu#0 connect 26133 server 172.17.0.7:42778 10.106.11.92:3550 4026532997\n"}
```

I can generate the network policy with:

```
$ inspektor-gadget network-policy report --input networktrace.log
```

Example of output:
<details>

```
apiVersion: networking.k8s.io/v1
kind: NetworkPolicy
metadata:
  creationTimestamp: null
  name: frontend-network
  namespace: demo
spec:
  egress:
  - ports:
    - port: 3550
      protocol: TCP
    to:
    - podSelector:
        matchLabels:
          app: productcatalogservice
  - ports:
    - port: 5050
      protocol: TCP
    to:
    - podSelector:
        matchLabels:
          app: checkoutservice
  - ports:
    - port: 7000
      protocol: TCP
    to:
    - podSelector:
        matchLabels:
          app: currencyservice
  ingress:
  - from:
    - ipBlock:
        cidr: 172.17.0.1/32
    ports:
    - port: 8080
      protocol: TCP
  - from:
    - podSelector:
        matchLabels:
          app: loadgenerator
    ports:
    - port: 8080
      protocol: TCP
  podSelector:
    matchLabels:
      app: frontend
  policyTypes:
  - Ingress
  - Egress
```

</details>

-----

TODO list for a follow up:
- [X] User documentation (main readme, demo)
- [ ] Unit tests for network policy report
- [ ] Developer documentation: A comment explaining how the network policies are generated from the packets would help a lot to understand it.
- [x] Print "ready" when it starts recording connections
- [x] Print "closing" after Ctrl+C
- [ ] Reconsider whether to use bcc-wrapper for the network-policy gadget
- [x] Make traceCollector thread safe.
- [ ] Sometimes, this error happens: `E0229 18:05:16.084586  704486 v2.go:147] short write`
- [ ] Avoid "get pod,svc" calls with go-client for every new TCP connection (optimization)
- [ ] Fix connections between pods across namespaces
- [ ] Naming the network policy when the pod was created by a Job and not a Deployment
