### PR TITLE
Implement execsnoop tracer

### DIFF
--- a/cmd/kubectl-gadget/bcck8s.go
+++ b/cmd/kubectl-gadget/bcck8s.go
@@ -21,7 +21,6 @@ import (
 	"io"
 	"os"
 	"os/signal"
-	"strconv"
 	"strings"
 	"sync/atomic"
 	"syscall"
@@ -170,7 +169,6 @@ type postProcess struct {
 }
 
 type postProcessSingle struct {
-	nodeShort        string
 	orig             io.Writer
 	firstLine        bool
 	firstLinePrinted *uint64
@@ -186,7 +184,6 @@ func newPostProcess(n int, outStream io.Writer, errStream io.Writer) *postProces
 
 	for i := 0; i < n; i++ {
 		p.outStreams[i] = &postProcessSingle{
-			nodeShort:        " " + strconv.Itoa(i),
 			orig:             outStream,
 			firstLine:        true,
 			firstLinePrinted: &p.firstLinePrinted,
@@ -194,7 +191,6 @@ func newPostProcess(n int, outStream io.Writer, errStream io.Writer) *postProces
 		}
 
 		p.errStreams[i] = &postProcessSingle{
-			nodeShort:        "E" + strconv.Itoa(i),
 			orig:             errStream,
 			firstLine:        false,
 			firstLinePrinted: &p.firstLinePrinted,
@@ -206,7 +202,6 @@ func newPostProcess(n int, outStream io.Writer, errStream io.Writer) *postProces
 }
 
 func (post *postProcessSingle) Write(p []byte) (n int, err error) {
-	prefix := "[" + post.nodeShort + "] "
 	asStr := post.buffer + string(p)
 
 	lines := strings.Split(asStr, "\n")
@@ -216,15 +211,14 @@ func (post *postProcessSingle) Write(p []byte) (n int, err error) {
 
 	// Print lines with prefix but the last one
 	for _, line := range lines[0 : len(lines)-1] {
+		// Skip printing the header multiple times
 		if post.firstLine {
 			post.firstLine = false
-			if atomic.AddUint64(post.firstLinePrinted, 1) == 1 {
-				prefix = "NODE "
-			} else {
-				continue // ignore this line, somebody else already printed it
+			if atomic.AddUint64(post.firstLinePrinted, 1) != 1 {
+				continue
 			}
 		}
-		fmt.Fprintf(post.orig, "%s\n", prefix+line)
+		fmt.Fprintf(post.orig, "%s\n", line)
 	}
 
 	post.buffer = lines[len(lines)-1] // Buffer last line to print in next iteration
@@ -323,12 +317,10 @@ func bccCmd(subCommand, bccScript string) func(*cobra.Command, []string) {
 
 		postProcess := newPostProcess(len(nodes.Items), os.Stdout, os.Stderr)
 
-		fmt.Printf("Node numbers:")
 		for i, node := range nodes.Items {
 			if nodeParam != "" && node.Name != nodeParam {
 				continue
 			}
-			fmt.Printf(" %d = %s", i, node.Name)
 			go func(nodeName string, index int) {
 				cmd := fmt.Sprintf("exec /opt/bcck8s/bcc-wrapper.sh --tracerid %s --gadget %s %s %s %s %s -- %s",
 					tracerId, bccScript, labelFilter, namespaceFilter, podnameFilter, containernameFilter, gadgetParams)
@@ -344,7 +336,6 @@ func bccCmd(subCommand, bccScript string) func(*cobra.Command, []string) {
 				}
 			}(node.Name, i) // node.Name is invalidated by the above for loop, causes races
 		}
-		fmt.Println()
 
 		select {
 		case <-sigs:

--- a/cmd/kubectl-gadget/bcck8s_test.go
+++ b/cmd/kubectl-gadget/bcck8s_test.go
@@ -37,7 +37,7 @@ func TestPostProcessFirstLineOutStream(t *testing.T) {
 	postProcess.outStreams[1].Write([]byte("PCOMM  PID    PPID   RET ARGS\n"))
 
 	expected := `
-NODE PCOMM  PID    PPID   RET ARGS
+PCOMM  PID    PPID   RET ARGS
 `
 	if "\n"+string(mock.output) != expected {
 		t.Fatalf("%v != %v", string(mock.output), expected)
@@ -54,8 +54,8 @@ func TestPostProcessFirstLineErrStream(t *testing.T) {
 	postProcess.errStreams[1].Write([]byte("error in node1\n"))
 
 	expected := `
-[E0] error in node0
-[E1] error in node1
+error in node0
+error in node1
 `
 	if "\n"+string(mock.output) != expected {
 		t.Fatalf("%v != %v", string(mock.output), expected)
@@ -71,7 +71,7 @@ func TestPostProcessMultipleLines(t *testing.T) {
 
 	postProcess.outStreams[0].Write([]byte("wget   "))
 	expected = `
-NODE PCOMM  PID    PPID   RET ARGS
+PCOMM  PID    PPID   RET ARGS
 `
 	if "\n"+string(mock.output) != expected {
 		t.Fatalf("%v != %v", string(mock.output), expected)
@@ -80,8 +80,8 @@ NODE PCOMM  PID    PPID   RET ARGS
 	postProcess.outStreams[0].Write([]byte("200000 200000   0 /usr/bin/wget\n"))
 
 	expected = `
-NODE PCOMM  PID    PPID   RET ARGS
-[ 0] wget   200000 200000   0 /usr/bin/wget
+PCOMM  PID    PPID   RET ARGS
+wget   200000 200000   0 /usr/bin/wget
 `
 	if "\n"+string(mock.output) != expected {
 		t.Fatalf("%v != %v", string(mock.output), expected)
@@ -107,10 +107,10 @@ func TestMultipleNodes(t *testing.T) {
 	postProcess.outStreams[2].Write([]byte("0 /usr/bin/mkdir /tmp/install.sh.10\n"))
 
 	expected := `
-NODE PCOMM  PID    PPID   RET ARGS
-[ 0] curl   100000 100000   0 /usr/bin/curl
-[ 1] wget   200000 200000   0 /usr/bin/wget
-[ 2] mkdir  199679 199678   0 /usr/bin/mkdir /tmp/install.sh.10
+PCOMM  PID    PPID   RET ARGS
+curl   100000 100000   0 /usr/bin/curl
+wget   200000 200000   0 /usr/bin/wget
+mkdir  199679 199678   0 /usr/bin/mkdir /tmp/install.sh.10
 `
 	if "\n"+string(mock.output) != expected {
 		t.Fatalf("%v != %v", string(mock.output), expected)

--- a/gadget-container/gadgettracermanager/controller.go
+++ b/gadget-container/gadgettracermanager/controller.go
@@ -32,10 +32,13 @@ import (
 	gadgetkinvolkiov1alpha1 "github.com/kinvolk/inspektor-gadget/pkg/api/v1alpha1"
 	"github.com/kinvolk/inspektor-gadget/pkg/controllers"
 	"github.com/kinvolk/inspektor-gadget/pkg/gadgets"
-	"github.com/kinvolk/inspektor-gadget/pkg/gadgets/biolatency"
-	networkpolicyadvisor "github.com/kinvolk/inspektor-gadget/pkg/gadgets/networkpolicy"
 	"github.com/kinvolk/inspektor-gadget/pkg/gadgettracermanager"
+
 	//+kubebuilder:scaffold:imports
+
+	"github.com/kinvolk/inspektor-gadget/pkg/gadgets/biolatency"
+	"github.com/kinvolk/inspektor-gadget/pkg/gadgets/execsnoop"
+	networkpolicyadvisor "github.com/kinvolk/inspektor-gadget/pkg/gadgets/networkpolicy"
 )
 
 var (
@@ -61,6 +64,7 @@ func startController(node string, tracerManager *gadgettracermanager.GadgetTrace
 
 	traceFactories := make(map[string]gadgets.TraceFactory)
 	traceFactories["biolatency"] = &biolatency.TraceFactory{}
+	traceFactories["execsnoop"] = &execsnoop.TraceFactory{}
 	traceFactories["network-policy-advisor"] = &networkpolicyadvisor.TraceFactory{}
 
 	if err = (&controllers.TraceReconciler{

--- a/gadget.Dockerfile
+++ b/gadget.Dockerfile
@@ -33,10 +33,10 @@ FROM docker.io/kinvolk/traceloop:202006050210553a5730 as traceloop
 # Main gadget image
 
 # BCC built from:
-# https://github.com/kinvolk/bcc/commit/321c9c979889abce48d0844b3d539ec9a01e6f3c
+# https://github.com/kinvolk/bcc/commit/9ee4930a5becb4e76ca10106e330f4148c7f2569
 # See BCC section in docs/CONTRIBUTING.md for further details.
 
-FROM quay.io/kinvolk/bcc:321c9c979889abce48d0844b3d539ec9a01e6f3c-focal-release
+FROM quay.io/kinvolk/bcc:9ee4930a5becb4e76ca10106e330f4148c7f2569-focal-release
 
 RUN set -ex; \
 	export DEBIAN_FRONTEND=noninteractive; \

--- a/gadget.Dockerfile
+++ b/gadget.Dockerfile
@@ -33,10 +33,10 @@ FROM docker.io/kinvolk/traceloop:202006050210553a5730 as traceloop
 # Main gadget image
 
 # BCC built from:
-# https://github.com/kinvolk/bcc/commit/9ee4930a5becb4e76ca10106e330f4148c7f2569
+# https://github.com/kinvolk/bcc/commit/8813c58718518aeace8f580f06bfece5ccff4985
 # See BCC section in docs/CONTRIBUTING.md for further details.
 
-FROM quay.io/kinvolk/bcc:9ee4930a5becb4e76ca10106e330f4148c7f2569-focal-release
+FROM quay.io/kinvolk/bcc:8813c58718518aeace8f580f06bfece5ccff4985-focal-release
 
 RUN set -ex; \
 	export DEBIAN_FRONTEND=noninteractive; \

--- a/pkg/api/v1alpha1/trace_types.go
+++ b/pkg/api/v1alpha1/trace_types.go
@@ -58,6 +58,10 @@ type TraceSpec struct {
 
 	// OutputMode is "Status" or "File"
 	OutputMode string `json:"outputMode,omitempty"`
+
+	// OutputFile is the path of the file to save the output when OutputMode is
+	// "File"
+	OutputFile string `json:"outputFile,omitempty"`
 }
 
 // TraceStatus defines the observed state of Trace

--- a/pkg/controllers/trace_controller.go
+++ b/pkg/controllers/trace_controller.go
@@ -172,7 +172,7 @@ func (r *TraceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 	}
 
 	// For now, only support output in the TraceStatus field
-	if trace.Spec.OutputMode != "Status" {
+	if trace.Spec.OutputMode != "Status" && trace.Spec.OutputMode != "File" {
 		log.Errorf("Unsupported OutputMode: %q", trace.Spec.OutputMode)
 		return ctrl.Result{}, nil
 	}

--- a/pkg/gadgets/execsnoop/gadget.go
+++ b/pkg/gadgets/execsnoop/gadget.go
@@ -1,0 +1,145 @@
+// Copyright 2019-2021 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package execsnoop
+
+import (
+	"fmt"
+	"os/exec"
+	"sync"
+	"syscall"
+
+	log "github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/types"
+
+	gadgetv1alpha1 "github.com/kinvolk/inspektor-gadget/pkg/api/v1alpha1"
+	"github.com/kinvolk/inspektor-gadget/pkg/gadgets"
+)
+
+type Trace struct {
+	started bool
+	cmd     *exec.Cmd
+}
+
+type TraceFactory struct {
+	mu     sync.Mutex
+	traces map[string]*Trace
+}
+
+func (f *TraceFactory) LookupOrCreate(name types.NamespacedName) gadgets.Trace {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.traces == nil {
+		f.traces = make(map[string]*Trace)
+	}
+	trace, ok := f.traces[name.String()]
+	if ok {
+		return trace
+	}
+	trace = &Trace{}
+	f.traces[name.String()] = trace
+
+	return trace
+}
+
+func (f *TraceFactory) Delete(name types.NamespacedName) error {
+	log.Infof("Deleting %s", name.String())
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	t, ok := f.traces[name.String()]
+	if !ok {
+		log.Infof("Deleting %s: does not exist", name.String())
+		return nil
+	}
+	if t.started {
+		t.cmd.Process.Kill()
+		t.cmd.Wait()
+	}
+	delete(f.traces, name.String())
+	return nil
+}
+
+func (t *Trace) Operation(trace *gadgetv1alpha1.Trace, operation string, params map[string]string) {
+	if trace.ObjectMeta.Namespace != gadgets.TRACE_DEFAULT_NAMESPACE {
+		trace.Status.OperationError = fmt.Sprintf("This gadget only accepts operations on traces in the %s namespace", gadgets.TRACE_DEFAULT_NAMESPACE)
+		return
+	}
+	switch operation {
+	case "start":
+		t.start(trace)
+	case "stop":
+		t.stop(trace)
+	default:
+		trace.Status.OperationError = fmt.Sprintf("Unknown operation %q", operation)
+	}
+}
+
+func (t *Trace) start(trace *gadgetv1alpha1.Trace) {
+	if t.started {
+		trace.Status.OperationError = ""
+		trace.Status.State = "Started"
+		return
+	}
+
+	if trace.Spec.OutputMode != "File" {
+		trace.Status.OperationError = fmt.Sprintf("Output mode %q not supported for execsnoop", trace.Spec.OutputMode)
+		trace.Status.State = ""
+		return
+	}
+
+	if trace.Spec.OutputFile == "" {
+		trace.Status.OperationError = "OutputFile is missing"
+		trace.Status.State = ""
+		return
+	}
+
+	mntnsMapPath := gadgets.TracePinPath(trace.Namespace, trace.Name)
+
+	t.cmd = exec.Command("/usr/share/bcc/tools/execsnoop", "--json",
+		"--mntnsmap", mntnsMapPath, "--file", trace.Spec.OutputFile)
+	err := t.cmd.Start()
+	if err != nil {
+		trace.Status.OperationError = fmt.Sprintf("Failed to start: %s", err)
+		return
+	}
+	t.started = true
+
+	trace.Status.OperationError = ""
+	trace.Status.State = "Started"
+	return
+}
+
+func (t *Trace) stop(trace *gadgetv1alpha1.Trace) {
+	if !t.started {
+		trace.Status.OperationError = "Not started"
+		return
+	}
+	err := t.cmd.Process.Signal(syscall.SIGINT)
+	if err != nil {
+		trace.Status.OperationError = fmt.Sprintf("Failed to send SIGINT to process: %s", err)
+		return
+	}
+
+	err = t.cmd.Wait()
+	if err != nil {
+		trace.Status.OperationError = fmt.Sprintf("Failed to wait for process: %s", err)
+		return
+	}
+	t.cmd = nil
+	t.started = false
+
+	trace.Status.OperationError = ""
+	trace.Status.State = "Completed"
+	return
+}

--- a/pkg/gadgets/helpers.go
+++ b/pkg/gadgets/helpers.go
@@ -29,10 +29,18 @@ const (
 	TRACE_DEFAULT_NAMESPACE = "gadget"
 )
 
+func TraceName(namespace, name string) string {
+	return "trace_" + namespace + "_" + name
+}
+
 func TraceNameFromNamespacedName(n types.NamespacedName) string {
-	return "trace_" + n.Namespace + "_" + n.Name
+	return TraceName(n.Namespace, n.Name)
+}
+
+func TracePinPath(namespace, name string) string {
+	return fmt.Sprintf("%s/%s%s", PIN_PATH, MNTMAP_PREFIX, TraceName(namespace, name))
 }
 
 func TracePinPathFromNamespacedName(n types.NamespacedName) string {
-	return fmt.Sprintf("%s/%s%s", PIN_PATH, MNTMAP_PREFIX, TraceNameFromNamespacedName(n))
+	return TracePinPath(n.Namespace, n.Name)
 }

--- a/pkg/gadgettracermanager/gadgettracermanager.go
+++ b/pkg/gadgettracermanager/gadgettracermanager.go
@@ -19,17 +19,16 @@ import (
 	"crypto/rand"
 	"errors"
 	"fmt"
-	"log"
 	"os"
 	"path/filepath"
 	"sync"
-
-	v1 "k8s.io/api/core/v1"
-	"k8s.io/client-go/tools/cache"
+	"unsafe"
 
 	"github.com/cilium/ebpf"
-
+	log "github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/cache"
 
 	"github.com/kinvolk/inspektor-gadget/pkg/gadgets"
 	pb "github.com/kinvolk/inspektor-gadget/pkg/gadgettracermanager/api"
@@ -58,6 +57,8 @@ type GadgetTracerManager struct {
 	// key is "namespace/podname"
 	// value is an set of containerId
 	containerIDsByKey map[string]map[string]struct{}
+
+	containersMap *ebpf.Map
 }
 
 type tracer struct {
@@ -67,6 +68,20 @@ type tracer struct {
 
 	cgroupIdSetMap *ebpf.Map
 	mntnsSetMap    *ebpf.Map
+}
+
+const (
+	NAME_MAX_LENGTH     = 256
+	NAME_MAX_CHARACTERS = 255
+)
+
+// struct container needs to be kept in sync with the same struct from
+// pkg/gadgettracermanager/gadget-tracer-manager-maps.h
+type container struct {
+	ContainerID         [NAME_MAX_LENGTH]byte
+	KubernetesNamespace [NAME_MAX_LENGTH]byte
+	KubernetesPod       [NAME_MAX_LENGTH]byte
+	KubernetesContainer [NAME_MAX_LENGTH]byte
 }
 
 func containerSelectorMatches(s *pb.ContainerSelector, c *pb.ContainerDefinition) bool {
@@ -212,6 +227,7 @@ func (g *GadgetTracerManager) AddContainer(ctx context.Context, containerDefinit
 	}
 
 	g.containers[containerDefinition.ContainerId] = *containerDefinition
+	g.addContainerInMap(*containerDefinition)
 	return &pb.AddContainerResponse{}, nil
 }
 
@@ -234,6 +250,7 @@ func (g *GadgetTracerManager) RemoveContainer(ctx context.Context, containerDefi
 		}
 	}
 
+	g.deleteContainerFromMap(c)
 	delete(g.containers, containerDefinition.ContainerId)
 	return &pb.RemoveContainerResponse{}, nil
 }
@@ -297,6 +314,62 @@ func (g *GadgetTracerManager) run() {
 	}
 }
 
+// createContainersMap creates a global map /sys/fs/bpf/gadget/containers
+// exposing container details for each mount namespace.
+//
+// This makes it possible for gadgets to access that information and
+// display it directly from the BPF code. Example of such code:
+//
+//     struct container *container_entry;
+//     container_entry = bpf_map_lookup_elem(&containers, &mntns_id);
+//
+// See usage in gadget-container/gadgets/collector-process/bpf/collector-process.c
+//
+// External tools such as tracee or bpftrace could also benefit from this just
+// by using this "containers" map (other interaction with Inspektor Gadget is
+// not necessary for this).
+func (g *GadgetTracerManager) createContainersMap() error {
+	// Create and pin BPF map
+	containersMapSpec := &ebpf.MapSpec{
+		Name:       "containers",
+		Type:       ebpf.Hash,
+		KeySize:    8,
+		ValueSize:  uint32(unsafe.Sizeof(container{})),
+		MaxEntries: 1024,
+		Pinning:    ebpf.PinByName,
+	}
+	var err error
+	log.Printf("Creating BPF map: %s/%s", gadgets.PIN_PATH, containersMapSpec.Name)
+	g.containersMap, err = ebpf.NewMapWithOptions(containersMapSpec, ebpf.MapOptions{PinPath: gadgets.PIN_PATH})
+	if err != nil {
+		return fmt.Errorf("error creating containers map: %w", err)
+	}
+	return nil
+}
+
+func (g *GadgetTracerManager) addContainerInMap(c pb.ContainerDefinition) {
+	if g.containersMap == nil || c.Mntns == 0 {
+		return
+	}
+	mntnsC := uint64(c.Mntns)
+
+	val := container{}
+	copy(val.ContainerID[:NAME_MAX_CHARACTERS], []byte(c.ContainerId))
+	copy(val.KubernetesNamespace[:NAME_MAX_CHARACTERS], []byte(c.Namespace))
+	copy(val.KubernetesPod[:NAME_MAX_CHARACTERS], []byte(c.Podname))
+	copy(val.KubernetesContainer[:NAME_MAX_CHARACTERS], []byte(c.ContainerName))
+
+	g.containersMap.Put(mntnsC, val)
+}
+
+func (g *GadgetTracerManager) deleteContainerFromMap(c pb.ContainerDefinition) {
+	if g.containersMap == nil || c.Mntns == 0 {
+		return
+	}
+	mntnsC := uint64(c.Mntns)
+	g.containersMap.Delete(mntnsC)
+}
+
 func NewServerWithPodInformer(nodeName string) (*GadgetTracerManager, error) {
 	if err := initServer(); err != nil {
 		return nil, err
@@ -324,6 +397,9 @@ func NewServerWithPodInformer(nodeName string) (*GadgetTracerManager, error) {
 		containerIDsByKey: make(map[string]map[string]struct{}),
 		k8sClient:         k8sClient,
 	}
+	if err = g.createContainersMap(); err != nil {
+		return nil, err
+	}
 
 	go g.run()
 
@@ -349,6 +425,9 @@ func NewServer(nodeName string) (*GadgetTracerManager, error) {
 		tracers:    make(map[string]tracer),
 		k8sClient:  k8sClient,
 	}
+	if err = g.createContainersMap(); err != nil {
+		return nil, err
+	}
 
 	containers, err := k8sClient.ListContainers()
 	if err != nil {
@@ -357,6 +436,7 @@ func NewServer(nodeName string) (*GadgetTracerManager, error) {
 		log.Printf("gadgettracermanager found %d containers: %+v", len(containers), containers)
 		for _, container := range containers {
 			g.containers[container.ContainerId] = container
+			g.addContainerInMap(container)
 		}
 	}
 	return g, nil

--- a/pkg/resources/crd/bases/gadget.kinvolk.io_traces.yaml
+++ b/pkg/resources/crd/bases/gadget.kinvolk.io_traces.yaml
@@ -63,6 +63,10 @@ spec:
                 description: Node is the name of the node on which this trace should
                   run
                 type: string
+              outputFile:
+                description: OutputFile is the path of the file to save the output
+                  when OutputMode is "File"
+                type: string
               outputMode:
                 description: OutputMode is "Status" or "File"
                 type: string

--- a/pkg/resources/samples/trace-execsnoop.yaml
+++ b/pkg/resources/samples/trace-execsnoop.yaml
@@ -1,0 +1,13 @@
+apiVersion: gadget.kinvolk.io/v1alpha1
+kind: Trace
+metadata:
+  name: execsnoop
+  namespace: gadget
+spec:
+  node: "127.0.0.1"
+  gadget: execsnoop
+  filter:
+    namespace: default
+  runMode: Manual
+  outputMode: File
+  outputFile: "/tmp/execsnoop.json"


### PR DESCRIPTION
# Summary

This PR:
- Extends the tracer definition to support a new `File` mode for `OutputMode`
- Implements the Tracer interface for execsnoop

Builds on top of https://github.com/kinvolk/inspektor-gadget/pull/207. 

# How to test

```
# Be sure `node` matches your node!
$ kubectl apply -f pkg/resources/samples/trace-execsnoop.yaml
$ kubectl annotate -n gadget trace/execsnoop gadget.kinvolk.io/operation=start

# execute some new processes in pods running in the default namespace

$ kubectl annotate -n gadget trace/execsnoop gadget.kinvolk.io/operation=stop
$ PODNAME=$(kubectl -n kube-system get pods --selector=k8s-app=gadget --output=jsonpath={.items[0].metadata.name})
$ kubectl -n kube-system exec $PODNAME -- cat /tmp/execsnoop.json
```



