### PR TITLE
Find containers started before Inspektor Gadget

### DIFF
--- a/cmd/kubectl-gadget/deploy.go
+++ b/cmd/kubectl-gadget/deploy.go
@@ -85,6 +85,10 @@ spec:
         imagePullPolicy: Always
         command: [ "/entrypoint.sh" ]
         env:
+          - name: NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
           - name: TRACELOOP_NODE_NAME
             valueFrom:
               fieldRef:

--- a/gadget-container/gadgettracermanager/main.go
+++ b/gadget-container/gadgettracermanager/main.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/kinvolk/inspektor-gadget/pkg/gadgettracermanager"
 	pb "github.com/kinvolk/inspektor-gadget/pkg/gadgettracermanager/api"
+	"github.com/kinvolk/inspektor-gadget/pkg/gadgettracermanager/initialcontainers"
 )
 
 var (
@@ -163,7 +164,13 @@ func main() {
 
 		var opts []grpc.ServerOption
 		grpcServer := grpc.NewServer(opts...)
-		pb.RegisterGadgetTracerManagerServer(grpcServer, gadgettracermanager.NewServer())
+		containers, err := initialcontainers.InitialContainers()
+		if err != nil {
+			log.Printf("gadgettracermanager failed to get initial containers: %v", err)
+		} else {
+			log.Printf("gadgettracermanager found %d initial containers: %+v", len(containers), containers)
+		}
+		pb.RegisterGadgetTracerManagerServer(grpcServer, gadgettracermanager.NewServer(containers))
 		grpcServer.Serve(lis)
 	}
 }

--- a/pkg/gadgettracermanager/containerutils/containerutils.go
+++ b/pkg/gadgettracermanager/containerutils/containerutils.go
@@ -1,0 +1,116 @@
+package containerutils
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"unsafe"
+)
+
+/*
+#define _GNU_SOURCE
+#include <stdlib.h>
+#include <stdio.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <stdint.h>
+
+struct cgid_file_handle
+{
+  //struct file_handle handle;
+  unsigned int handle_bytes;
+  int handle_type;
+  uint64_t cgid;
+};
+
+uint64_t get_cgroupid(char *path) {
+  struct cgid_file_handle *h;
+  int mount_id;
+  int err;
+  uint64_t ret;
+
+  h = malloc(sizeof(struct cgid_file_handle));
+  if (!h)
+    return 0;
+
+  h->handle_bytes = 8;
+  err = name_to_handle_at(AT_FDCWD, path, (struct file_handle *)h, &mount_id, 0);
+  if (err != 0)
+    return 0;
+
+  if (h->handle_bytes != 8)
+    return 0;
+
+  ret = h->cgid;
+  free(h);
+
+  return ret;
+}
+*/
+import "C"
+
+func GetCgroupID(path string) (uint64, error) {
+	cpath := C.CString(path)
+	ret := uint64(C.get_cgroupid(cpath))
+	C.free(unsafe.Pointer(cpath))
+	if ret == 0 {
+		return 0, fmt.Errorf("GetCgroupID on %q failed", path)
+	}
+	return ret, nil
+}
+
+func GetCgroup2Path(pid int) (string, error) {
+	cgroupPath := ""
+	if cgroupFile, err := os.Open(filepath.Join("/proc", fmt.Sprintf("%d", pid), "cgroup")); err == nil {
+		defer cgroupFile.Close()
+		reader := bufio.NewReader(cgroupFile)
+		for {
+			line, err := reader.ReadString('\n')
+			if err != nil {
+				break
+			}
+			if strings.HasPrefix(line, "0::") {
+				cgroupPath = strings.TrimPrefix(line, "0::")
+				cgroupPath = strings.TrimSuffix(cgroupPath, "\n")
+				break
+			}
+		}
+	} else {
+		return "", fmt.Errorf("cannot parse cgroup: %v", err)
+	}
+	if cgroupPath == "" {
+		return "", fmt.Errorf("cannot find cgroup path in /proc/PID/cgroup")
+	}
+	cgroupPath = filepath.Join("/sys/fs/cgroup/unified", cgroupPath)
+	if _, err := os.Stat(cgroupPath); os.IsNotExist(err) {
+		return "", fmt.Errorf("cannot access cgroup %q: %v", cgroupPath, err)
+	}
+
+	return cgroupPath, nil
+}
+
+func PidFromContainerId(containerID string) (int, error) {
+	out, err := exec.Command("chroot", "/host", "docker", "inspect", strings.TrimPrefix(containerID, "docker://")).Output()
+	if err != nil {
+		return -1, err
+	}
+	type DockerInspect struct {
+		State struct {
+			Pid int
+		}
+	}
+	var dockerInspect []DockerInspect
+	err = json.Unmarshal(out, &dockerInspect)
+	if err != nil {
+		return -1, err
+	}
+	if len(dockerInspect) != 1 {
+		return -1, fmt.Errorf("invalid output")
+	}
+	return dockerInspect[0].State.Pid, nil
+}

