### PR TITLE
Build and publish container image for integration tests

### DIFF
--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -63,9 +63,22 @@ jobs:
         kubernetes version: 'v1.18.2'
         github token: ${{ secrets.GITHUB_TOKEN }}
 
+    - uses: azure/docker-login@v1
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+
     - name: Integration tests
       run: |
-        IMAGE_TAG=${{steps.publish-registry.outputs.snapshot-tag}} make integration-tests
+        export IMAGE_TAG=${{steps.publish-registry.outputs.snapshot-tag}}
+        echo "Using IMAGE_TAG=$IMAGE_TAG"
+
+        make -C integration build push
+
+        TESTS_DOCKER_ARGS="-e KUBECONFIG=/root/.kube/config -v /home/runner/.kube:/root/.kube -v /home/runner/work/_temp/.minikube:/home/runner/work/_temp/.minikube" \
+            make -C integration test
+
+        sed -i "s/latest/$IMAGE_TAG/g" integration/gadget-integration-tests-job.yaml
 
     - name: Smoke test build of the dev image for minikube
       run: |
@@ -120,3 +133,15 @@ jobs:
         asset_path: inspektor-gadget-darwin-amd64.tar.gz
         asset_name: inspektor-gadget-darwin-amd64.tar.gz
         asset_content_type: application/gzip
+
+    - name: Upload Testing Asset
+      id: upload-release-asset-testing
+      uses: actions/upload-release-asset@v1.0.1
+      if: startsWith(github.ref, 'refs/tags/v')
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: integration/gadget-integration-tests-job.yaml
+        asset_name: gadget-integration-tests-job.yaml
+        asset_content_type: application/x-yaml

--- a/integration/Dockerfile
+++ b/integration/Dockerfile
@@ -1,0 +1,19 @@
+FROM golang:1.14-alpine AS build_base
+RUN apk add --no-cache git
+WORKDIR /build
+RUN go get -d -v github.com/kr/pretty
+RUN go install -v github.com/kr/pretty
+COPY . .
+RUN go test -c -o gadget-integration.test ./...
+
+FROM alpine:3.11
+RUN apk add ca-certificates curl
+ENV KUBECTL_GADGET /bin/kubectl-gadget
+
+RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
+RUN chmod +x ./kubectl
+RUN mv ./kubectl /usr/local/bin
+
+COPY bin/kubectl-gadget /bin/kubectl-gadget
+COPY --from=build_base /build/gadget-integration.test /bin/gadget-integration.test
+CMD ["/bin/sh", "-c", "gadget-integration.test -test.v -integration"]

--- a/integration/Makefile
+++ b/integration/Makefile
@@ -1,0 +1,34 @@
+IMAGE_TAG=$(shell ../tools/image-tag)
+IMAGE_BRANCH_TAG=$(shell ../tools/image-tag branch)
+
+TESTS_DOCKER_ARGS ?= "-e KUBECONFIG=/opt/kubeconfig/config -v $(HOME)/.kube:/opt/kubeconfig"
+
+.PHONY: build
+build:
+	mkdir -p bin
+	cp ../kubectl-gadget-linux-amd64 bin/kubectl-gadget
+	docker build -t docker.io/kinvolk/gadgettest:$(IMAGE_TAG) -f Dockerfile .
+	rm -f bin/kubectl-gadget
+	docker tag docker.io/kinvolk/gadgettest:$(IMAGE_TAG) docker.io/kinvolk/gadgettest:$(IMAGE_BRANCH_TAG)
+
+.PHONY: push
+push:
+	docker push docker.io/kinvolk/gadgettest:$(IMAGE_TAG)
+	docker push docker.io/kinvolk/gadgettest:$(IMAGE_BRANCH_TAG)
+
+.PHONY: test
+test:
+	if [ "x$(KUBECONFIG)" = "x" ] ; then \
+		echo "Running tests without KUBECONFIG variable" ; \
+		docker run -i \
+			--net=host \
+			$(TESTS_DOCKER_ARGS) \
+			docker.io/kinvolk/gadgettest:$(IMAGE_TAG) ; \
+	else \
+		echo "Running tests with KUBECONFIG = $(KUBECONFIG)" ; \
+		docker run -i \
+			--net=host \
+			-e KUBECONFIG=/opt/kubeconfig/$(shell basename "$(KUBECONFIG)") \
+			-v $(shell dirname "$(KUBECONFIG)"):/opt/kubeconfig \
+			docker.io/kinvolk/gadgettest:$(IMAGE_TAG) ; \
+	fi

--- a/integration/gadget-integration-tests-job.yaml
+++ b/integration/gadget-integration-tests-job.yaml
@@ -1,0 +1,41 @@
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: gadget-test
+  labels:
+    name: gadget-test
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: gadget-test
+  namespace: gadget-test
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: gadget-test
+subjects:
+- kind: ServiceAccount
+  name: gadget-test
+  namespace: gadget-test
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: gadget-test
+  namespace: gadget-test
+spec:
+  template:
+    spec:
+      serviceAccount: gadget-test
+      containers:
+      - name: gadget-test
+        image: docker.io/kinvolk/gadgettest:latest
+        imagePullPolicy: Always
+      restartPolicy: Never
+  backoffLimit: 0


### PR DESCRIPTION
Then, Kubernetes distributions will be able to run the tests from Inspektor Gadget with the following commands, without installing kubectl-gadget or recompiling:

```
wget https://github.com/kinvolk/inspektor-gadget/releases/download/v0.2.0/gadget-integration-tests-job.yaml
kubectl apply -f gadget-integration-tests-job.yaml
kubectl logs -n gadget-test -l job-name=gadget-test
```
