### PR TITLE
Dockerfile: faster builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+*
+!go.mod
+!go.sum
+!cmd
+!gadget-container
+!pkg

--- a/gadget.Dockerfile
+++ b/gadget.Dockerfile
@@ -8,6 +8,11 @@ RUN set -ex; \
 	apt-get install -y gcc make golang-1.13 ca-certificates git && \
 	ln -s /usr/lib/go-1.13/bin/go /bin/go
 
+# Cache go modules so they won't be downloaded at each build
+COPY go.mod go.sum /gadget/
+RUN cd /gadget && go mod download
+
+# This COPY is limited by .dockerignore
 COPY ./ /gadget
 RUN cd /gadget/gadget-container && make gadget-container-deps
 


### PR DESCRIPTION
- Cache go modules in a Docker layer to avoid downloading them at each
  build

- Only copy necessary files in the build context

This patch uses the ideas from the following article:
https://medium.com/@pliutau/docker-and-go-modules-4265894f9fc

-----

## Example of developer workflow

- Compile everything: `make`
- Test
- Make some changes in some Go code of the gadget container.
- Recompile: `make`. Thanks to this patch, the Go modules will not be downloaded again.
- Make some changes unrelated to the gadget container (e.g. `docs/install.md`).
- Recompile: `make`. Thanks to this patch, the gadget container will not be recompiled.

