### PR TITLE
kubectl-gadget: look for gadget pods in all namespaces

### DIFF
--- a/cmd/kubectl-gadget/traceloop.go
+++ b/cmd/kubectl-gadget/traceloop.go
@@ -103,7 +103,7 @@ func getTracesListPerNode(client *kubernetes.Clientset) (out map[string][]tracem
 		LabelSelector: "k8s-app=gadget",
 		FieldSelector: fields.Everything().String(),
 	}
-	pods, err := client.CoreV1().Pods("kube-system").List(listOptions)
+	pods, err := client.CoreV1().Pods("").List(listOptions)
 	if err != nil {
 		return nil, fmt.Errorf("Cannot find gadget pods: %q", err)
 	}

--- a/cmd/kubectl-gadget/utils.go
+++ b/cmd/kubectl-gadget/utils.go
@@ -39,7 +39,7 @@ func execPod(client *kubernetes.Clientset, node string, podCmd string, cmdStdout
 		LabelSelector: "k8s-app=gadget",
 		FieldSelector: "spec.nodeName=" + node + ",status.phase=Running",
 	}
-	pods, err := client.CoreV1().Pods("kube-system").List(listOptions)
+	pods, err := client.CoreV1().Pods("").List(listOptions)
 	if err != nil {
 		return err
 	}
@@ -50,6 +50,8 @@ func execPod(client *kubernetes.Clientset, node string, podCmd string, cmdStdout
 		return errors.New("Multiple Gadget Daemons found")
 	}
 	podName := pods.Items[0].Name
+
+	namespace := pods.Items[0].Namespace
 
 	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
 	loadingRules.DefaultClientConfig = &clientcmd.DefaultClientConfig
@@ -71,7 +73,7 @@ func execPod(client *kubernetes.Clientset, node string, podCmd string, cmdStdout
 	req := restClient.Post().
 		Resource("pods").
 		Name(podName).
-		Namespace("kube-system").
+		Namespace(namespace).
 		SubResource("exec").
 		Param("container", "gadget").
 		VersionedParams(&corev1.PodExecOptions{


### PR DESCRIPTION
This allows users to install the gadget DaemonSet in the namespace they
choose.

Fixes #139