### PR TITLE
Fix minikube dev image

### DIFF
--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -49,6 +49,12 @@ jobs:
       run: |
         make test
 
+    - name: Smoke test build of the dev image for minikube
+      run: |
+        mkdir ../traceloop
+        touch ../traceloop/traceloop
+        MINIKUBE=true make -C gadget-container/ docker-gadget/minikube-build
+
     - name: Upload Inspektor Gadget artifact
       uses: actions/upload-artifact@v1
       with:

--- a/Documentation/install.md
+++ b/Documentation/install.md
@@ -120,6 +120,10 @@ If you wish to install all the gadgets on another Kubernetes distribution, you w
 It's possible to make changes to traceloop and test them on minikube locally without pushing container images to any registry.
 
 * Make sure the git repositories `traceloop` and `inspektor-gadget` are cloned in sibling directories
+* Minikube with the docker driver does not work for traceloop. You can use another driver, for example:
+```
+$ minikube start --driver=kvm2
+```
 * Install Inspektor Gadget on minikube as usual:
 ```
 $ kubectl gadget deploy | kubectl apply -f -

--- a/gadget-container/Makefile
+++ b/gadget-container/Makefile
@@ -1,6 +1,8 @@
 IMAGE_TAG=$(shell ../tools/image-tag)
 IMAGE_BRANCH_TAG=$(shell ../tools/image-tag branch)
 
+MINIKUBE ?= minikube
+
 .PHONY: gadget-container-deps
 gadget-container-deps: ocihookgadget gadgettracermanager networkpolicyadvisor
 
@@ -46,7 +48,7 @@ minikube: docker-gadget/minikube-build docker-gadget/minikube-install
 
 docker-gadget/minikube-build:
 	cp ../../traceloop/traceloop ./
-	eval $(shell minikube docker-env | grep =) ; docker build -t docker.io/kinvolk/gadget:minikube -f gadget-from-local-bin.Dockerfile .
+	eval $(shell $(MINIKUBE) docker-env | grep =) ; docker build -t docker.io/kinvolk/gadget:minikube -f gadget-from-local-bin.Dockerfile .
 	rm -f traceloop
 
 docker-gadget/minikube-install:

--- a/gadget-container/gadget-from-local-bin.Dockerfile
+++ b/gadget-container/gadget-from-local-bin.Dockerfile
@@ -1,20 +1,29 @@
 # Main gadget image
 
-FROM docker.io/kinvolk/bcc:ig-latest
+# BCC built from:
+# https://github.com/kinvolk/bcc/commit/ab54de2e4449027f2b4dccd022adc57bec4fd4eb
+# See:
+# - https://github.com/kinvolk/bcc/actions
+# - https://hub.docker.com/repository/docker/kinvolk/bcc/tags
+
+FROM docker.io/kinvolk/bcc:20200330122541ab54de
+
 RUN set -ex; \
 	export DEBIAN_FRONTEND=noninteractive; \
 	apt-get update && \
 	apt-get install -y --no-install-recommends \
 		ca-certificates curl
 
-COPY files/runc-hook-prestart.sh /bin/runc-hook-prestart.sh
-COPY files/runc-hook-poststop.sh /bin/runc-hook-poststop.sh
-COPY files/entrypoint.sh /entrypoint.sh
+COPY entrypoint.sh /entrypoint.sh
 COPY cleanup.sh /cleanup.sh
-COPY files/bcck8s /opt/bcck8s
+
+COPY ocihookgadget/runc-hook-prestart.sh /bin/runc-hook-prestart.sh
+COPY ocihookgadget/runc-hook-poststop.sh /bin/runc-hook-poststop.sh
+COPY bin/ocihookgadget /bin/ocihookgadget
 
 COPY bin/gadgettracermanager /bin/gadgettracermanager
-COPY bin/ocihookgadget /bin/ocihookgadget
+
+COPY gadgets/bcck8s /opt/bcck8s
 COPY bin/networkpolicyadvisor /bin/networkpolicyadvisor
 
 ADD traceloop /bin/traceloop


### PR DESCRIPTION
Also, add a build smoke-test to check that `gadget-from-local-bin.Dockerfile` is still buildable.