### PR TITLE
Fixes for containerd and Ubuntu

### DIFF
--- a/cmd/kubectl-gadget/deploy.go
+++ b/cmd/kubectl-gadget/deploy.go
@@ -100,6 +100,10 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
+          - name: GADGET_POD_UID
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.uid
           - name: TRACELOOP_NODE_NAME
             valueFrom:
               fieldRef:

--- a/gadget-container/gadget-from-local-bin.Dockerfile
+++ b/gadget-container/gadget-from-local-bin.Dockerfile
@@ -1,12 +1,12 @@
 # Main gadget image
 
 # BCC built from:
-# https://github.com/kinvolk/bcc/commit/32ab858309c84c23049715aaab936ce654ad5792
+# https://github.com/kinvolk/bcc/commit/5fed2a94da19501c3088161db0c412b5623050ca
 # See:
 # - https://github.com/kinvolk/bcc/actions
-# - https://hub.docker.com/repository/docker/kinvolk/bcc/tags
+# - https://hub.docker.com/r/kinvolk/bcc/tags
 
-FROM docker.io/kinvolk/bcc:2020052208101032ab85
+FROM docker.io/kinvolk/bcc:202006031708335fed2a
 
 RUN set -ex; \
 	export DEBIAN_FRONTEND=noninteractive; \

--- a/gadget-container/gadget.Dockerfile
+++ b/gadget-container/gadget.Dockerfile
@@ -4,19 +4,19 @@
 # https://github.com/kinvolk/traceloop/commit/0b9f44a1b61b528145f56c8e4b271186be6028f2
 # See:
 # - https://github.com/kinvolk/traceloop/actions
-# - https://hub.docker.com/repository/docker/kinvolk/traceloop/tags
+# - https://hub.docker.com/r/kinvolk/traceloop/tags
 
 FROM docker.io/kinvolk/traceloop:202005220209060b9f44 as traceloop
 
 # Main gadget image
 
 # BCC built from:
-# https://github.com/kinvolk/bcc/commit/32ab858309c84c23049715aaab936ce654ad5792
+# https://github.com/kinvolk/bcc/commit/5fed2a94da19501c3088161db0c412b5623050ca
 # See:
 # - https://github.com/kinvolk/bcc/actions
-# - https://hub.docker.com/repository/docker/kinvolk/bcc/tags
+# - https://hub.docker.com/r/kinvolk/bcc/tags
 
-FROM docker.io/kinvolk/bcc:2020052208101032ab85
+FROM docker.io/kinvolk/bcc:202006031708335fed2a
 
 RUN set -ex; \
 	export DEBIAN_FRONTEND=noninteractive; \

--- a/gadget-container/gadgets/bcck8s/bcc-wrapper.sh
+++ b/gadget-container/gadgets/bcck8s/bcc-wrapper.sh
@@ -134,7 +134,9 @@ if [ "$MANAGER" = "true" ] ; then
   MODE="--mntnsmap"
   MAPPATH=$BPFDIR/gadget/mntnsset-$TRACERID
   CGROUP_V2_PATH=$(cat /proc/self/cgroup |grep ^0:|cut -d: -f3)
-  if [ ! -z "$CGROUP_V2_PATH" ] && [ "$CGROUP_V2_PATH" != "/" ]; then
+  UID_UNDER=`echo $GADGET_POD_UID | sed 's/-/_/g'`
+  if [[ "$CGROUP_V2_PATH" == *"$GADGET_POD_UID"* ||
+      "$CGROUP_V2_PATH" == *"$UID_UNDER"* ]]; then
     MODE="--cgroupmap"
     MAPPATH=$BPFDIR/gadget/cgroupidset-$TRACERID
   fi

--- a/pkg/gadgettracermanager/k8s/k8s.go
+++ b/pkg/gadgettracermanager/k8s/k8s.go
@@ -5,9 +5,9 @@ import (
 	"os"
 	"strings"
 
+	"github.com/kinvolk/inspektor-gadget/pkg/k8sutil"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
-	"github.com/kinvolk/inspektor-gadget/pkg/k8sutil"
 
 	pb "github.com/kinvolk/inspektor-gadget/pkg/gadgettracermanager/api"
 )
@@ -38,16 +38,16 @@ func FillContainer(containerDefinition *pb.ContainerDefinition) error {
 	labels := []*pb.Label{}
 	for _, pod := range pods.Items {
 		uid := string(pod.ObjectMeta.UID)
+		// check if this container is associated to this pod
 		uidWithUnderscores := strings.ReplaceAll(uid, "-", "_")
-		if cgroupPathV2 != "" {
-			if !strings.Contains(cgroupPathV2, uidWithUnderscores) && !strings.Contains(cgroupPathV2, uid) {
-				continue
-			}
-		} else {
-			if !strings.Contains(cgroupPathV1, uidWithUnderscores) && !strings.Contains(cgroupPathV1, uid) {
-				continue
-			}
+
+		if !strings.Contains(cgroupPathV2, uidWithUnderscores) &&
+			!strings.Contains(cgroupPathV2, uid) &&
+			!strings.Contains(cgroupPathV1, uidWithUnderscores) &&
+			!strings.Contains(cgroupPathV1, uid) {
+			continue
 		}
+
 		namespace = pod.ObjectMeta.Namespace
 		podname = pod.ObjectMeta.Name
 


### PR DESCRIPTION
This PR fixes some problems I found while experimenting with containerd on Ubuntu 20.04. 

- Kernel headers missing
- containerd runtime not considered
- Bad handling of wrong cgroupsv2 path