### PR TITLE
Two small fixes

### DIFF
--- a/cmd/kubectl-gadget/bcck8s.go
+++ b/cmd/kubectl-gadget/bcck8s.go
@@ -299,6 +299,7 @@ func bccCmd(subCommand, bccScript string) func(*cobra.Command, []string) {
 				}
 			}(node.Name, i) // node.Name is invalidated by the above for loop, causes races
 		}
+		fmt.Println()
 
 		select {
 		case <-sigs:

--- a/gadget-container/gadgets/networkpolicyadvisor/main.go
+++ b/gadget-container/gadgets/networkpolicyadvisor/main.go
@@ -12,11 +12,11 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/weaveworks/tcptracer-bpf/pkg/tracer"
 
 	"github.com/kinvolk/inspektor-gadget/pkg/gadgets/networkpolicy/types"
+	"github.com/kinvolk/inspektor-gadget/pkg/k8sutil"
 )
 
 var (
@@ -144,11 +144,7 @@ func main() {
 	}
 
 	// Connect to the API server
-	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
-	if err != nil {
-		panic(err)
-	}
-	clientset, err := kubernetes.NewForConfig(config)
+	clientset, err := k8sutil.NewClientset(kubeconfig)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/k8sutil/client.go
+++ b/pkg/k8sutil/client.go
@@ -3,16 +3,24 @@ package k8sutil
 import (
 	"k8s.io/client-go/kubernetes"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )
 
 func NewClientset(kubeconfigPath string) (*kubernetes.Clientset, error) {
-	c, err := clientcmd.BuildConfigFromFlags("", kubeconfigPath)
+	var config *rest.Config
+	var err error
+	if kubeconfigPath == "" {
+		config, err = rest.InClusterConfig()
+	} else {
+		config, err = clientcmd.BuildConfigFromFlags("", kubeconfigPath)
+	}
+
 	if err != nil {
 		return nil, err
 	}
 
-	apiclientset, err := kubernetes.NewForConfig(c)
+	apiclientset, err := kubernetes.NewForConfig(config)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
- bcck8s: Add line break after printing the nodes names
- gadgets/networkpolicyadvisor: Use k8sutil to create k8s client set
