### PR TITLE
Docs: Add krew install instructions

### DIFF
--- a/Documentation/install.md
+++ b/Documentation/install.md
@@ -5,7 +5,26 @@ system and a DaemonSet deployed in the cluster.
 
 ## Installing kubectl-gadget
 
-### Stable version
+Choose one way to install the Inspektor Gadget `kubectl` plugin.
+
+### Using krew
+
+[krew](https://sigs.k8s.io/krew) is the recommended way to install
+`kubectl-gadget`. You can follow the
+[krew's quickstart](https://krew.sigs.k8s.io/docs/user-guide/quickstart/)
+to install it and then install `kubectl-gadget` by executing the following
+commands.
+
+```
+kubectl krew install gadget
+kubectl gadget --help
+```
+
+### Install a specific release
+
+Download the asset for a given release and platform from the
+[releases page](https://github.com/kinvolk/inspektor-gadget/releases/),
+uncompress and move the `kubectl-gadget` executable to your `PATH`.
 
 ```
 $ wget https://github.com/kinvolk/inspektor-gadget/releases/download/v0.1.0/inspektor-gadget-linux-amd64.tar.gz
@@ -13,8 +32,6 @@ $ tar xvf inspektor-gadget-linux-amd64.tar.gz
 $ sudo cp kubectl-gadget /usr/local/bin/
 $ kubectl gadget version
 ```
-
-You can find other releases on [releases](https://github.com/kinvolk/inspektor-gadget/releases).
 
 ### Download from Github Actions artifacts
 

--- a/README.md
+++ b/README.md
@@ -67,11 +67,11 @@ programs are and how Inspektor Gadget uses them is briefly explained here:
 
 Install Inspektor Gadget (client-side):
 
+Use [krew](https://sigs.k8s.io/krew) plugin manager to install:
+
 ```
-$ wget https://github.com/kinvolk/inspektor-gadget/releases/download/v0.1.0/inspektor-gadget-linux-amd64.tar.gz
-$ tar xvf inspektor-gadget-linux-amd64.tar.gz
-$ sudo cp kubectl-gadget /usr/local/bin/
-$ kubectl gadget version
+kubectl krew install gadget
+kubectl gadget --help
 ```
 
 Install Inspektor Gadget on Kubernetes:
@@ -80,7 +80,7 @@ Install Inspektor Gadget on Kubernetes:
 $ kubectl gadget deploy | kubectl apply -f -
 ```
 
-[Read the detailed install instructions](Documentation/install.md)
+Read the detailed [install instructions](Documentation/install.md) to find more information.
 
 ## Contributing
 


### PR DESCRIPTION
To be merged once https://github.com/kubernetes-sigs/krew-index/pull/628 is merged.