### PR TITLE
gadget tracer manager: fix logic to get existing containers

### DIFF
--- a/pkg/gadgettracermanager/gadgettracermanager.go
+++ b/pkg/gadgettracermanager/gadgettracermanager.go
@@ -335,11 +335,11 @@ func NewServer(nodeName string) *GadgetTracerManager {
 	containers, err := k8sClient.ListContainers()
 	if err != nil {
 		log.Printf("gadgettracermanager failed to list containers: %v", err)
+	} else {
+		log.Printf("gadgettracermanager found %d containers: %+v", len(containers), containers)
 		for _, container := range containers {
 			g.containers[container.ContainerId] = container
 		}
-	} else {
-		log.Printf("gadgettracermanager found %d containers: %+v", len(containers), containers)
 	}
 	return g
 }


### PR DESCRIPTION
Somehow I managed to break this in a previous commit some months ago.
It was probably not detected before because it doesn't affect the
pod informer mechanism that uses the K8s api server to get the list
of pods.

# Testing done

Deploy Inspektor Gadget using `--runc-hooks-mode` different to `auto` or `podinformer` in a cluster with some existing pods and check that those are correctly added to the list of containers in the gadget tracer manager by executing `gadgettracermanager -dump` in the gadget pod. 


