### PR TITLE
Extend gadgets to print container & pod information

### DIFF
--- a/cmd/kubectl-gadget/bcck8s.go
+++ b/cmd/kubectl-gadget/bcck8s.go
@@ -21,7 +21,6 @@ import (
 	"io"
 	"os"
 	"os/signal"
-	"strconv"
 	"strings"
 	"sync/atomic"
 	"syscall"
@@ -170,7 +169,6 @@ type postProcess struct {
 }
 
 type postProcessSingle struct {
-	nodeShort        string
 	orig             io.Writer
 	firstLine        bool
 	firstLinePrinted *uint64
@@ -186,7 +184,6 @@ func newPostProcess(n int, outStream io.Writer, errStream io.Writer) *postProces
 
 	for i := 0; i < n; i++ {
 		p.outStreams[i] = &postProcessSingle{
-			nodeShort:        " " + strconv.Itoa(i),
 			orig:             outStream,
 			firstLine:        true,
 			firstLinePrinted: &p.firstLinePrinted,
@@ -194,7 +191,6 @@ func newPostProcess(n int, outStream io.Writer, errStream io.Writer) *postProces
 		}
 
 		p.errStreams[i] = &postProcessSingle{
-			nodeShort:        "E" + strconv.Itoa(i),
 			orig:             errStream,
 			firstLine:        false,
 			firstLinePrinted: &p.firstLinePrinted,
@@ -206,7 +202,6 @@ func newPostProcess(n int, outStream io.Writer, errStream io.Writer) *postProces
 }
 
 func (post *postProcessSingle) Write(p []byte) (n int, err error) {
-	prefix := "[" + post.nodeShort + "] "
 	asStr := post.buffer + string(p)
 
 	lines := strings.Split(asStr, "\n")
@@ -216,15 +211,14 @@ func (post *postProcessSingle) Write(p []byte) (n int, err error) {
 
 	// Print lines with prefix but the last one
 	for _, line := range lines[0 : len(lines)-1] {
+		// Skip printing the header multiple times
 		if post.firstLine {
 			post.firstLine = false
-			if atomic.AddUint64(post.firstLinePrinted, 1) == 1 {
-				prefix = "NODE "
-			} else {
-				continue // ignore this line, somebody else already printed it
+			if atomic.AddUint64(post.firstLinePrinted, 1) != 1 {
+				continue
 			}
 		}
-		fmt.Fprintf(post.orig, "%s\n", prefix+line)
+		fmt.Fprintf(post.orig, "%s\n", line)
 	}
 
 	post.buffer = lines[len(lines)-1] // Buffer last line to print in next iteration
@@ -323,12 +317,10 @@ func bccCmd(subCommand, bccScript string) func(*cobra.Command, []string) {
 
 		postProcess := newPostProcess(len(nodes.Items), os.Stdout, os.Stderr)
 
-		fmt.Printf("Node numbers:")
 		for i, node := range nodes.Items {
 			if nodeParam != "" && node.Name != nodeParam {
 				continue
 			}
-			fmt.Printf(" %d = %s", i, node.Name)
 			go func(nodeName string, index int) {
 				cmd := fmt.Sprintf("exec /opt/bcck8s/bcc-wrapper.sh --tracerid %s --gadget %s %s %s %s %s -- %s",
 					tracerId, bccScript, labelFilter, namespaceFilter, podnameFilter, containernameFilter, gadgetParams)
@@ -344,7 +336,6 @@ func bccCmd(subCommand, bccScript string) func(*cobra.Command, []string) {
 				}
 			}(node.Name, i) // node.Name is invalidated by the above for loop, causes races
 		}
-		fmt.Println()
 
 		select {
 		case <-sigs:

--- a/cmd/kubectl-gadget/bcck8s.go
+++ b/cmd/kubectl-gadget/bcck8s.go
@@ -274,6 +274,12 @@ func bccCmd(subCommand, bccScript string) func(*cobra.Command, []string) {
 		}
 
 		gadgetParams := ""
+
+		// add container info to gadgets that support it
+		if subCommand != "tcptop" {
+			gadgetParams = "--containersmap /sys/fs/bpf/gadget/containers"
+		}
+
 		switch subCommand {
 		case "capabilities":
 			if stackFlag {

--- a/cmd/kubectl-gadget/bcck8s_test.go
+++ b/cmd/kubectl-gadget/bcck8s_test.go
@@ -37,7 +37,7 @@ func TestPostProcessFirstLineOutStream(t *testing.T) {
 	postProcess.outStreams[1].Write([]byte("PCOMM  PID    PPID   RET ARGS\n"))
 
 	expected := `
-NODE PCOMM  PID    PPID   RET ARGS
+PCOMM  PID    PPID   RET ARGS
 `
 	if "\n"+string(mock.output) != expected {
 		t.Fatalf("%v != %v", string(mock.output), expected)
@@ -54,8 +54,8 @@ func TestPostProcessFirstLineErrStream(t *testing.T) {
 	postProcess.errStreams[1].Write([]byte("error in node1\n"))
 
 	expected := `
-[E0] error in node0
-[E1] error in node1
+error in node0
+error in node1
 `
 	if "\n"+string(mock.output) != expected {
 		t.Fatalf("%v != %v", string(mock.output), expected)
@@ -71,7 +71,7 @@ func TestPostProcessMultipleLines(t *testing.T) {
 
 	postProcess.outStreams[0].Write([]byte("wget   "))
 	expected = `
-NODE PCOMM  PID    PPID   RET ARGS
+PCOMM  PID    PPID   RET ARGS
 `
 	if "\n"+string(mock.output) != expected {
 		t.Fatalf("%v != %v", string(mock.output), expected)
@@ -80,8 +80,8 @@ NODE PCOMM  PID    PPID   RET ARGS
 	postProcess.outStreams[0].Write([]byte("200000 200000   0 /usr/bin/wget\n"))
 
 	expected = `
-NODE PCOMM  PID    PPID   RET ARGS
-[ 0] wget   200000 200000   0 /usr/bin/wget
+PCOMM  PID    PPID   RET ARGS
+wget   200000 200000   0 /usr/bin/wget
 `
 	if "\n"+string(mock.output) != expected {
 		t.Fatalf("%v != %v", string(mock.output), expected)
@@ -107,10 +107,10 @@ func TestMultipleNodes(t *testing.T) {
 	postProcess.outStreams[2].Write([]byte("0 /usr/bin/mkdir /tmp/install.sh.10\n"))
 
 	expected := `
-NODE PCOMM  PID    PPID   RET ARGS
-[ 0] curl   100000 100000   0 /usr/bin/curl
-[ 1] wget   200000 200000   0 /usr/bin/wget
-[ 2] mkdir  199679 199678   0 /usr/bin/mkdir /tmp/install.sh.10
+PCOMM  PID    PPID   RET ARGS
+curl   100000 100000   0 /usr/bin/curl
+wget   200000 200000   0 /usr/bin/wget
+mkdir  199679 199678   0 /usr/bin/mkdir /tmp/install.sh.10
 `
 	if "\n"+string(mock.output) != expected {
 		t.Fatalf("%v != %v", string(mock.output), expected)

--- a/gadget.Dockerfile
+++ b/gadget.Dockerfile
@@ -32,11 +32,11 @@ FROM docker.io/kinvolk/traceloop:202006050210553a5730 as traceloop
 
 # Main gadget image
 
-# BCC built from:
-# https://github.com/kinvolk/bcc/commit/321c9c979889abce48d0844b3d539ec9a01e6f3c
+# BCC built from the gadget branch in the kinvolk/bcc fork:
+# https://github.com/kinvolk/bcc/commit/c5ad55e0067b4d87e503f80367066c5ae1d7acac
 # See BCC section in docs/CONTRIBUTING.md for further details.
 
-FROM quay.io/kinvolk/bcc:321c9c979889abce48d0844b3d539ec9a01e6f3c-focal-release
+FROM quay.io/kinvolk/bcc:c5ad55e0067b4d87e503f80367066c5ae1d7acac-focal-release
 
 RUN set -ex; \
 	export DEBIAN_FRONTEND=noninteractive; \


### PR DESCRIPTION
This PR extends the gadgets to print information about the pod & container where the event happened. 

The gadget tracer manager creates an eBPF map where it saves all the details of the container. The different gadgets then perform a lookup in this map to get the information about the container and print it. This PR also changes how the node name is printed, now the full name (instead of just an integer is printed). 

Example of the output for the execsnoop gadget
```
$ ./kubectl-gadget-linux-amd64 execsnoop 
NODE             NAMESPACE        PODNAME          CONTAINERNAME   PCOMM            PID    PPID   RET ARGS
127.0.0.1        default          pod2             pod2            ping             227616 53305    0 /bin/ping 8.8.8.8
127.0.0.1        default          pod2             pod2            cat              227719 53305    0 /bin/cat /dev/null
^C
Terminating...
```

Example of output for the opensnoop gadget:
```
$ ./kubectl-gadget-linux-amd64 opensnoop 
NODE             NAMESPACE        PODNAME          CONTAINERNAME   PID    COMM               FD ERR PATH
127.0.0.1        default          pod              pod             380870 cat                 3   0 /etc/passwd
127.0.0.1        default          pod              pod             36996  sh                  3   0 /etc/passwd
127.0.0.1        default          pod2             pod2            380520 sh                  3   0 /
127.0.0.1        default          pod2             pod2            380520 sh                  3   0 /etc/
127.0.0.1        default          pod2             pod2            380520 sh                  3   0 /root/.ash_history
127.0.0.1        default          pod2             pod2            380961 cat                -1   2 /etc/host
127.0.0.1        default          pod2             pod2            380520 sh                  3   0 /etc/passwd
^C
Terminating...
```

Changes in bcc are available here -> https://github.com/kinvolk/bcc/pull/1

TODO:
- [x] Change BCC container image tag after https://github.com/kinvolk/bcc/pull/1 is merged
