### PR TITLE
Integration tests: add tests for other gadgets

### DIFF
--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -82,6 +82,11 @@ jobs:
       run: |
         echo "Using IMAGE_TAG=$IMAGE_TAG"
 
+        sudo apt-get install linux-headers-$(uname -r)
+        ls -l /lib/modules/5.3.0-1020-azure/ || true
+        ls -l /lib/modules/5.3.0-1020-azure/build || true
+        dpkg -L linux-headers-$(uname -r) || true
+
         TESTS_DOCKER_ARGS="-e KUBECONFIG=/root/.kube/config -v /home/runner/.kube:/root/.kube -v /home/runner/work/_temp/.minikube:/home/runner/work/_temp/.minikube" \
             make -C integration build test
 

--- a/gadget-container/gadget-from-local-bin.Dockerfile
+++ b/gadget-container/gadget-from-local-bin.Dockerfile
@@ -1,12 +1,12 @@
 # Main gadget image
 
 # BCC built from:
-# https://github.com/kinvolk/bcc/commit/5fed2a94da19501c3088161db0c412b5623050ca
+# https://github.com/kinvolk/bcc/commit/ba3f5a
 # See:
 # - https://github.com/kinvolk/bcc/actions
 # - https://hub.docker.com/r/kinvolk/bcc/tags
 
-FROM docker.io/kinvolk/bcc:202006031708335fed2a
+FROM docker.io/kinvolk/bcc:20200608131331ba3f5a
 
 RUN set -ex; \
 	export DEBIAN_FRONTEND=noninteractive; \

--- a/gadget-container/gadget.Dockerfile
+++ b/gadget-container/gadget.Dockerfile
@@ -11,12 +11,12 @@ FROM docker.io/kinvolk/traceloop:202006050210553a5730 as traceloop
 # Main gadget image
 
 # BCC built from:
-# https://github.com/kinvolk/bcc/commit/5fed2a94da19501c3088161db0c412b5623050ca
+# https://github.com/kinvolk/bcc/commit/ba3f5a
 # See:
 # - https://github.com/kinvolk/bcc/actions
 # - https://hub.docker.com/r/kinvolk/bcc/tags
 
-FROM docker.io/kinvolk/bcc:202006031708335fed2a
+FROM docker.io/kinvolk/bcc:20200608131331ba3f5a
 
 RUN set -ex; \
 	export DEBIAN_FRONTEND=noninteractive; \

--- a/integration/gadgets_test.go
+++ b/integration/gadgets_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"flag"
 	"os"
 	"os/exec"
@@ -15,18 +16,29 @@ var integration = flag.Bool("integration", false, "run integration tests")
 // image such as docker.io/kinvolk/gadget:latest
 var image = flag.String("image", "", "gadget container image")
 
