### PR TITLE
Fix short descs for opensnoop and tcpconnect

### DIFF
--- a/cmd/kubectl-gadget/bcck8s.go
+++ b/cmd/kubectl-gadget/bcck8s.go
@@ -29,7 +29,7 @@ var execsnoopCmd = &cobra.Command{
 
 var opensnoopCmd = &cobra.Command{
 	Use:   "opensnoop",
-	Short: "Trace files",
+	Short: "Trace open() system calls",
 	Run:   bccCmd("opensnoop", "/usr/share/bcc/tools/opensnoop"),
 }
 
@@ -53,7 +53,7 @@ var tcptopCmd = &cobra.Command{
 
 var tcpconnectCmd = &cobra.Command{
 	Use:   "tcpconnect",
-	Short: "Suggest Kubernetes Network Policies",
+	Short: "Trace TCP connect() system calls",
 	Run:   bccCmd("tcpconnect", "/usr/share/bcc/tools/tcpconnect"),
 }
 


### PR DESCRIPTION
The current description for tcpconnect seems wrong: "Suggest Kubernetes Network Policies", that's not what the bcc tcpconnect tool does.

The one for opensnoop looks weird compared to the others: "Trace files" vs "Trace IPv4 and IPv6 bind() system calls".

This change fixes tcpconnect to match the description from the bcc tools and the opensnoop one to be more similar to the bindsnoop one.