### PR TITLE
GHA: Fix pushing latest container image

### DIFF
--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -59,7 +59,11 @@ jobs:
       run: |
         TMP1=${GITHUB_REF#*/}
         TMP2=${TMP1#*/}
-        echo IMAGE_TAG=${TMP2//\//-} >> $GITHUB_ENV
+        IMAGE_TAG=${TMP2//\//-}
+        if [ "$IMAGE_TAG" = "main" ]; then
+            IMAGE_TAG="latest"
+        fi
+        echo IMAGE_TAG=$IMAGE_TAG >> $GITHUB_ENV
 
     - name: Build gadget container
       run: |

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ TAG := `git describe --tags --always`
 VERSION :=
 
 CONTAINER_REPO ?= docker.io/kinvolk/gadget
-IMAGE_TAG=$(shell ./tools/image-tag branch)
+IMAGE_TAG ?= $(shell ./tools/image-tag branch)
 
 MINIKUBE ?= minikube
 
@@ -15,7 +15,7 @@ else
 endif
 
 LDFLAGS := "-X main.version=$(VERSION) \
--X main.gadgetimage=$(CONTAINER_REPO):$(shell ./tools/image-tag branch) \
+-X main.gadgetimage=$(CONTAINER_REPO):$(IMAGE_TAG) \
 -extldflags '-static'"
 
 .PHONY: build
@@ -70,7 +70,7 @@ integration-tests:
 	KUBECTL_GADGET="$(shell pwd)/kubectl-gadget-linux-amd64" \
 		go test ./integration/... \
 			-integration \
-			-image $(CONTAINER_REPO):$(shell ./tools/image-tag branch)
+			-image $(CONTAINER_REPO):$(IMAGE_TAG)
 
 # minikube
 LIVENESS_PROBE_INITIAL_DELAY_SECONDS ?= 10


### PR DESCRIPTION
https://github.com/kinvolk/inspektor-gadget/pull/164/commits/2ef22b70e5af388ea9f1c396962be729e73418ab broke the pushing of the `latest` tag of the container image. It happened because it defined `IMAGE_TAG` on github actions, then `tools/image-tag` returned here https://github.com/kinvolk/inspektor-gadget/blob/b1dac15b475b3d4fe572a3f3087e345491bb9607/tools/image-tag#L10 without running the conditional to set IMAGE_TAG to latest when the branch is main. 

This commit fixes that problem taking into consideration that case directly in the github actions workflow. 

Please note that `tools/image-tag` can't be used directly in GHA because the repo is in "detached HEAD" status when it's run and hence it'll always return `HEAD`. 
