### PR TITLE
Improve runc hooks mode

### DIFF
--- a/Documentation/install.md
+++ b/Documentation/install.md
@@ -73,6 +73,15 @@ If you wish to install an alternative gadget image, you could use the following 
 $ kubectl gadget deploy --image=docker.io/myfork/gadget:tag | kubectl apply -f -
 ```
 
+### runc hooks mode
+
+Inspektor Gadget needs to detect when containers are started and stopped.
+The different supported modes can be set by using the `runc-hooks-mode` option:
+
+- `auto`(default): Inspektor Gadget will try to find the best option based on the system it is running on.
+- `flatcar_edge`: Use a custom `runc` version shipped with Flatcar Container Linux Edge.
+- `ldpreload`: Adds an entry in `/etc/ld.so.preload` to call a custom shared library that looks for `runc` calls and dynamically adds the needed OCI hooks to the cointainer `config.json` specification. Since this feature is highly experimental, it'll not be considered when `auto` is used.
+
 ## Getting all gadgets
 
 Not all gadgets currently work everywhere.

--- a/gadget-container/cleanup.sh
+++ b/gadget-container/cleanup.sh
@@ -2,8 +2,18 @@
 
 # This script cleans up all the files installed by Inspektor Gadget
 
+# OCI hooks
 for i in ocihookgadget runc-hook-prestart.sh runc-hook-poststop.sh ; do
-  echo "Removing $i..."
   /bin/rm -f /host/opt/bin/$i
 done
+
+# ld preload support
+if [ -f "/host/etc/ld.so.preload" ] ; then
+  # remove entry in /host/etc/ld.so.preload
+  sed -i '/\/opt\/runchooks\/runchooks.so/d' "/host/etc/ld.so.preload"
+fi
+
+/bin/rm -f /host/opt/runchooks/runchooks.so
+/bin/rm -f /host/opt/runchooks/add-hooks.jq
+
 echo "Cleanup completed"

--- a/pkg/gadgettracermanager/containerutils/containerutils.go
+++ b/pkg/gadgettracermanager/containerutils/containerutils.go
@@ -105,6 +105,14 @@ func GetCgroupPaths(pid int) (string, string, error) {
 		return "", "", fmt.Errorf("cannot parse cgroup: %v", err)
 	}
 
+	if cgroupPathV1 == "/" {
+		cgroupPathV1 = ""
+	}
+
+	if cgroupPathV2 == "/" {
+		cgroupPathV2 = ""
+	}
+
 	if cgroupPathV2 == "" && cgroupPathV1 == "" {
 		return "", "", fmt.Errorf("cannot find cgroup path in /proc/PID/cgroup")
 	}


### PR DESCRIPTION
Improve runc hooks mode support

- Rename the option to 'runc-hooks-mode'
- Make 'auto' mode detect the config if possible
- Add a 'flatcar_edge' mode
- Add some documentation
- Clean up changes in /etc/ls.so.preload when uninstalling IG

The target of this PR is to add changes to https://github.com/kinvolk/inspektor-gadget/pull/58, not directly the master branch.