### PR TITLE
Fix a couple of error messages

### DIFF
--- a/pkg/gadgettracermanager/gadgettracermanager.go
+++ b/pkg/gadgettracermanager/gadgettracermanager.go
@@ -377,7 +377,7 @@ func increaseRlimit() error {
 
 func initServer() error {
 	if err := increaseRlimit(); err != nil {
-		return fmt.Errorf("failed to increase limit memlock limit: %w", err)
+		return fmt.Errorf("failed to increase memlock limit: %w", err)
 	}
 
 	if err := os.Mkdir(PIN_PATH, 0700); err != nil && !errors.Is(err, unix.EEXIST) {

--- a/pkg/gadgettracermanager/k8s/k8s.go
+++ b/pkg/gadgettracermanager/k8s/k8s.go
@@ -175,6 +175,10 @@ func (k *K8sClient) PodToContainers(pod *v1.Pod) []pb.ContainerDefinition {
 			log.Printf("Skip pod %s/%s: cannot find pid: %v", pod.GetNamespace(), pod.GetName(), err)
 			continue
 		}
+		if pid == 0 {
+			log.Printf("Skip pod %s/%s: got zero pid", pod.GetNamespace(), pod.GetName())
+			continue
+		}
 		_, cgroupPathV2, err := containerutils.GetCgroupPaths(pid)
 		if err != nil {
 			log.Printf("Skip pod %s/%s: cannot find cgroup path: %v", pod.GetNamespace(), pod.GetName(), err)


### PR DESCRIPTION
# CRI: return a better error when pid is zero

Sometimes, the container runtime says the pid of the container is zero:
```
Skip pod kube-system/gadget-prm95: cannot find cgroup path: cannot parse cgroup: open /proc/0/cgroup: no such file or directory
```

In this case, don't try to read /proc/0/cgroup but return an error message early.

The OCI Container Runtime specification says that the pid is required when the state of the container is 'created' or 'running' but not when it is 'creating' or 'stopped'.

# gadgettracermanager: fix error message

Double "limit":
```
failed to increase limit memlock limit: %w
```

Typo reported by @marga-kinvolk 