### PR TITLE
Miscellaneous fixes

### DIFF
--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -38,7 +38,7 @@ jobs:
 
     - name: Build Inspektor Gadget
       run: |
-        IMAGE_TAG=${{steps.publish-registry.outputs.snapshot-tag}} make build-ig
+        IMAGE_TAG=${{steps.publish-registry.outputs.snapshot-tag}} make kubectl-gadget
 
         mkdir -p out/inspektor-gadget
         cp kubectl-gadget-* out/inspektor-gadget/

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,8 @@
 *.dll
 *.so
 *.dylib
-/kubectl-gadget
+/kubectl-gadget-darwin-amd64
+/kubectl-gadget-linux-amd64
 /gadget-container/bin
 
 # Test binary, build with `go test -c`

--- a/Makefile
+++ b/Makefile
@@ -14,31 +14,33 @@ LDFLAGS := "-X main.version=$(VERSION) \
 -extldflags '-static'"
 
 .PHONY: build
-build: build-ig build-gadget-container
+build: kubectl-gadget build-gadget-container
 
-.PHONY: build-ig
-build-ig: kubectl-gadget-linux-amd64 kubectl-gadget-darwin-amd64
+.PHONY: kubectl-gadget
+kubectl-gadget: kubectl-gadget-linux-amd64 kubectl-gadget-darwin-amd64
 
+.PHONY: kubectl-gadget-linux-amd64
 kubectl-gadget-linux-amd64:
 	GO111MODULE=on CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
 		-ldflags $(LDFLAGS) \
 		-o kubectl-gadget-linux-amd64 \
 		github.com/kinvolk/inspektor-gadget/cmd/kubectl-gadget
 
+.PHONY: kubectl-gadget-darwin-amd64
 kubectl-gadget-darwin-amd64:
 	GO111MODULE=on CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build \
 		-ldflags $(LDFLAGS) \
 		-o kubectl-gadget-darwin-amd64 \
 		github.com/kinvolk/inspektor-gadget/cmd/kubectl-gadget
 
+.PHONY: install-user-linux
+install-user-linux: kubectl-gadget-linux-amd64
+	mkdir -p ~/.local/bin/
+	cp kubectl-gadget-linux-amd64 ~/.local/bin/kubectl-gadget
+
 .PHONY: build-gadget-container
 build-gadget-container:
 	make -C gadget-container build
-
-.PHONY: install-user
-install-user: build-ig
-	mkdir -p ~/.local/bin/
-	cp kubectl-gadget ~/.local/bin/
 
 .PHONY: test
 test:

--- a/cmd/kubectl-gadget/bcck8s.go
+++ b/cmd/kubectl-gadget/bcck8s.go
@@ -214,6 +214,13 @@ func bccCmd(subCommand, bccScript string) func(*cobra.Command, []string) {
 
 		labelFilter := ""
 		if labelParam != "" {
+			pairs := strings.Split(labelParam, ",")
+			for _, pair := range pairs {
+				kv := strings.Split(pair, "=")
+				if len(kv) != 2 {
+					contextLogger.Fatalf("labels should be a comma-separated list of key-value pairs (key=value[,key=value,...])\n")
+				}
+			}
 			labelFilter = fmt.Sprintf("--label %q", labelParam)
 		}
 

--- a/cmd/kubectl-gadget/traceloop.go
+++ b/cmd/kubectl-gadget/traceloop.go
@@ -238,18 +238,16 @@ func runTraceloopList(cmd *cobra.Command, args []string) {
 		case "created":
 			fallthrough
 		case "ready":
-			t, err := time.Parse(time.RFC3339, trace.TimeCreation)
-			if err == nil {
-				status = fmt.Sprintf("created %s ago", units.HumanDuration(time.Now().Sub(t)))
-			} else {
-				status = fmt.Sprintf("created a while ago (%v)", err)
+			status = "started"
+			if t, err := time.Parse(time.RFC3339, trace.TimeCreation); err == nil {
+				status += fmt.Sprintf(" %s ago",
+					strings.ToLower(units.HumanDuration(time.Now().Sub(t))))
 			}
 		case "deleted":
-			t, err := time.Parse(time.RFC3339, trace.TimeDeletion)
-			if err == nil {
-				status = fmt.Sprintf("%s %s ago", trace.Status, units.HumanDuration(time.Now().Sub(t)))
-			} else {
-				status = fmt.Sprintf("%s a while ago (%v)", trace.Status, err)
+			status = "terminated"
+			if t, err := time.Parse(time.RFC3339, trace.TimeDeletion); err == nil {
+				status += fmt.Sprintf(" %s ago",
+					strings.ToLower(units.HumanDuration(time.Now().Sub(t))))
 			}
 		default:
 			status = fmt.Sprintf("unknown (%v)", trace.Status)

--- a/gadget-container/gadgettracermanager/main.go
+++ b/gadget-container/gadgettracermanager/main.go
@@ -65,7 +65,7 @@ func main() {
 		for _, pair := range pairs {
 			kv := strings.Split(pair, "=")
 			if len(kv) != 2 {
-				fmt.Printf("invalid key=value[:key=value...] %q\n", label)
+				fmt.Printf("invalid key=value[,key=value,...] %q\n", label)
 				flag.PrintDefaults()
 				os.Exit(1)
 			}


### PR DESCRIPTION
- Add kubectl-gadget executables to .gitignore
- traceloop list: improve duration display in status
- bcc gadgets: check --label flag before using it

Extract some commits originally added in https://github.com/kinvolk/inspektor-gadget/pull/76 to make that review easier.