--- a/pkg/gadgettracermanager/gadgettracermanager.go
+++ b/pkg/gadgettracermanager/gadgettracermanager.go
@@ -202,10 +202,13 @@ func (g *GadgetTracerManager) DumpState(ctx context.Context, req *pb.DumpStateRe
 	return &pb.Dump{State: out}, nil
 }
 
-func NewServer() *GadgetTracerManager {
+func NewServer(initialContainers []pb.ContainerDefinition) *GadgetTracerManager {
 	g := &GadgetTracerManager{
 		containers: make(map[string]pb.ContainerDefinition),
 		tracers:    make(map[string]tracer),
+	}
+	for _, containerDefinition := range initialContainers {
+		g.containers[containerDefinition.ContainerId] = containerDefinition
 	}
 	return g
 }

--- a/pkg/gadgettracermanager/initialcontainers/initialcontainers.go
+++ b/pkg/gadgettracermanager/initialcontainers/initialcontainers.go
@@ -1,0 +1,76 @@
+package initialcontainers
+
+import (
+	"log"
+	"os"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+
+	pb "github.com/kinvolk/inspektor-gadget/pkg/gadgettracermanager/api"
+	"github.com/kinvolk/inspektor-gadget/pkg/gadgettracermanager/containerutils"
+)
+
+func InitialContainers() (arr []pb.ContainerDefinition, err error) {
+	// Connect to the API server
+	kubeconfig := "" // internal access
+	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+	if err != nil {
+		return nil, err
+	}
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+
+	// List pods
+	pods, err := clientset.CoreV1().Pods("").List(metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	nodeSelf := os.Getenv("NODE_NAME")
+	for _, pod := range pods.Items {
+		if pod.Spec.NodeName != nodeSelf {
+			continue
+		}
+		labels := []*pb.Label{}
+		for k, v := range pod.ObjectMeta.Labels {
+			labels = append(labels, &pb.Label{Key: k, Value: v})
+		}
+		for i, s := range pod.Status.ContainerStatuses {
+			if s.ContainerID == "" {
+				continue
+			}
+
+			pid, err := containerutils.PidFromContainerId(s.ContainerID)
+			if err != nil {
+				log.Printf("Skip pod %s/%s: cannot find pid: %v", pod.GetNamespace(), pod.GetName(), err)
+				continue
+			}
+			cgroupPath, err := containerutils.GetCgroup2Path(pid)
+			if err != nil {
+				log.Printf("Skip pod %s/%s: cannot find cgroup path: %v", pod.GetNamespace(), pod.GetName(), err)
+				continue
+			}
+			cgroupId, err := containerutils.GetCgroupID(cgroupPath)
+			if err != nil {
+				log.Printf("Skip pod %s/%s: cannot find cgroup id: %v", pod.GetNamespace(), pod.GetName(), err)
+				continue
+			}
+
+			containerDef := pb.ContainerDefinition{
+				ContainerId:    s.ContainerID,
+				CgroupPath:     cgroupPath,
+				CgroupId:       cgroupId,
+				Namespace:      pod.GetNamespace(),
+				Podname:        pod.GetName(),
+				ContainerIndex: int32(i),
+				Labels:         labels,
+			}
+			arr = append(arr, containerDef)
+		}
+	}
+	return arr, nil
+}


### PR DESCRIPTION
The Gadget Tracer Manager currently only finds out about new containers via the OCI PreStart hook. If a container was started before Inspektor Gadget is deployed, then it will not be found and gadgets won't be able to get events for that container.

This patch adds support to find out about those containers.

Functions from ocihookgadget to read cgroup paths and cgroup ids are moved to a new package pkg/gadgettracermanager/containerutils.