### PR TITLE
Update branch name to main

### DIFF
--- a/.krew.yaml
+++ b/.krew.yaml
@@ -17,7 +17,7 @@ spec:
     fetch the log data from ring buffers and display it. What BPF programs are
     and how Inspektor Gadget uses them is briefly explained in the architecture
     document:
-    https://github.com/kinvolk/inspektor-gadget/blob/master/Documentation/architecture.md
+    https://github.com/kinvolk/inspektor-gadget/blob/main/Documentation/architecture.md
   caveats: |
     Inspektor Gadget needs to be deployed to each node:
 

--- a/tools/image-tag
+++ b/tools/image-tag
@@ -15,7 +15,7 @@ fi
 WORKING_SUFFIX=$(if git status --porcelain | grep -qE '^(?:[^?][^ ]|[^ ][^?])\s'; then echo "-WIP"; else echo ""; fi)
 BRANCH_PREFIX=$(git rev-parse --abbrev-ref HEAD)
 if [ "$1" = "branch" ] ; then
-  if [ "$BRANCH_PREFIX" = "master" ] ; then
+  if [ "$BRANCH_PREFIX" = "main" ] ; then
     BRANCH_PREFIX="latest"
   fi
   echo "${BRANCH_PREFIX//\//-}$WORKING_SUFFIX"


### PR DESCRIPTION
# Update branch name to main

The default branch name was `master` and I renamed it to `main`. This PR adjusts the code to this new name.

For more background, see:
https://github.com/github/renaming#renaming-existing-branches

