### PR TITLE
Fix kubeconfig sources

### DIFF
--- a/pkg/k8sutil/client.go
+++ b/pkg/k8sutil/client.go
@@ -1,19 +1,30 @@
 package k8sutil
 
 import (
+	"path/filepath"
+
 	"k8s.io/client-go/kubernetes"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/util/homedir"
 )
 
 func NewClientset(kubeconfigPath string) (*kubernetes.Clientset, error) {
 	var config *rest.Config
 	var err error
-	if kubeconfigPath == "" {
-		config, err = rest.InClusterConfig()
-	} else {
+	if kubeconfigPath != "" {
+		// kubeconfig is set explicitly (-kubeconfig flag or $KUBECONFIG variable)
 		config, err = clientcmd.BuildConfigFromFlags("", kubeconfigPath)
+	} else {
+		// kubeconfig from a pod Service Account token
+		config, err = rest.InClusterConfig()
+		if err == rest.ErrNotInCluster {
+			// kubeconfig from $HOME/.kube/config
+			if home := homedir.HomeDir(); home != "" {
+				config, err = clientcmd.BuildConfigFromFlags("", filepath.Join(home, ".kube", "config"))
+			}
+		}
 	}
 
 	if err != nil {


### PR DESCRIPTION
Symptoms from integration tests:

```
--- FAIL: TestTraceloop (89.38s)
    --- FAIL: TestTraceloop/Check_traceloop_list (5.01s)
        traceloop_test.go:101: Command: sleep 5 ; $KUBECTL_GADGET traceloop list -n test-traceloop --no-headers | grep multiplication | awk '{print $1" "$6}'
make: *** [integration-tests] Error 1
        traceloop_test.go:105: Command returned:
            time="2020-06-03T02:11:36Z" level=fatal msg="Error in creating setting up Kubernetes client: \"unable to load in-cluster configuration, KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined\"" args="[]" command="kubectl-gadget traceloop list"
```