### PR TITLE
Add access to /usr/src without direct bind-mount

### DIFF
--- a/gadget-container/entrypoint.sh
+++ b/gadget-container/entrypoint.sh
@@ -68,6 +68,7 @@ if grep -q '^ID="rhcos"$' /host/etc/os-release > /dev/null ; then
         curl -fsSLo $RPMHOSTDIR/$RPM $REPO/$RPM
     test -r $RPMHOSTDIR/usr/src/kernels/`uname -r`/.config || \
         chroot /host sh -c "cd $RPMDIR && rpm2cpio $RPM | cpio -i"
+    test ! -L /usr/src || /bin/rm -f /usr/src
     mkdir -p /usr/src/kernels/`uname -r`/
     mount --bind $RPMHOSTDIR/usr/src/kernels/`uname -r` /usr/src/kernels/`uname -r`
   fi

--- a/gadget-container/gadget-from-local-bin.Dockerfile
+++ b/gadget-container/gadget-from-local-bin.Dockerfile
@@ -12,7 +12,8 @@ RUN set -ex; \
 	export DEBIAN_FRONTEND=noninteractive; \
 	apt-get update && \
 	apt-get install -y --no-install-recommends \
-		ca-certificates curl
+		ca-certificates curl && \
+        rmdir /usr/src && ln -sf /host/usr/src /usr/src
 
 COPY entrypoint.sh /entrypoint.sh
 COPY cleanup.sh /cleanup.sh

--- a/gadget-container/gadget.Dockerfile
+++ b/gadget-container/gadget.Dockerfile
@@ -22,7 +22,8 @@ RUN set -ex; \
 	export DEBIAN_FRONTEND=noninteractive; \
 	apt-get update && \
 	apt-get install -y --no-install-recommends \
-		ca-certificates curl
+		ca-certificates curl && \
+        rmdir /usr/src && ln -sf /host/usr/src /usr/src
 
 COPY entrypoint.sh /entrypoint.sh
 COPY cleanup.sh /cleanup.sh


### PR DESCRIPTION
Ubuntu has /usr/src with the kernel headers but on Flatcar Container Linux, this directory does not exist and the kernel headers are located in /lib/modules/$(uname -r) directly.

Attempting to mount /usr/src from the host would cause Docker to attempt to create that directory but this does not work when the host /usr is read-only.

This patch adds access to /usr/src with a symbolic link, so it works both for Linux distributions with and without /usr/src.

----

Symptoms from a GitHub action (https://github.com/kinvolk/inspektor-gadget/pull/109#issuecomment-640650397):
```
[E0] xz: (stdin): Read error: No such device
[E0] tar: Unexpected EOF in archive
[E0] tar: Unexpected EOF in archive
[E0] tar: Error is not recoverable: exiting now
[E0] rmmod: ERROR: Module kheaders is not currently loaded
[E0] chdir(/lib/modules/5.3.0-1020-azure/build): No such file or directory
[E0] Traceback (most recent call last):
[E0]   File "/usr/share/bcc/tools/execsnoop", line 227, in <module>
[E0]     b = BPF(text=bpf_text)
[E0]   File "/usr/lib/python2.7/dist-packages/bcc/__init__.py", line 357, in __init__
[E0]     raise Exception("Failed to compile BPF module %s" % (src_file or "<text>"))
[E0] Exception: Failed to compile BPF module <text>
Node numbers: 0 = fv-az12
NODE Unable to find kernel headers. Try rebuilding kernel with CONFIG_IKHEADERS=m (module)
```

----
Related issue in kubectl-trace: https://github.com/iovisor/kubectl-trace/pull/103