### PR TITLE
Update BCC container image

### DIFF
--- a/gadget-local.Dockerfile
+++ b/gadget-local.Dockerfile
@@ -1,12 +1,12 @@
 # Main gadget image
 
 # BCC built from:
-# https://github.com/kinvolk/bcc/commit/5fed2a94da19501c3088161db0c412b5623050ca
+# https://github.com/kinvolk/bcc/commit/4e8e8c65335d650414cd05a38b6860080dba81da
 # See:
 # - https://github.com/kinvolk/bcc/actions
 # - https://hub.docker.com/r/kinvolk/bcc/tags
 
-FROM docker.io/kinvolk/bcc:202006031708335fed2a
+FROM docker.io/kinvolk/bcc:202107061407494e8e8c
 
 RUN set -ex; \
 	export DEBIAN_FRONTEND=noninteractive; \

--- a/gadget.Dockerfile
+++ b/gadget.Dockerfile
@@ -24,12 +24,12 @@ FROM docker.io/kinvolk/traceloop:202006050210553a5730 as traceloop
 # Main gadget image
 
 # BCC built from:
-# https://github.com/kinvolk/bcc/commit/5fed2a94da19501c3088161db0c412b5623050ca
+# https://github.com/kinvolk/bcc/commit/4e8e8c65335d650414cd05a38b6860080dba81da
 # See:
 # - https://github.com/kinvolk/bcc/actions
 # - https://hub.docker.com/r/kinvolk/bcc/tags
 
-FROM docker.io/kinvolk/bcc:202006031708335fed2a
+FROM docker.io/kinvolk/bcc:202107061407494e8e8c
 
 RUN set -ex; \
 	export DEBIAN_FRONTEND=noninteractive; \


### PR DESCRIPTION
# Update BCC container image

Currently, the BCC container image used for InspektorGadget is based on kinvolk/bcc@5fed2a9 (v0.14.0) but changes introduced in torvalds/linux@97e4910232fa1f81e806aa60c25a0450276d99a2 (v5.12) make BCC-based gadgets to start complaining about macros redefinition when compiling BPF programs.

Issue was already solved in BCC upstream with iovisor/bcc#3391. Therefore, this commit updates the BCC container image to be used by InspektorGadget to one based on kinvolk/bcc@4e8e8c6 (v0.20.0) which includes the fix.

This commit fixes issue #182.

## Warnings
Please notice that the size of the final InspektorGadget container image is passing from ~180MB to ~320MB. This increment is coming from BCC upstream where container image size passed from ~110MB (v0.14.0) to ~250MB (v0.20.0). Check container registries:
- BCC: https://hub.docker.com/r/kinvolk/bcc/tags?page=1&ordering=last_updated
- InspektorGadget: https://hub.docker.com/r/kinvolk/gadget/tags?page=1&ordering=last_updated

## How to use
Trying BCC-based gadgets.

## Testing done
### Setup:
- Linux Mint with kernel v5.12.14
- Kubernetes cluster created using kubeadm v1.21.2
- Docker v20.10.2

### Before this PR:
```
$ kubectl gadget execsnoop --namespace=kube-system
Node numbers: 0 = blanquicet
[E0] In file included from <built-in>:2:
[E0] In file included from /virtual/include/bcc/bpf.h:12:
[E0] In file included from include/linux/types.h:6:
[E0] In file included from include/uapi/linux/types.h:14:
[E0] In file included from ./include/uapi/linux/posix_types.h:5:
[E0] In file included from include/linux/stddef.h:5:
[E0] In file included from include/uapi/linux/stddef.h:2:
[E0] In file included from include/linux/compiler_types.h:80:
[E0] include/linux/compiler-clang.h:35:9: warning: '__HAVE_BUILTIN_BSWAP32__' macro redefined [-Wmacro-redefined]
[E0] #define __HAVE_BUILTIN_BSWAP32__
[E0]         ^
[E0] <command line>:4:9: note: previous definition is here
[E0] #define __HAVE_BUILTIN_BSWAP32__ 1
[E0]         ^
[E0] In file included from <built-in>:2:
[E0] In file included from /virtual/include/bcc/bpf.h:12:
[E0] In file included from include/linux/types.h:6:
[E0] In file included from include/uapi/linux/types.h:14:
[E0] In file included from ./include/uapi/linux/posix_types.h:5:
[E0] In file included from include/linux/stddef.h:5:
[E0] In file included from include/uapi/linux/stddef.h:2:
[E0] In file included from include/linux/compiler_types.h:80:
[E0] include/linux/compiler-clang.h:36:9: warning: '__HAVE_BUILTIN_BSWAP64__' macro redefined [-Wmacro-redefined]
[E0] #define __HAVE_BUILTIN_BSWAP64__
[E0]         ^
[E0] <command line>:5:9: note: previous definition is here
[E0] #define __HAVE_BUILTIN_BSWAP64__ 1
[E0]         ^
[E0] In file included from <built-in>:2:
[E0] In file included from /virtual/include/bcc/bpf.h:12:
[E0] In file included from include/linux/types.h:6:
[E0] In file included from include/uapi/linux/types.h:14:
[E0] In file included from ./include/uapi/linux/posix_types.h:5:
[E0] In file included from include/linux/stddef.h:5:
[E0] In file included from include/uapi/linux/stddef.h:2:
[E0] In file included from include/linux/compiler_types.h:80:
[E0] include/linux/compiler-clang.h:37:9: warning: '__HAVE_BUILTIN_BSWAP16__' macro redefined [-Wmacro-redefined]
[E0] #define __HAVE_BUILTIN_BSWAP16__
[E0]         ^
[E0] <command line>:3:9: note: previous definition is here
[E0] #define __HAVE_BUILTIN_BSWAP16__ 1
[E0]         ^
[E0] 3 warnings generated.
NODE PCOMM            PID    PPID   RET ARGS
```
### After this PR:
```
$ kubectl gadget execsnoop --namespace=kube-system
Node numbers: 0 = blanquicet
NODE PCOMM            PID    PPID   RET ARGS
```