-func TestTraceloop(t *testing.T) {
+type command struct {
+	id             string
+	name           string
+	cmd            string
+	background     bool
+	expectedString string
+	expectedRegexp string
+	cleanup        bool
+}
+
+type backgroundCommand struct {
+	id     string
+	cmd    *exec.Cmd
+	stdout bytes.Buffer
+	stderr bytes.Buffer
+}
+
+func TestGadgets(t *testing.T) {
 	if !*integration {
 		t.Skip("skipping integration test.")
 	}
 
-	commands := []struct {
-		name           string
-		cmd            string
-		expectedString string
-		expectedRegexp string
-		cleanup        bool
-	}{
+	commands := []command{
 		{
 			name:           "Deploy Inspektor Gadget",
 			cmd:            "$KUBECTL_GADGET deploy $GADGET_IMAGE_FLAG | kubectl apply -f -",
@@ -39,6 +51,48 @@ func TestTraceloop(t *testing.T) {
 		{
 			name: "Wait until Inspektor Gadget is initialised",
 			cmd:  "sleep 15",
+		},
+		{
+			id:         "execsnoop",
+			name:       "Start execsnoop",
+			cmd:        "$KUBECTL_GADGET execsnoop --namespace test-snoop",
+			background: true,
+		},
+		{
+			id:         "tcptracer",
+			name:       "Start tcptracer",
+			cmd:        "$KUBECTL_GADGET tcptracer --namespace test-snoop",
+			background: true,
+		},
+		{
+			name: "Wait until gadgets are ready",
+			cmd:  "sleep 10",
+		},
+		{
+			name:           "Create test namespace",
+			cmd:            "kubectl create ns test-snoop",
+			expectedString: "namespace/test-snoop created\n",
+		},
+		{
+			name: "Run test pod",
+			cmd:  "kubectl run -i --restart=Never -n test-snoop --image=busybox snooptest -- sh -c 'sleep 2 ; cat /non-existent ; nc -w 1 -l -p 8080 & (echo ok | nc -w 1 127.0.0.1 8080) ; sleep 10 ; exit 0'",
+		},
+		{
+			id:   "execsnoop",
+			name: "Stop execsnoop",
+			expectedRegexp: "(?s)NODE PCOMM            PID    PPID   RET ARGS\n" +
+				".*/bin/cat /non-existent\n",
+		},
+		{
+			id:             "tcptracer",
+			name:           "Stop tcptracer",
+			expectedRegexp: "C .*nc .*4 .*127.0.0.1 .*127.0.0.1 .*8080",
+		},
+		{
+			name:           "Cleanup test namespace",
+			cmd:            "kubectl delete ns test-snoop",
+			expectedString: "namespace \"test-snoop\" deleted\n",
+			cleanup:        true,
 		},
 		{
 			name:           "Create test namespace",
@@ -91,6 +145,8 @@ func TestTraceloop(t *testing.T) {
 		os.Setenv("GADGET_IMAGE_FLAG", "--image "+*image)
 	}
 
+	backgroundCommands := map[string]*backgroundCommand{}
+
 	failed := false
 	for _, tt := range commands {
 		t.Run(tt.name, func(t *testing.T) {
@@ -98,14 +154,38 @@ func TestTraceloop(t *testing.T) {
 				t.Skip("Previous command failed.")
 			}
 
-			t.Logf("Command: %s\n", tt.cmd)
-			cmd := exec.Command("/bin/sh", "-c", tt.cmd)
-			output, err := cmd.CombinedOutput()
-			actual := string(output)
-			t.Logf("Command returned:\n%s\n", actual)
-			if err != nil {
-				failed = true
-				t.Fatal(err)
+			t.Logf("Command %s: %s\n", tt.id, tt.cmd)
+			var cmd *exec.Cmd
+			var actual string
+			if tt.cmd != "" {
+				cmd = exec.Command("/bin/sh", "-c", tt.cmd)
+			} else {
+				bg, ok := backgroundCommands[tt.id]
+				if !ok {
+					failed = true
+					t.Fatalf("cannot find command: %s\n", tt.id)
+				}
+				cmd = bg.cmd
+				actual = bg.stderr.String() + bg.stdout.String()
+				t.Logf("Background command returned:\n%s\n", actual)
+			}
+			if tt.background {
+				bg := backgroundCommand{
+					cmd: cmd,
+				}
+				backgroundCommands[tt.id] = &bg
+				cmd.Stdout = &bg.stdout
+				cmd.Stderr = &bg.stderr
+				t.Logf("Start command\n")
+				cmd.Start()
+			} else if tt.cmd != "" {
+				output, err := cmd.CombinedOutput()
+				if err != nil {
+					failed = true
+					t.Fatal(err)
+				}
+				actual = string(output)
+				t.Logf("Command returned:\n%s\n", actual)
 			}
 
 			if tt.expectedRegexp != "" {
@@ -120,5 +200,18 @@ func TestTraceloop(t *testing.T) {
 				t.Fatalf("diff: %v", pretty.Diff(tt.expectedString, actual))
 			}
 		})
+	}
+	for id, bg := range backgroundCommands {
+		err := bg.cmd.Process.Kill()
+		if err != nil {
+			t.Fatalf("cannot kill %s: %s", id, err)
+		}
+		err = bg.cmd.Wait()
+		if err != nil {
+			_, ok := err.(*exec.ExitError)
+			if !ok {
+				t.Fatalf("cannot terminate %s: %s", id, err)
+			}
+		}
 	}
 }

--- a/integration/gadgets_test.go
+++ b/integration/gadgets_test.go
@@ -81,7 +81,7 @@ func TestGadgets(t *testing.T) {
 		},
 		{
 			name: "Run test pod",
-			cmd:  "kubectl run -i --restart=Never -n test-snoop --image=busybox snooptest -- sh -c 'sleep 2 ; cat /non-existent ; nc -w 1 -l -p 8080 & (echo ok | nc -w 1 127.0.0.1 8080) ; sleep 10 ; exit 0'",
+			cmd:  "kubectl run -i --restart=Never -n test-snoop --image=busybox snooptest -- sh -c 'sleep 10 ; cat /non-existent ; nc -w 1 -l -p 8080 & (echo ok | nc -w 1 127.0.0.1 8080) ; sleep 10 ; exit 0'",
 		},
 		{
 			id:   "execsnoop",

--- a/integration/gadgets_test.go
+++ b/integration/gadgets_test.go
@@ -59,6 +59,12 @@ func TestGadgets(t *testing.T) {
 			background: true,
 		},
 		{
+			id:         "opensnoop",
+			name:       "Start opensnoop",
+			cmd:        "$KUBECTL_GADGET opensnoop --namespace test-snoop",
+			background: true,
+		},
+		{
 			id:         "tcptracer",
 			name:       "Start tcptracer",
 			cmd:        "$KUBECTL_GADGET tcptracer --namespace test-snoop",
@@ -82,6 +88,12 @@ func TestGadgets(t *testing.T) {
 			name: "Stop execsnoop",
 			expectedRegexp: "(?s)NODE PCOMM            PID    PPID   RET ARGS\n" +
 				".*/bin/cat /non-existent\n",
+		},
+		{
+			id:   "opensnoop",
+			name: "Stop opensnoop",
+			expectedRegexp: "(?s)NODE.*PID.*COMM.*FD.*ERR.*PATH\n" +
+				".*cat.*/non-existent\n",
 		},
 		{
 			id:             "tcptracer",


### PR DESCRIPTION
Depends on:
- [x] #107 - Fix non-random tracer id
- [x] #110 - Add access to /usr/src without direct bind-mount
- [x] #113 - pod informer to get pod information without OCI hooks