### PR TITLE
Initial containers: only check pid of running containers

### DIFF
--- a/pkg/gadgettracermanager/initialcontainers/initialcontainers.go
+++ b/pkg/gadgettracermanager/initialcontainers/initialcontainers.go
@@ -43,6 +43,9 @@ func InitialContainers() (arr []pb.ContainerDefinition, err error) {
 			if s.ContainerID == "" {
 				continue
 			}
+			if s.State.Running == nil {
+				continue
+			}
 
 			pid, err := containerutils.PidFromContainerId(s.ContainerID)
 			if err != nil {


### PR DESCRIPTION
There is no point of checking the pid of containers that are not running yet, or that have terminated. This causes unnecessary errors.