### PR TITLE
ocihookgadget: Remove unused node parameter

### DIFF
--- a/gadget-container/entrypoint.sh
+++ b/gadget-container/entrypoint.sh
@@ -114,8 +114,6 @@ if [ "$RUNC_HOOK_MODE" = "flatcar_edge" ] ||
     cp /bin/$i /host/opt/bin/
   done
 
-  sed -i "s@%NODE%@-node $NODE_NAME@g" /host/opt/bin/runc-hook-{prestart,poststop}.sh
-
   if [ "$RUNC_HOOK_MODE" = "crio" ] ; then
     echo "Installing OCI hooks configuration in /etc/containers/oci/hooks.d/"
     mkdir -p /host/etc/containers/oci/hooks.d/

--- a/gadget-container/ocihookgadget/main.go
+++ b/gadget-container/ocihookgadget/main.go
@@ -26,13 +26,11 @@ import (
 var (
 	socketfile string
 	hook       string
-	node       string
 )
 
 func init() {
 	flag.StringVar(&socketfile, "socketfile", "/run/gadgettracermanager.socket", "Socket file")
 	flag.StringVar(&hook, "hook", "", "OCI hook: prestart or poststop")
-	flag.StringVar(&node, "node", "", "node name as known in Kubernetes")
 }
 
 func main() {

--- a/gadget-container/ocihookgadget/runc-hook-poststop.sh
+++ b/gadget-container/ocihookgadget/runc-hook-poststop.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 read JSON
 pidof gadgettracermanager > /dev/null || exit 0
-echo $JSON | /opt/bin/ocihookgadget %NODE% -hook poststop >> /var/log/gadget.log 2>&1
+echo $JSON | /opt/bin/ocihookgadget -hook poststop >> /var/log/gadget.log 2>&1
 exit 0

--- a/gadget-container/ocihookgadget/runc-hook-prestart.sh
+++ b/gadget-container/ocihookgadget/runc-hook-prestart.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 read JSON
 pidof gadgettracermanager > /dev/null || exit 0
-echo $JSON | /opt/bin/ocihookgadget %NODE% -hook prestart >> /var/log/gadget.log 2>&1
+echo $JSON | /opt/bin/ocihookgadget -hook prestart >> /var/log/gadget.log 2>&1
 exit 0


### PR DESCRIPTION
The parameter is not needed anymore after 068c46f90270eaf0f4aec3ba867754479abbeb1d.