### PR TITLE
tools: Fix image tag generation

### DIFF
--- a/tools/image-tag
+++ b/tools/image-tag
@@ -9,6 +9,9 @@ set -o pipefail
 WORKING_SUFFIX=$(if git status --porcelain | grep -qE '^(?:[^?][^ ]|[^ ][^?])\s'; then echo "-WIP"; else echo ""; fi)
 BRANCH_PREFIX=$(git rev-parse --abbrev-ref HEAD)
 if [ "$1" = "branch" ] ; then
+  if [ "$BRANCH_PREFIX" = "master" ] ; then
+    BRANCH_PREFIX="latest"
+  fi
   echo "${BRANCH_PREFIX//\//-}$WORKING_SUFFIX"
 else
   echo "${BRANCH_PREFIX//\//-}-$(git rev-parse --short HEAD)$WORKING_SUFFIX"


### PR DESCRIPTION
If the current branch is master the tag should be "latest", otherwise the
deployment will fail because there is not such "master" tag.