### PR TITLE
GitHub action: cache Go mods and deb packages

### DIFF
--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -22,12 +22,28 @@ jobs:
     - name: Check out code
       uses: actions/checkout@v1
 
-    - name: Install dependencies
+    - name: Cache deb packages
+      uses: actions/cache@v2
+      id: cache-debs
+      with:
+          path: "~/cache-debs"
+          key: cache-debs-libbpf-1:0.4.0-1ubuntu1
+
+    - name: Install deb packages
+      env:
+        CACHE_HIT: ${{steps.cache-debs.outputs.cache-hit}}
+        LIBBPF_VERSION: "1:0.4.0-1ubuntu1"
       run: |
-        sudo apt install -y software-properties-common
-        sudo add-apt-repository -y ppa:tuxinvader/kernel-build-tools
-        sudo apt-get update
-        sudo apt install -y libbpf-dev
+          if [[ "$CACHE_HIT" == 'true' ]]; then
+            sudo cp --verbose --force --recursive ~/cache-debs/* /
+          else
+            sudo apt install -y software-properties-common
+            sudo add-apt-repository -y ppa:tuxinvader/kernel-build-tools
+            sudo apt-get update
+            sudo apt install -y libbpf-dev="$LIBBPF_VERSION"
+            mkdir -p ~/cache-debs
+            sudo dpkg -L libbpf-dev | while IFS= read -r f; do if test -f $f; then echo $f; fi; done | xargs cp --parents --target-directory ~/cache-debs/
+          fi
 
     - name: Set IMAGE_TAG
       run: |

--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -45,6 +45,16 @@ jobs:
             sudo dpkg -L libbpf-dev | while IFS= read -r f; do if test -f $f; then echo $f; fi; done | xargs cp --parents --target-directory ~/cache-debs/
           fi
 
+    - name: Cache Go modules
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.cache/go-build
+          ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
+
     - name: Set IMAGE_TAG
       run: |
         TMP1=${GITHUB_REF#*/}


### PR DESCRIPTION
## GitHub action: cache deb packages install

Installing libbpf-dev used to take 20 seconds. Additionally, this causes
unnecessary network traffic to Ubuntu package repositories and PPA
repositories. This patch optimizes that by using the GitHub action
cache.

After this patch, checking the cache takes less than 1 second and
installing from the cache takes 1 second.

Technique inspired from:
https://stackoverflow.com/questions/59269850/caching-apt-packages-in-github-actions-workflow

-----
## GitHub action: cache Go modules

Using the technique from the documentation:
https://github.com/actions/cache/blob/main/examples.md#go---modules

This is useful for building the kubectl plugin ("make kubectl-gadget")
and the unit tests ("make test"): those are built directly on the Ubuntu
host.

Before this patch:

- make kubectl-gadget: 2m 42s (test 1) and 2m 18s (test 2)
- make test: 57s (test 1) and 48s (test 2)

After this patch, in case of cache hit:
- restoring the cache: 8s
- make kubectl-gadget 12s
- make test: 3s

Note: this patch is complementary with the previous commit 93f2f767688e
("Dockerfile: faster builds") where we cache the Go modules in a Docker
layer. This was useful for building the gadget container image in Docker
("make gadget-container").
