### PR TITLE
Only fetch local pods

### DIFF
--- a/gadget-container/entrypoint.sh
+++ b/gadget-container/entrypoint.sh
@@ -123,6 +123,8 @@ if [ "$RUNC_HOOK_MODE" = "flatcar_edge" ] ||
   # used in ocihookgadget
   sed -i "s@%KUBECONFIG%@$KUBECONFIG_PARAM@g" /host/opt/bin/runc-hook-{prestart,poststop}.sh
 
+  sed -i "s@%NODE%@-node $NODE_NAME@g" /host/opt/bin/runc-hook-{prestart,poststop}.sh
+
   if [ "$RUNC_HOOK_MODE" = "crio" ] ; then
     echo "Installing OCI hooks configuration in /etc/containers/oci/hooks.d/"
     mkdir -p /host/etc/containers/oci/hooks.d/

--- a/gadget-container/ocihookgadget/runc-hook-poststop.sh
+++ b/gadget-container/ocihookgadget/runc-hook-poststop.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 read JSON
 pidof gadgettracermanager > /dev/null || exit 0
-echo $JSON | /opt/bin/ocihookgadget %KUBECONFIG% -hook poststop >> /var/log/gadget.log 2>&1
+echo $JSON | /opt/bin/ocihookgadget %KUBECONFIG% %NODE% -hook poststop >> /var/log/gadget.log 2>&1
 exit 0

--- a/gadget-container/ocihookgadget/runc-hook-prestart.sh
+++ b/gadget-container/ocihookgadget/runc-hook-prestart.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 read JSON
 pidof gadgettracermanager > /dev/null || exit 0
-echo $JSON | /opt/bin/ocihookgadget %KUBECONFIG% -hook prestart >> /var/log/gadget.log 2>&1
+echo $JSON | /opt/bin/ocihookgadget %KUBECONFIG% %NODE% -hook prestart >> /var/log/gadget.log 2>&1
 exit 0

--- a/pkg/gadgettracermanager/initialcontainers/initialcontainers.go
+++ b/pkg/gadgettracermanager/initialcontainers/initialcontainers.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 
@@ -25,12 +26,14 @@ func InitialContainers() (arr []pb.ContainerDefinition, err error) {
 	}
 
 	// List pods
-	pods, err := clientset.CoreV1().Pods("").List(metav1.ListOptions{})
+	nodeSelf := os.Getenv("NODE_NAME")
+	pods, err := clientset.CoreV1().Pods("").List(metav1.ListOptions{
+		FieldSelector: fields.OneTermEqualSelector("spec.nodeName", nodeSelf).String(),
+	})
 	if err != nil {
 		return nil, err
 	}
 
-	nodeSelf := os.Getenv("NODE_NAME")
 	for _, pod := range pods.Items {
 		if pod.Spec.NodeName != nodeSelf {
 			continue


### PR DESCRIPTION
There are 2 locations where IG fetches the list of pods from the API
server:
- the oci hooks
- during initialisation of the gadgettracermanager

In both cases, IG does not need to get all the pods but only the local
pods. Use a field selector to filter pods.