### PR TITLE
Describe how to update BCC on gadget container image

### DIFF
--- a/gadget-local.Dockerfile
+++ b/gadget-local.Dockerfile
@@ -2,9 +2,7 @@
 
 # BCC built from:
 # https://github.com/kinvolk/bcc/commit/4e8e8c65335d650414cd05a38b6860080dba81da
-# See:
-# - https://github.com/kinvolk/bcc/actions
-# - https://hub.docker.com/r/kinvolk/bcc/tags
+# See BCC section in docs/CONTRIBUTING.md for further details.
 
 FROM docker.io/kinvolk/bcc:202107061407494e8e8c
 

--- a/gadget.Dockerfile
+++ b/gadget.Dockerfile
@@ -25,9 +25,7 @@ FROM docker.io/kinvolk/traceloop:202006050210553a5730 as traceloop
 
 # BCC built from:
 # https://github.com/kinvolk/bcc/commit/4e8e8c65335d650414cd05a38b6860080dba81da
-# See:
-# - https://github.com/kinvolk/bcc/actions
-# - https://hub.docker.com/r/kinvolk/bcc/tags
+# See BCC section in docs/CONTRIBUTING.md for further details.
 
 FROM docker.io/kinvolk/bcc:202107061407494e8e8c
 


### PR DESCRIPTION
# Describe how to update BCC on gadget container image

Add new section in `docs/CONTRIBUTING.md` to describe how to update BCC from upstream.

I also put the building notes in a separate section because they are actually related to both, client and image compilation.