### PR TITLE
New gadget: process collector

### DIFF
--- a/gadget-container/gadgettracermanager/controller.go
+++ b/gadget-container/gadgettracermanager/controller.go
@@ -34,6 +34,7 @@ import (
 	"github.com/kinvolk/inspektor-gadget/pkg/gadgets"
 	"github.com/kinvolk/inspektor-gadget/pkg/gadgets/biolatency"
 	networkpolicyadvisor "github.com/kinvolk/inspektor-gadget/pkg/gadgets/networkpolicy"
+	"github.com/kinvolk/inspektor-gadget/pkg/gadgets/process-collector"
 	"github.com/kinvolk/inspektor-gadget/pkg/gadgettracermanager"
 	//+kubebuilder:scaffold:imports
 )
@@ -61,6 +62,7 @@ func startController(node string, tracerManager *gadgettracermanager.GadgetTrace
 
 	traceFactories := make(map[string]gadgets.TraceFactory)
 	traceFactories["biolatency"] = &biolatency.TraceFactory{}
+	traceFactories["process-collector"] = &processcollector.TraceFactory{}
 	traceFactories["network-policy-advisor"] = &networkpolicyadvisor.TraceFactory{}
 
 	if err = (&controllers.TraceReconciler{

--- a/pkg/gadgets/helpers.go
+++ b/pkg/gadgets/helpers.go
@@ -29,10 +29,18 @@ const (
 	TRACE_DEFAULT_NAMESPACE = "gadget"
 )
 
+func TraceName(namespace, name string) string {
+	return "trace_" + namespace + "_" + name
+}
+
 func TraceNameFromNamespacedName(n types.NamespacedName) string {
-	return "trace_" + n.Namespace + "_" + n.Name
+	return TraceName(n.Namespace, n.Name)
+}
+
+func TracePinPath(namespace, name string) string {
+	return fmt.Sprintf("%s/%s%s", PIN_PATH, MNTMAP_PREFIX, TraceName(namespace, name))
 }
 
 func TracePinPathFromNamespacedName(n types.NamespacedName) string {
-	return fmt.Sprintf("%s/%s%s", PIN_PATH, MNTMAP_PREFIX, TraceNameFromNamespacedName(n))
+	return TracePinPath(n.Namespace, n.Name)
 }

--- a/pkg/gadgets/process-collector/gadget.go
+++ b/pkg/gadgets/process-collector/gadget.go
@@ -1,0 +1,90 @@
+// Copyright 2019-2021 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package processcollector
+
+import (
+	"fmt"
+	"sync"
+
+	log "github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/types"
+
+	gadgetv1alpha1 "github.com/kinvolk/inspektor-gadget/pkg/api/v1alpha1"
+	"github.com/kinvolk/inspektor-gadget/pkg/gadgets"
+	"github.com/kinvolk/inspektor-gadget/pkg/gadgets/process-collector/tracer"
+)
+
+type Trace struct {
+}
+
+type TraceFactory struct {
+	mu     sync.Mutex
+	traces map[string]*Trace
+}
+
+func (f *TraceFactory) LookupOrCreate(name types.NamespacedName) gadgets.Trace {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.traces == nil {
+		f.traces = make(map[string]*Trace)
+	}
+	trace, ok := f.traces[name.String()]
+	if ok {
+		return trace
+	}
+	trace = &Trace{}
+	f.traces[name.String()] = trace
+
+	return trace
+}
+
+func (f *TraceFactory) Delete(name types.NamespacedName) error {
+	log.Infof("Deleting %s", name.String())
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	_, ok := f.traces[name.String()]
+	if !ok {
+		log.Infof("Deleting %s: does not exist", name.String())
+		return nil
+	}
+	delete(f.traces, name.String())
+	return nil
+}
+
+func (t *Trace) Operation(trace *gadgetv1alpha1.Trace, resolver gadgets.Resolver, operation string, params map[string]string) {
+	if trace.ObjectMeta.Namespace != gadgets.TRACE_DEFAULT_NAMESPACE {
+		trace.Status.OperationError = fmt.Sprintf("This gadget only accepts operations on traces in the %s namespace", gadgets.TRACE_DEFAULT_NAMESPACE)
+		return
+	}
+	switch operation {
+	case "start":
+		t.Start(trace)
+	default:
+		trace.Status.OperationError = fmt.Sprintf("Unknown operation %q", operation)
+	}
+}
+
+func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
+	output, err := tracer.RunCollector(
+		gadgets.TracePinPath(trace.ObjectMeta.Namespace, trace.ObjectMeta.Name),
+	)
+	if err != nil {
+		trace.Status.OperationError = err.Error()
+		return
+	}
+	trace.Status.OperationError = ""
+	trace.Status.Output = output
+	trace.Status.State = "Completed"
+}

--- a/pkg/gadgets/process-collector/tracer/bpf/Makefile
+++ b/pkg/gadgets/process-collector/tracer/bpf/Makefile
@@ -1,0 +1,10 @@
+.PHONY: all
+all: process-collector.o process-collector-with-filter.o
+
+PKG_DIR=../../../..
+
+process-collector.o: process-collector.c
+	clang -I$(PKG_DIR) -target bpf -O2 -g -c -x c $< -o $@
+
+process-collector-with-filter.o: process-collector.c
+	clang -I$(PKG_DIR) -target bpf -O2 -g -c -x c $< -o $@ -DWITH_FILTER=1

--- a/pkg/gadgets/process-collector/tracer/bpf/process-collector.c
+++ b/pkg/gadgets/process-collector/tracer/bpf/process-collector.c
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: GPL-2.0 WITH Linux-syscall-note
+
+/* Copyright (c) 2021 The Inspektor Gadget authors */
+
+/* Inspired by the BPF iterator in the Linux tree:
+ * https://github.com/torvalds/linux/blob/v5.12/tools/testing/selftests/bpf/progs/bpf_iter_task.c
+ */
+
+/* This BPF program uses the GPL-restricted function bpf_seq_printf().
+ */
+
+#include <vmlinux/vmlinux.h>
+
+#include <bpf/bpf_helpers.h>
+/* libbpf v0.4.0 introduced BPF_SEQ_PRINTF in bpf_tracing.h.
+ * In future versions, it will be in bpf_helpers.h.
+ */
+#include <bpf/bpf_tracing.h>
+
+#include <gadgettracermanager/bpf-maps.h>
+
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__type(key, __u64);
+	__type(value, __u64);
+	__uint(max_entries, 128);
+} context SEC(".maps");
+
+SEC("iter/task")
+int dump_task(struct bpf_iter__task *ctx)
+{
+	struct seq_file *seq = ctx->meta->seq;
+	__u32 seq_num = ctx->meta->seq_num;
+	__u64 session_id = ctx->meta->session_id;
+	struct task_struct *task = ctx->task;
+	__u64 *counter;
+	__u64 zero = 0;
+
+	if (seq_num == 0) {
+		BPF_SEQ_PRINTF(seq, "[\n");
+		bpf_map_update_elem(&context, &session_id, &zero, BPF_ANY);
+	}
+
+	counter = bpf_map_lookup_elem(&context, &session_id);
+	if (!counter)
+		return 0;
+
+	if (task == (void *)0) {
+		if (*counter)
+			BPF_SEQ_PRINTF(seq, "\n");
+		BPF_SEQ_PRINTF(seq, "]\n");
+		bpf_map_delete_elem(&context, &session_id);
+		return 0;
+	}
+
+	__u64 mntns_id = task->nsproxy->mnt_ns->ns.inum;
+
+#ifdef WITH_FILTER
+	__u32 *found = bpf_map_lookup_elem(&filter, &mntns_id);
+	if (!found)
+		return 0;
+#endif
+
+	if (*counter)
+		BPF_SEQ_PRINTF(seq, ",\n");
+
+	__sync_fetch_and_add(counter, 1);
+	BPF_SEQ_PRINTF(seq, "  {\n    \"tgid\": %d,\n    \"pid\": %d,\n    \"comm\": \"%s\",\n    \"mntns\": %llu", task->tgid, task->pid, task->comm, mntns_id);
+
+	struct container *container_entry;
+	container_entry = bpf_map_lookup_elem(&containers, &mntns_id);
+	if (container_entry) {
+		BPF_SEQ_PRINTF(seq, ",\n    \"container_id\": \"%s\"", container_entry->container_id);
+		BPF_SEQ_PRINTF(seq, ",\n    \"kubernetes_namespace\": \"%s\"", container_entry->kubernetes_namespace);
+		BPF_SEQ_PRINTF(seq, ",\n    \"kubernetes_pod\": \"%s\"", container_entry->kubernetes_pod);
+		BPF_SEQ_PRINTF(seq, ",\n    \"kubernetes_container\": \"%s\"", container_entry->kubernetes_container);
+	}
+
+	BPF_SEQ_PRINTF(seq, "\n  }");
+
+	return 0;
+}
+
+char _license[] SEC("license") = "GPL";

--- a/pkg/gadgets/process-collector/tracer/embed-ebpf.go
+++ b/pkg/gadgets/process-collector/tracer/embed-ebpf.go
@@ -1,0 +1,27 @@
+// +build withebpf
+
+// Copyright 2019-2021 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tracer
+
+import (
+	_ "embed"
+)
+
+//go:embed bpf/process-collector.o
+var ebpfProg []byte
+
+//go:embed bpf/process-collector-with-filter.o
+var ebpfProgWithFilter []byte

--- a/pkg/gadgets/process-collector/tracer/embed-none.go
+++ b/pkg/gadgets/process-collector/tracer/embed-none.go
@@ -1,0 +1,21 @@
+// +build !withebpf
+
+// Copyright 2019-2021 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tracer
+
+var ebpfProg []byte
+
+var ebpfProgWithFilter []byte

--- a/pkg/gadgets/process-collector/tracer/tracer.go
+++ b/pkg/gadgets/process-collector/tracer/tracer.go
@@ -1,0 +1,88 @@
+// Copyright 2019-2021 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tracer
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/link"
+
+	"github.com/kinvolk/inspektor-gadget/pkg/gadgets"
+)
+
+const (
+	BPF_ITER_NAME = "dump_task"
+)
+
+func RunCollector(mntnsmap string) (string, error) {
+	var prog []byte
+	if mntnsmap == "" {
+		prog = ebpfProg
+	} else {
+		if filepath.Dir(mntnsmap) != gadgets.PIN_PATH {
+			return "", fmt.Errorf("error while checking pin path: only paths in %s are supported", gadgets.PIN_PATH)
+		}
+
+		prog = ebpfProgWithFilter
+	}
+	spec, err := ebpf.LoadCollectionSpecFromReader(bytes.NewReader(prog))
+	if err != nil {
+		return "", fmt.Errorf("failed to load asset: %w", err)
+	}
+
+	spec.Maps["containers"].Pinning = ebpf.PinByName
+	if mntnsmap != "" {
+		spec.Maps["filter"].Name = filepath.Base(mntnsmap)
+		spec.Maps["filter"].Pinning = ebpf.PinByName
+	}
+
+	coll, err := ebpf.NewCollectionWithOptions(spec,
+		ebpf.CollectionOptions{
+			Maps: ebpf.MapOptions{
+				PinPath: gadgets.PIN_PATH,
+			},
+		},
+	)
+	if err != nil {
+		return "", fmt.Errorf("failed to create BPF collection: %w", err)
+	}
+
+	dumpTask, ok := coll.Programs[BPF_ITER_NAME]
+	if !ok {
+		return "", fmt.Errorf("failed to find BPF iterator %q", BPF_ITER_NAME)
+	}
+	dumpTaskIter, err := link.AttachIter(link.IterOptions{
+		Program: dumpTask,
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to attach BPF iterator: %w", err)
+	}
+
+	file, err := dumpTaskIter.Open()
+	if err != nil {
+		return "", fmt.Errorf("failed to open BPF iterator: %w", err)
+	}
+	defer file.Close()
+
+	contents, err := ioutil.ReadAll(file)
+	if err != nil {
+		return "", fmt.Errorf("failed to read BPF iterator: %w", err)
+	}
+	return string(contents), nil
+}

--- a/pkg/resources/samples/trace-process-collector.yaml
+++ b/pkg/resources/samples/trace-process-collector.yaml
@@ -1,0 +1,14 @@
+apiVersion: gadget.kinvolk.io/v1alpha1
+kind: Trace
+metadata:
+  name: process-collector
+  namespace: gadget
+spec:
+  node: minikube
+  gadget: process-collector
+  filter:
+    namespace: default
+    labels:
+      role: demo
+  runMode: Manual
+  outputMode: Status


### PR DESCRIPTION
# New gadget: process collector

Add a new gadget that gather the list of all processes enriched with container metadata.

This is implemented with BPF iterators, a new feature of Linux 5.8. For an introduction to BPF iterators, see:
https://devconfcz2021.sched.com/event/gmK5/ebpf-iterators

process-collector can optionally use filters as prepared by the Gadget Tracer Manager in the same way as other bcc tools such as opensnoop or execsnoop:
```
apiVersion: gadget.kinvolk.io/v1alpha1
kind: Trace
metadata:
  name: process-collector
  namespace: gadget
spec:
  node: minikube
  gadget: process-collector
  filter:
    namespace: default
    labels:
      role: demo
  runMode: Manual
  outputMode: Status
```

Implementation details:
- The BPF program is compiled twice: one time with the filter and one time without. The Go program selects the right one to use depending on the command line arguments.
- To print correct json from the BPF iterator, we cannot rely solely on seq_num to know if we've printed the first entry since entries can be filtered out. We use a temporary BPF map to keep context between calls.

## How to use

```
$ kubectl apply -f  pkg/resources/samples/trace-process-collector.yaml
$ kubectl annotate -n gadget trace/process-collector gadget.kinvolk.io/operation=start
$ kubectl get -n gadget trace/process-collector -o jsonpath='{.status.output}'
[
  {
    "tgid": 921951,
    "pid": 921951,
    "comm": "sleep",
    "mntns": 4026532639,
    "container_id": "docker://d897a9298d94ce9c8d5cc8ad233936c457710358e9fda3871fa914b11bfe5d91",
    "kubernetes_namespace": "default",
    "kubernetes_pod": "privileged-pod-4m79d",
    "kubernetes_container": "privileged-pod"
  }
]
```

## Testing done

Tested on Minikube with the docker driver on Linux 5.12.

