### PR TITLE
gadget-container: Add liveness probe

### DIFF
--- a/cmd/kubectl-gadget/deploy.go
+++ b/cmd/kubectl-gadget/deploy.go
@@ -115,6 +115,13 @@ spec:
             exec:
               command:
                 - "/cleanup.sh"
+        livenessProbe:
+          initialDelaySeconds: 10
+          periodSeconds: 5
+          exec:
+            command:
+              - /bin/gadgettracermanager
+              - -liveness
         env:
           - name: NODE_NAME
             valueFrom:

--- a/gadget-container/gadgettracermanager/main.go
+++ b/gadget-container/gadgettracermanager/main.go
@@ -25,6 +25,8 @@ import (
 	"time"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/health"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 
 	"github.com/kinvolk/inspektor-gadget/pkg/gadgettracermanager"
 	pb "github.com/kinvolk/inspektor-gadget/pkg/gadgettracermanager/api"
@@ -198,6 +200,10 @@ func main() {
 		}
 
 		pb.RegisterGadgetTracerManagerServer(grpcServer, tracerManager)
+
+		healthserver := health.NewServer()
+		healthpb.RegisterHealthServer(grpcServer, healthserver)
+
 		grpcServer.Serve(lis)
 	}
 }

--- a/gadget-container/gadgettracermanager/main.go
+++ b/gadget-container/gadgettracermanager/main.go
@@ -25,8 +25,10 @@ import (
 	"time"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/health"
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/status"
 
 	"github.com/kinvolk/inspektor-gadget/pkg/gadgettracermanager"
 	pb "github.com/kinvolk/inspektor-gadget/pkg/gadgettracermanager/api"
@@ -35,6 +37,7 @@ import (
 var (
 	serve         bool
 	dump          bool
+	liveness      bool
 	podInformer   bool
 	socketfile    string
 	method        string
@@ -46,6 +49,10 @@ var (
 	namespace     string
 	podname       string
 	containername string
+)
+
+const (
+	clientTimeout = 2 * time.Second
 )
 
 func init() {
@@ -65,6 +72,7 @@ func init() {
 	flag.StringVar(&containername, "containername", "", "container name to use in add-container")
 
 	flag.BoolVar(&dump, "dump", false, "Dump state for debugging")
+	flag.BoolVar(&liveness, "liveness", false, "Execute as client and perform liveness probe")
 }
 
 func main() {
@@ -93,15 +101,17 @@ func main() {
 	var client pb.GadgetTracerManagerClient
 	var ctx context.Context
 	var cancel context.CancelFunc
-	if dump || method != "" {
-		conn, err := grpc.Dial("unix://"+socketfile, grpc.WithInsecure())
+	var conn *grpc.ClientConn
+	if liveness || dump || method != "" {
+		var err error
+		conn, err = grpc.Dial("unix://"+socketfile, grpc.WithInsecure())
 		if err != nil {
 			log.Fatalf("fail to dial: %v", err)
 		}
 		defer conn.Close()
 		client = pb.NewGadgetTracerManagerClient(conn)
 
-		ctx, cancel = context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel = context.WithTimeout(context.Background(), clientTimeout)
 		defer cancel()
 	}
 
@@ -170,6 +180,29 @@ func main() {
 			log.Fatalf("%v", err)
 		}
 		fmt.Println(out.State)
+		os.Exit(0)
+	}
+
+	if liveness {
+		resp, err := healthpb.NewHealthClient(conn).Check(ctx, &healthpb.HealthCheckRequest{Service: ""})
+		if err != nil {
+			stat := status.Convert(err)
+
+			if stat.Code() == codes.DeadlineExceeded {
+				fmt.Printf("Gadget Tracer Manager health RPC reached the timeout: %v", clientTimeout)
+			} else {
+				fmt.Printf("Gadget Tracer Manager health RPC failed: '%s'", stat.Message())
+			}
+
+			os.Exit(1)
+		}
+
+		if resp.GetStatus() != healthpb.HealthCheckResponse_SERVING {
+			fmt.Printf("Gadget Tracer Manager unhealthy: %s", resp.GetStatus().String())
+			os.Exit(1)
+		}
+
+		fmt.Printf("Gadget Tracer Manager healthy: %s", resp.GetStatus().String())
 		os.Exit(0)
 	}
 


### PR DESCRIPTION
# Add liveness probe

This PR implements liveness probe for the GadgetTracerManager using the [grpc_health_v1 package](https://pkg.go.dev/google.golang.org/grpc/health/grpc_health_v1).

Given that Kubernetes does not support gRPC probes, a gRPC client is called by command to check if the container is alive and healthy. The client was actually developed inside the GadgetTracerManager itself and can be launched by using parameter `-liveness`. It will return 0 if status [SERVING](https://pkg.go.dev/google.golang.org/grpc@v1.33.2/health/grpc_health_v1#HealthCheckResponse_SERVING) is received from server and 1 otherwise. Notice that server and client use the service created by default with empty string name ("") and status [SERVING](https://pkg.go.dev/google.golang.org/grpc@v1.33.2/health/grpc_health_v1#HealthCheckResponse_SERVING).

Only the timeout error is handled independently just to include the timeout information on the log that will be passed to kubelet and visible in the failure event message. All the other errors are handled in the same way.

Liveness probe was configured with the following parameters:

- initialDelaySeconds: 10
- periodSeconds: 5
- timeoutSeconds: 1 (Default value)
- failureThreshold: 3 (Default value)
- successThreshold: 1 (Default value)

## Testing done
The simplest way to test this feature is to manually kill the GadgetTracerManager server and check on the pod events how the liveness probe fails 3 time before container is restarted:

`$ kubectl exec -it <pod-name> -n kube-system -- /bin/bash -c 'kill $(pidof gadgettracermanager)'`

```
$ kubectl get events --watch -n kube-system --field-selector involvedObject.name==<pod-name> -o custom-columns=TIME:.lastTimestamp,REASON:.reason,MSG:.message
TIME                   REASON      MSG
<nil>                  Scheduled   Successfully assigned kube-system/gadget-5zqcw to blanquicet
2021-07-01T10:44:35Z   Pulling     Pulling image "docker.io/blanquicet/gadget:issue-liveness"
2021-07-01T10:25:07Z   Pulled      Successfully pulled image "docker.io/blanquicet/gadget:issue-liveness" in 3.241719551s
2021-07-01T10:45:00Z   Created     Created container gadget
2021-07-01T10:25:09Z   Started     Started container gadget
2021-07-01T10:53:05Z   Unhealthy   Liveness probe failed: Gadget Tracer Manager health RPC failed: 'connection error: desc = "transport: Error while dialing dial unix /run/gadgettracermanager.socket: connect: connection refused"'
2021-07-01T10:53:10Z   Unhealthy   Liveness probe failed: Gadget Tracer Manager health RPC failed: 'connection error: desc = "transport: Error while dialing dial unix /run/gadgettracermanager.socket: connect: connection refused"'
2021-07-01T10:53:15Z   Unhealthy   Liveness probe failed: Gadget Tracer Manager health RPC failed: 'connection error: desc = "transport: Error while dialing dial unix /run/gadgettracermanager.socket: connect: connection refused"'
2021-07-01T10:53:15Z   Killing     Container gadget failed liveness probe, will be restarted
2021-07-01T10:53:17Z   Pulling     Pulling image "docker.io/blanquicet/gadget:issue-liveness"
2021-07-01T10:53:20Z   Pulled      Successfully pulled image "docker.io/blanquicet/gadget:issue-liveness" in 3.307725671s
2021-07-01T10:53:22Z   Created     Created container gadget
2021-07-01T10:53:22Z   Started     Started container gadget
```

Moreover, considering that the gRPC client timeout is configured to be 2s:
https://github.com/kinvolk/inspektor-gadget/blob/e00f136dd61b88c57737741c15bda87c9aeda273/gadget-container/gadgettracermanager/main.go#L102

If for any reason the GadgetTracerManager server is too busy and does not response withing that time, the following event will be displayed:
```
$ kubectl get events --watch -n kube-system --field-selector involvedObject.name==<pod-name> -o custom-columns=TIME:.lastTimestamp,REASON:.reason,MSG:.message
TIME                   REASON      MSG
<nil>                  Scheduled   Successfully assigned kube-system/gadget-cbtdh to blanquicet
2021-07-01T11:16:24Z   Pulling     Pulling image "docker.io/blanquicet/gadget:issue-liveness"
2021-07-01T11:16:27Z   Pulled      Successfully pulled image "docker.io/blanquicet/gadget:issue-liveness" in 3.151307923s
2021-07-01T11:16:29Z   Created     Created container gadget
2021-07-01T11:16:29Z   Started     Started container gadget
2021-07-01T11:20:01Z   Unhealthy   Liveness probe failed: Gadget Tracer Manager health RPC reached the timeout: 2s
```

However, if for any reason the entired node has a very high workload, it could happen that the liveness probe does not even arrive to the container making kubelet go in timeout. In this case, the event will not contain any error detail:
```
$ kubectl get events --watch -n kube-system --field-selector involvedObject.name==<pod-name> -o custom-columns=TIME:.lastTimestamp,REASON:.reason,MSG:.message
TIME                   REASON      MSG
<nil>                  Scheduled   Successfully assigned kube-system/gadget-nzg7r to blanquicet
2021-07-01T13:53:17Z   Pulling     Pulling image "docker.io/blanquicet/gadget:issue-liveness"
2021-07-01T13:53:20Z   Pulled      Successfully pulled image "docker.io/blanquicet/gadget:issue-liveness" in 3.244215468s
2021-07-01T13:53:22Z   Created     Created container gadget
2021-07-01T13:53:23Z   Started     Started container gadget
2021-07-01T13:58:33Z   Unhealthy   Liveness probe failed: 
2021-07-01T13:58:49Z   Unhealthy   Liveness probe failed: 
2021-07-01T13:58:59Z   Unhealthy   Liveness probe failed: 
2021-07-01T13:58:59Z   Killing     Container gadget failed liveness probe, will be restarted
2021-07-01T13:59:09Z   Pulling     Pulling image "docker.io/blanquicet/gadget:issue-liveness"
2021-07-01T13:59:15Z   Pulled      Successfully pulled image "docker.io/blanquicet/gadget:issue-liveness" in 5.710371319s
2021-07-01T13:59:17Z   Created     Created container gadget
2021-07-01T13:59:18Z   Started     Started container gadget
```

For instance, by running execnoop on the container with the timestamp, it will be possible to see that liveness probe client is being executed periodically but one call should miss at the time of the failure event.

To make up for it, from the kubelet logs in the node (If available), it will be possible to see the timeout (https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/cri/remote/remote_runtime.go#L394) (DeadlineExceeded) which is configurable through the livenessProbe parameter [timeoutSeconds](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes).
```
$ journalctl -xeu kubelet  | grep -i <container-id>
Jul 01 15:58:37 blanquicet kubelet[1215]: E0701 15:58:33.570755    1215 remote_runtime.go:394] "ExecSync cmd from runtime service failed" err="rpc error: code = DeadlineExceeded desc = context deadline exceeded" containerID="95781a54feaea6fed0245ca2928b42ade8acfcd7d1b2473edde9c4491e3216f4" cmd=[/bin/gadgettracermanager -liveness]
Jul 01 15:58:49 blanquicet kubelet[1215]: E0701 15:58:49.920023    1215 remote_runtime.go:394] "ExecSync cmd from runtime service failed" err="rpc error: code = DeadlineExceeded desc = context deadline exceeded" containerID="95781a54feaea6fed0245ca2928b42ade8acfcd7d1b2473edde9c4491e3216f4" cmd=[/bin/gadgettracermanager -liveness]
Jul 01 15:58:59 blanquicet kubelet[1215]: E0701 15:58:59.923276    1215 remote_runtime.go:394] "ExecSync cmd from runtime service failed" err="rpc error: code = DeadlineExceeded desc = context deadline exceeded" containerID="95781a54feaea6fed0245ca2928b42ade8acfcd7d1b2473edde9c4491e3216f4" cmd=[/bin/gadgettracermanager -liveness]
Jul 01 15:59:23 blanquicet kubelet[1215]: I0701 15:59:23.488980    1215 scope.go:111] "RemoveContainer" containerID="95781a54feaea6fed0245ca2928b42ade8acfcd7d1b2473edde9c4491e3216f4"
```

## Notes

During testing, sometimes gadget container fails to start with the following error:
```
error while loading "tracepoint/raw_syscalls/sys_exit" (resource temporarily unavailable):
processed 1 insns (limit 1000000) max_states_per_insn 0 total_states 0 peak_states 0 mark_read 0
```
Further details in issue #186.