### PR TITLE
Fix first line print logic

### DIFF
--- a/cmd/inspektor-gadget/cmd/bcck8s.go
+++ b/cmd/inspektor-gadget/cmd/bcck8s.go
@@ -119,7 +119,7 @@ type postProcess struct {
 	failure          chan string
 }
 
-func (post postProcess) Write(p []byte) (n int, err error) {
+func (post *postProcess) Write(p []byte) (n int, err error) {
 	prefix := "[" + post.nodeShort + "] "
 	asStr := string(p)
 	lineBreakPos := strings.Index(asStr, "\n")
@@ -131,9 +131,6 @@ func (post postProcess) Write(p []byte) (n int, err error) {
 			prefix = "NODE "
 		}
 
-		// FIXME: Write() is a method with a value received. The
-		// following statement does not modify the real postProcess
-		// struct!!
 		post.firstLine = false
 	}
 	if asStr != "" && asStr != "\n" {
@@ -216,13 +213,13 @@ func bccCmd(subCommand, bccScript string) func(*cobra.Command, []string) {
 			id := strconv.Itoa(i)
 			fmt.Printf(" %s = %s", id, node.Name)
 			go func(nodeName string, id string) {
-				postOut := postProcess{nodeName, " " + id, os.Stdout, false /* see FIXME in Writer() */, &firstLinePrinted, failure}
+				postOut := postProcess{nodeName, " " + id, os.Stdout, true, &firstLinePrinted, failure}
 				postErr := postProcess{nodeName, "E" + id, os.Stderr, false, &firstLinePrinted, failure}
 				cmd := fmt.Sprintf("exec /opt/bcck8s/bcc-wrapper.sh --flatcaredgeonly --tracerid %s --gadget %s %s %s %s -- %s",
 					tracerId, bccScript, labelFilter, namespaceFilter, podnameFilter, gadgetParams)
 				var err error
 				if subCommand != "tcptop" {
-					err = execPod(client, nodeName, cmd, postOut, postErr)
+					err = execPod(client, nodeName, cmd, &postOut, &postErr)
 				} else {
 					err = execPod(client, nodeName, cmd, os.Stdout, os.Stderr)
 				}


### PR DESCRIPTION
0549db2e37f3 ("Filter first bcc tool lines and annotate nodes") introduced a way
to skip printing the first line of the bcc tools as it is printed once per node.
That commit had a bug and was partially reverted by
6a0116f077d3 ("Workaround for the output disappearing"). This commit fixes the
logic in the original commit by using a pointer receiver notation in the Write()
method of postProcess.

Fixes https://github.com/kinvolk/inspektor-gadget/issues/33.