### PR TITLE
GitHub action: cache Docker layers

### DIFF
--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -65,9 +65,42 @@ jobs:
         fi
         echo IMAGE_TAG=$IMAGE_TAG >> $GITHUB_ENV
 
+    - name: Set up Docker Buildx
+      id: buildx
+      uses: docker/setup-buildx-action@v1
+
+    - name: Cache Docker layers
+      uses: actions/cache@v2
+      with:
+        path: /tmp/.buildx-cache
+        key: ${{ runner.os }}-single-buildx-${{ hashFiles('gadget.Dockerfile') }}
+        restore-keys: |
+          ${{ runner.os }}-single-buildx
+
+    - name: Login to DockerHub
+      uses: docker/login-action@v1
+      with:
+        username: ${{ secrets.CONTAINER_REGISTRY_USERNAME }}
+        password: ${{ secrets.CONTAINER_REGISTRY_PASSWORD }}
+
     - name: Build gadget container
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        file: gadget.Dockerfile
+        # TODO: how to avoid pushing a container before running integration tests
+        push: true
+        tags: ${{ secrets.CONTAINER_REPO }}:${{ env.IMAGE_TAG }}
+        cache-from: type=local,src=/tmp/.buildx-cache
+        cache-to: type=local,dest=/tmp/.buildx-cache-new
+
+      # Temp fix
+      # https://github.com/docker/build-push-action/issues/252
+      # https://github.com/moby/buildkit/issues/1896
+    - name: Move Docker layers cache
       run: |
-        make gadget-container
+        rm -rf /tmp/.buildx-cache
+        mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
     - name: Build kubectl gadget Plugin
       run: |
@@ -95,16 +128,6 @@ jobs:
         minikube version: 'v1.9.2'
         kubernetes version: 'v1.18.2'
         github token: ${{ secrets.GITHUB_TOKEN }}
-
-    - uses: azure/docker-login@v1
-      with:
-        username: ${{ secrets.CONTAINER_REGISTRY_USERNAME }}
-        password: ${{ secrets.CONTAINER_REGISTRY_PASSWORD }}
-
-    # TODO: how to avoid pushing a container before running integration tests
-    - name: Push Gadget Container
-      run: |
-          make push-gadget-container
 
     - name: Integration tests
       run: |


### PR DESCRIPTION
Without this patch, the step "Build gadget container" takes 4m 10s.

With this patch, it takes as little as 11s if there was no changes and
all the layers were cached.

Inspired by:
https://evilmartians.com/chronicles/build-images-on-github-actions-with-docker-layer-caching#building-a-single-stage-dockerfile
