### PR TITLE
go.mod: update cilium/ebpf to include fix for Linux 5.13

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/kinvolk/inspektor-gadget
 
 require (
-	github.com/cilium/ebpf v0.6.2
+	github.com/cilium/ebpf v0.6.3-0.20210726151910-bf9a97c3237e
 	github.com/containerd/nri v0.1.1-0.20210619071632-28f76457b672
 	github.com/docker/docker v17.12.0-ce-rc1.0.20200608131505-3aac5f0bbb5c+incompatible
 	github.com/docker/go-connections v0.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -116,6 +116,8 @@ github.com/cilium/ebpf v0.2.0/go.mod h1:To2CFviqOWL/M0gIMsvSMlqe7em/l1ALkX1PyjrX
 github.com/cilium/ebpf v0.4.0/go.mod h1:4tRaxcgiL706VnOzHOdBlY8IEAIdxINsQBcU4xJJXRs=
 github.com/cilium/ebpf v0.6.2 h1:iHsfF/t4aW4heW2YKfeHrVPGdtYTL4C4KocpM8KTSnI=
 github.com/cilium/ebpf v0.6.2/go.mod h1:4tRaxcgiL706VnOzHOdBlY8IEAIdxINsQBcU4xJJXRs=
+github.com/cilium/ebpf v0.6.3-0.20210726151910-bf9a97c3237e h1:HVWePROc06gro3LIM28FLs4VGGvFAfPKHgASvF98TWs=
+github.com/cilium/ebpf v0.6.3-0.20210726151910-bf9a97c3237e/go.mod h1:4tRaxcgiL706VnOzHOdBlY8IEAIdxINsQBcU4xJJXRs=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=


### PR DESCRIPTION
cilium/ebpf commit [f7c00a7b0e39](https://github.com/cilium/ebpf/commit/f7c00a7b0e39904bf62aa83910b55dd6c82fd834) ("btf: Add support for BTF_KIND_FLOAT") fixes support for Linux 5.13.


This is necessary for the new gadgets coming up:
- Seccomp Policy Advisor
- Process Collector
