### PR TITLE
Update go.mod with newer pretty version required by ebpf

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/gorilla/mux v1.7.4 // indirect
 	github.com/iovisor/gobpf v0.0.0-20191129151106-ac26197bb7be // indirect
 	github.com/kinvolk/traceloop v0.0.0-20210623155108-6f4efc6fca46
-	github.com/kr/pretty v0.2.0
+	github.com/kr/pretty v0.2.1
 	github.com/moby/term v0.0.0-20200507201656-73f35e472e8f // indirect
 	github.com/morikuni/aec v1.0.0 // indirect
 	github.com/opencontainers/runtime-spec v1.0.3-0.20200929063507-e6143ca7d51d


### PR DESCRIPTION
This PR updates pretty module to version 0.2.1 because it is required by ebpf version 0.4.0 which was introduced in 320f8f01
(Implement support for Node Resource Interface).

Current compilation error:
```
$ make gadget-container-local
...
mkdir -p bin
GO111MODULE=on CGO_ENABLED=1 GOOS=linux go build \
	-o bin/ocihookgadget \
	./hooks/oci/main.go
go: github.com/kr/pretty@v0.2.1: missing go.sum entry; to add it:
	go mod download github.com/kr/pretty
make[1]: *** [Makefile:29: ocihookgadget] Error 1
```

After debugging, it was possible to find that ebpf v0.4.0 is asking for pretty v0.2.1:

```
$ make gadget-container-local
...
mkdir -p bin
GO111MODULE=on CGO_ENABLED=1 GOOS=linux go build \
	-o bin/ocihookgadget \
	./hooks/oci/main.go
go: github.com/cilium/ebpf@v0.4.0 requires
	github.com/frankban/quicktest@v1.11.3 requires
	github.com/kr/pretty@v0.2.1: missing go.sum entry; to add it:
	go mod download github.com/kr/pretty
```