### PR TITLE
Introduce deployment options

### DIFF
--- a/gadget-container/Makefile
+++ b/gadget-container/Makefile
@@ -2,7 +2,7 @@ IMAGE_TAG=$(shell ../tools/image-tag)
 IMAGE_BRANCH_TAG=$(shell ../tools/image-tag branch)
 
 .PHONY: gadget-container-deps
-gadget-container-deps: ocihookgadget gadgettracermanager networkpolicyadvisor
+gadget-container-deps: ocihookgadget gadgettracermanager networkpolicyadvisor runchookslib
 
 .PHONY: gadgettracermanager
 gadgettracermanager:
@@ -30,6 +30,12 @@ networkpolicyadvisor:
 .PHONY: networkpolicyadvisor/push
 networkpolicyadvisor/push: networkpolicyadvisor
 	for POD in `kubectl get pod -n kube-system -l k8s-app=gadget -o=jsonpath='{.items[*].metadata.name}'` ; do kubectl cp ./bin/networkpolicyadvisor -n kube-system $$POD:/bin/ ; done
+
+.PHONY: runchookslib
+runchookslib:
+	mkdir -p bin
+	gcc -Wall -o bin/runchooks.so -shared -fPIC runchooks/runchooks.c -ldl
+
 
 .PHONY: build
 build: gadget-container-deps

--- a/gadget-container/entrypoint.sh
+++ b/gadget-container/entrypoint.sh
@@ -19,6 +19,9 @@ dpkg-query --show libbcc|awk '{print $2}'
 echo -n "Gadget image: "
 echo $TRACELOOP_IMAGE
 
+echo "Deployment options:"
+env | grep '^INSPEKTOR_GADGET_OPTION_.*='
+
 echo -n "Inspektor Gadget version: "
 echo $INSPEKTOR_GADGET_VERSION
 
@@ -63,5 +66,23 @@ if [ "$FLATCAR_EDGE" = 1 ] ; then
   /bin/gadgettracermanager -serve &
 fi
 
-rm -f /run/traceloop.socket
-exec /bin/traceloop $ARGS
+if [ "$INSPEKTOR_GADGET_OPTION_RUNC_HOOKS" = "ldpreload" ] ; then
+  echo "Installing ld.so.preload with runchooks.so for OCI hooks"
+  mkdir -p /host/opt/runchooks/
+  cp /opt/runchooks/runchooks.so /host/opt/runchooks/
+  cp /opt/runchooks/add-hooks.jq /host/opt/runchooks/
+  touch /host/etc/ld.so.preload
+  if grep -q ^/opt/runchooks/runchooks.so$ /host/etc/ld.so.preload > /dev/null ; then
+    echo "runchooks.so already setup in /etc/ld.so.preload"
+  else
+    echo "/opt/runchooks/runchooks.so" >> /host/etc/ld.so.preload
+  fi
+fi
+
+if [ "$INSPEKTOR_GADGET_OPTION_TRACELOOP" = "true" ] ; then
+  rm -f /run/traceloop.socket
+  exec /bin/traceloop $ARGS
+fi
+
+echo "Ready."
+sleep infinity

--- a/gadget-container/gadget-from-local-bin.Dockerfile
+++ b/gadget-container/gadget-from-local-bin.Dockerfile
@@ -1,8 +1,23 @@
 # Main gadget image
 
-FROM docker.io/kinvolk/bcc:latest
-RUN apt-get update && apt-get install -y \
-  curl
+FROM docker.io/kinvolk/bcc:ig-latest
+RUN set -ex; \
+	export DEBIAN_FRONTEND=noninteractive; \
+	apt-get update && \
+	apt-get install -y --no-install-recommends \
+		ca-certificates curl
+
+COPY files/runc-hook-prestart.sh /bin/runc-hook-prestart.sh
+COPY files/runc-hook-poststop.sh /bin/runc-hook-poststop.sh
+COPY files/entrypoint.sh /entrypoint.sh
+COPY files/bcck8s /opt/bcck8s
+
+COPY bin/gadgettracermanager /bin/gadgettracermanager
+COPY bin/ocihookgadget /bin/ocihookgadget
+COPY bin/networkpolicyadvisor /bin/networkpolicyadvisor
+
+COPY bin/runchooks.so /opt/runchooks/runchooks.so
+COPY bin/add-hooks.jq /opt/runchooks/add-hooks.jq
 
 ADD traceloop /bin/traceloop
 

