### PR TITLE
pkg/networkpolicy: sort policies by name

### DIFF
--- a/pkg/networkpolicy/networkpolicy.go
+++ b/pkg/networkpolicy/networkpolicy.go
@@ -271,6 +271,9 @@ func (a *NetworkPolicyAdvisor) GeneratePolicies() {
 		a.Policies = append(a.Policies, policy)
 	}
 
+	sort.Slice(a.Policies, func(i, j int) bool {
+		return a.Policies[i].Name < a.Policies[j].Name
+	})
 }
 
 func (a *NetworkPolicyAdvisor) FormatPolicies() (out string) {


### PR DESCRIPTION
Sort policies by name so they are easier to understand by users. It also fixes
a random failure in one test because the order of the generated policies was
not always the same.