### PR TITLE
doc: Small fixup on traceloop guide

### DIFF
--- a/docs/guides/traceloop.md
+++ b/docs/guides/traceloop.md
@@ -49,7 +49,7 @@ result was saved in `/tmp/file-1889` but we attempted to open
 
 We can close this trace now.
 ```
-$ kubectl gadget traceloop show 10.0.30.247_default_mypod
+$ kubectl gadget traceloop close 10.0.30.247_default_mypod
 closed
 ```
 


### PR DESCRIPTION
# Small fixup on traceloop guide

The idea of this step is to close the trace and not show it again.