--- a/gadget-container/gadget.Dockerfile
+++ b/gadget-container/gadget.Dockerfile
@@ -29,4 +29,7 @@ COPY bin/gadgettracermanager /bin/gadgettracermanager
 COPY gadgets/bcck8s /opt/bcck8s
 COPY bin/networkpolicyadvisor /bin/networkpolicyadvisor
 
+COPY bin/runchooks.so /opt/runchooks/runchooks.so
+COPY runchooks/add-hooks.jq /opt/runchooks/add-hooks.jq
+
 COPY --from=traceloop /bin/traceloop /bin/traceloop

--- a/gadget-container/runchooks/add-hooks.jq
+++ b/gadget-container/runchooks/add-hooks.jq
@@ -1,0 +1,16 @@
+{
+	"hooks": {
+		"prestart": [
+			{
+				"path": "/bin/sh",
+				"args": ["sh", "-c", "test ! -x /opt/bin/ocihookgadget || /opt/bin/ocihookgadget -hook prestart"]
+			}
+		],
+		"poststop": [
+			{
+				"path": "/bin/sh",
+				"args": ["sh", "-c", "test ! -x /opt/bin/ocihookgadget || /opt/bin/ocihookgadget -hook poststop"]
+			}
+		]
+	}
+}

--- a/gadget-container/runchooks/runchooks.c
+++ b/gadget-container/runchooks/runchooks.c
@@ -1,0 +1,64 @@
+#define _GNU_SOURCE
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <string.h>
+
+static void __myinit(void) __attribute__((constructor));
+static void __myinit(void)
+{
+	// ignore non-root programs
+	if (geteuid() != 0)
+		return;
+
+	// ignore non-runc programs
+	char buf[1024] = {0,};
+	int ret;
+	ret = readlink("/proc/self/exe", buf, sizeof(buf));
+	if (ret <= 0 || ret == sizeof(buf))
+		return;
+	char *b = basename(buf);
+	if (strcmp(b, "runc") != 0) {
+		return;
+	}
+
+	// find the bundle directory in the command line
+	FILE *cmdline = fopen("/proc/self/cmdline", "r");
+	char *arg = 0;
+	size_t size = 0;
+	int create_found = 0;
+	int next = 0;
+	char *bundledir = NULL;
+	while(getdelim(&arg, &size, 0, cmdline) != -1) {
+		if (strcmp("create", arg) == 0) {
+			create_found = 1;
+			continue;
+		}
+		if (create_found && strcmp("--bundle", arg) == 0) {
+			next = 1;
+			continue;
+		}
+		if (next) {
+			bundledir = strdup(arg);
+			break;
+		}
+	}
+	free(arg);
+	fclose(cmdline);
+
+	// ignore runc programs for other verbs than 'create'
+	if (!create_found)
+		return;
+
+	// ignore runc programs without bundle directory
+	if (bundledir == NULL)
+		return;
+
+	char cmd[1024] = {0,};
+
+	ret = snprintf(cmd, sizeof(cmd), "cd %s && cp config.json config.json.orig && cat config.json.orig | jq -r \". * `cat /opt/runchooks/add-hooks.jq`\" > config.json", bundledir);
+	free(bundledir);
+	if (ret < sizeof(cmd))
+		system(cmd);
+}


### PR DESCRIPTION
Deployment options can be set with:
```
  kubectl gadget deploy --opts <comma-separated-options>
```

This will set the environment variable $INSPEKTOR_GADGET_OPTIONS in the
gadget DaemonSet. The script entrypoint.sh will then act on it. This
allows to enable or disable some experimental options without
recompiling.

This patch introduces two options:

1. runc_hooks_ldpreload
    Inspektor Gadget currently uses OCI hooks via a patched runc that
    adds PreStart and PostStop hooks. As an alternative option, this
    patch adds support for unpatched runc using a ld.so.preload
    configuration.

2. notraceloop
    Don't start the traceloop daemon. This is useful to avoid the
    memory consumption of the traceloop gadget, if only the other
    gadgets are desired.