### PR TITLE
Fix string conversion error

### DIFF
--- a/pkg/gadgets/networkpolicy/networkpolicy.go
+++ b/pkg/gadgets/networkpolicy/networkpolicy.go
@@ -140,7 +140,7 @@ func (a *NetworkPolicyAdvisor) networkPeerKey(e types.KubernetesConnectionEvent)
 	} else if e.RemoteKind == "other" {
 		ret = e.RemoteKind + ":" + e.RemoteOther
 	}
-	return ret + ":" + string(e.Port)
+	return fmt.Sprintf("%s:%d", ret, e.Port)
 }
 
 func (a *NetworkPolicyAdvisor) eventToRule(e types.KubernetesConnectionEvent) (ports []networkingv1.NetworkPolicyPort, peers []networkingv1.NetworkPolicyPeer) {


### PR DESCRIPTION
Symptoms:
```
pkg/gadgets/networkpolicy/networkpolicy.go:143:21: conversion from uint16 to string yields a string of one rune, not a string of digits (did you mean fmt.Sprint(x)?)
```

See:
https://github.com/golang/go/issues/32479

Signed-off-by: Alban Crequy <alban@kinvolk.io>
