### PR TITLE
Automate krew plugin version update

### DIFF
--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -123,7 +123,7 @@ jobs:
       with:
         tag_name: ${{ github.ref }}
         release_name: Release ${{ github.ref }}
-        draft: true
+        draft: false
         prerelease: false
 
     - name: Upload linux-amd64 Release Asset
@@ -181,3 +181,7 @@ jobs:
         IMAGE_TAG: ${{ steps.publish-registry.outputs.snapshot-tag }}
       run: |
         make -C integration push
+
+    - name: Update new version in krew-index
+      if: startsWith(github.ref, 'refs/tags/v')
+      uses: rajatjindal/krew-release-bot@v0.0.38

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 *.dylib
 /kubectl-gadget-darwin-amd64
 /kubectl-gadget-linux-amd64
+/kubectl-gadget-windows-amd64
 /gadget-container/bin
 
 # Test binary, build with `go test -c`

--- a/.krew.yaml
+++ b/.krew.yaml
@@ -1,0 +1,46 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: gadget
+spec:
+  version: {{ .TagName }}
+  homepage: https://github.com/kinvolk/inspektor-gadget
+  shortDescription: Gadgets for debugging and introspecting apps
+  description: |
+    Inspektor Gadget is a collection of tools (or gadgets) for developers of
+    Kubernetes applications.
+
+    Inspektor Gadget is deployed to each node as a privileged DaemonSet.
+    It uses in-kernel BPF helper programs to monitor events mainly related to
+    syscalls from userspace programs in a pod. The BPF programs are run by
+    the kernel and gather the log data. Inspektor Gadget's userspace utilities
+    fetch the log data from ring buffers and display it. What BPF programs are
+    and how Inspektor Gadget uses them is briefly explained in the architecture
+    document:
+    https://github.com/kinvolk/inspektor-gadget/blob/master/Documentation/architecture.md
+  caveats: |
+    Inspektor Gadget needs to be deployed to each node:
+
+    $ kubectl gadget deploy | kubectl apply -f -
+
+    Read the documentation available at https://github.com/kinvolk/inspektor-gadget
+    to get more information about the server side installation process.
+  platforms:
+  - selector:
+      matchLabels:
+        os: linux
+        arch: amd64
+    {{addURIAndSha "https://github.com/kinvolk/inspektor-gadget/releases/download/{{ .TagName }}/inspektor-gadget-linux-amd64.tar.gz" .TagName }}
+    bin: kubectl-gadget
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: amd64
+    {{addURIAndSha "https://github.com/kinvolk/inspektor-gadget/releases/download/{{ .TagName }}/inspektor-gadget-darwin-amd64.tar.gz" .TagName }}
+    bin: kubectl-gadget
+  - selector:
+      matchLabels:
+        os: windows
+        arch: amd64
+    {{addURIAndSha "https://github.com/kinvolk/inspektor-gadget/releases/download/{{ .TagName }}/inspektor-gadget-windows-amd64.tar.gz" .TagName }}
+    bin: kubectl-gadget


### PR DESCRIPTION
Use the [krew-release-bot](https://github.com/rajatjindal/krew-release-bot) to automate the plugin update process. 

The main difference is that the releases created are not draft anymore, so pushing a tag to the repo will create a release and update it on the krew-index automatically.