### PR TITLE
gadget-dockerfiles: Change bcc-wrapper.sh installation directory

### DIFF
--- a/gadget-local.Dockerfile
+++ b/gadget-local.Dockerfile
@@ -20,7 +20,7 @@ COPY gadget-container/entrypoint.sh gadget-container/cleanup.sh /
 COPY gadget-container/bin/gadgettracermanager /bin/
 COPY gadget-container/bin/networkpolicyadvisor /bin/
 
-COPY gadget-container/gadgets/bcck8s /opt/
+COPY gadget-container/gadgets/bcck8s /opt/bcck8s/
 
 COPY gadget-container/bin/traceloop /bin/
 

--- a/gadget.Dockerfile
+++ b/gadget.Dockerfile
@@ -43,7 +43,7 @@ COPY gadget-container/entrypoint.sh gadget-container/cleanup.sh /
 COPY --from=builder /gadget/gadget-container/bin/gadgettracermanager /bin/
 COPY --from=builder /gadget/gadget-container/bin/networkpolicyadvisor /bin/
 
-COPY gadget-container/gadgets/bcck8s /opt/
+COPY gadget-container/gadgets/bcck8s /opt/bcck8s/
 
 COPY --from=traceloop /bin/traceloop /bin/
 


### PR DESCRIPTION
# Change bcc-wrapper.sh installation directory

This PR changes the directory where `bcc-wrapper.sh` is installed because gadgets are looking for it in `/opt/bcck8s/` while it is being installed in `/opt/`. For instance, networkpolicyadvisor and bcck8s in the following two lines (there are others):
https://github.com/kinvolk/inspektor-gadget/blob/0c92eed86b8f30c7533c4899d7203546de7aff41/cmd/kubectl-gadget/bcck8s.go#L332
https://github.com/kinvolk/inspektor-gadget/blob/0c92eed86b8f30c7533c4899d7203546de7aff41/cmd/kubectl-gadget/networkpolicyadvisor.go#L149

This issue prevents users to properly gadgets with the following error:
```
# kubectl-gadget execsnoop
Node numbers: 0 = blanquicet
[E0] /bin/sh: 1: exec: /opt/bcck8s/bcc-wrapper.sh: not found
```