### PR TITLE
networkpolicyadvisor: batch events to reduce api calls

### DIFF
--- a/gadget-container/gadgets/networkpolicyadvisor/main.go
+++ b/gadget-container/gadgets/networkpolicyadvisor/main.go
@@ -179,9 +179,9 @@ func main() {
 				// Consume that amount of events from the queue and use the same cache of
 				// pods and services with them. We might not consume all the events,
 				// that's ok, we'll get them at the next tick.
-				batch := make([]tracer.TcpV4, 0)
+				batch := make([]tracer.TcpV4, eventCount)
 				for i := 0; i < eventCount; i++ {
-					batch = append(batch, <-mytracer.queue)
+					batch[i] = <-mytracer.queue
 				}
 				pods, err := clientset.CoreV1().Pods("").List(metav1.ListOptions{})
 				if err != nil {


### PR DESCRIPTION
The Network Policy Advisor receives TCP connection tuples with IP
addresses from the BPF program. In order to match them with Kubernetes
pods and services, it needs to make two API calls to the kube-apiserver
to get the IP of the pods and the IP of the services.

Before this patch, the kube-apiserver was called for each new TCP
connection. This takes too much CPU and it is sometimes unable to handle
the connections fast enough.

With this patch, it uses a ticker and it can only call the API server
maximum every second and it caches the result for a batch of TCP
connections. It takes care of making the API calls after receiving the
TCP connection to avoid the race of evaluating a connection from a new
pod based on a old cache of the pod IPs.