### PR TITLE
GHA: Update actions-setup-minikube to 2.4.2

### DIFF
--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -64,7 +64,7 @@ jobs:
         make test
 
     - name: Setup Minikube
-      uses: manusa/actions-setup-minikube@v2.0.1
+      uses: manusa/actions-setup-minikube@v2.4.2
       with:
         minikube version: 'v1.9.2'
         kubernetes version: 'v1.18.2'


### PR DESCRIPTION
Previous version doesn't work with Ubuntu 20.04.2 that is now being
used.

It has been failing since a while but we haven't noticed it -> https://github.com/kinvolk/inspektor-gadget/actions?query=branch%3Amaster+
