### PR TITLE
Cleanup installed files

### DIFF
--- a/cmd/kubectl-gadget/deploy.go
+++ b/cmd/kubectl-gadget/deploy.go
@@ -84,6 +84,11 @@ spec:
         image: {{.Image}}
         imagePullPolicy: Always
         command: [ "/entrypoint.sh" ]
+        lifecycle:
+          preStop:
+            exec:
+              command:
+                - "/cleanup.sh"
         env:
           - name: NODE_NAME
             valueFrom:

--- a/gadget-container/cleanup.sh
+++ b/gadget-container/cleanup.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# This script cleans up all the files installed by Inspektor Gadget
+
+for i in ocihookgadget runc-hook-prestart.sh runc-hook-poststop.sh ; do
+  echo "Removing $i..."
+  /bin/rm -f /host/opt/bin/$i
+done
+echo "Cleanup completed"

--- a/gadget-container/gadget-from-local-bin.Dockerfile
+++ b/gadget-container/gadget-from-local-bin.Dockerfile
@@ -10,6 +10,7 @@ RUN set -ex; \
 COPY files/runc-hook-prestart.sh /bin/runc-hook-prestart.sh
 COPY files/runc-hook-poststop.sh /bin/runc-hook-poststop.sh
 COPY files/entrypoint.sh /entrypoint.sh
+COPY cleanup.sh /cleanup.sh
 COPY files/bcck8s /opt/bcck8s
 
 COPY bin/gadgettracermanager /bin/gadgettracermanager

--- a/gadget-container/gadget.Dockerfile
+++ b/gadget-container/gadget.Dockerfile
@@ -25,6 +25,7 @@ RUN set -ex; \
 		ca-certificates curl
 
 COPY entrypoint.sh /entrypoint.sh
+COPY cleanup.sh /cleanup.sh
 
 COPY ocihookgadget/runc-hook-prestart.sh /bin/runc-hook-prestart.sh
 COPY ocihookgadget/runc-hook-poststop.sh /bin/runc-hook-poststop.sh


### PR DESCRIPTION
Add a cleanup script using the preStop hook to remove all the files installed
in the host by Inspektor Gadget.