### PR TITLE
New Resolver interface for gadgets to call back the GadgetTracerManager

### DIFF
--- a/pkg/controllers/trace_controller.go
+++ b/pkg/controllers/trace_controller.go
@@ -216,7 +216,7 @@ func (r *TraceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 	// Call gadget.Operation()
 	traceBeforeOperation := trace.DeepCopy()
 	patch := client.MergeFrom(traceBeforeOperation)
-	factory.LookupOrCreate(req.NamespacedName).Operation(trace, op, params)
+	factory.LookupOrCreate(req.NamespacedName).Operation(trace, r.TracerManager, op, params)
 	if apiequality.Semantic.DeepEqual(traceBeforeOperation.Status, trace.Status) {
 		log.Info("Gadget completed operation without changing the trace status")
 	} else {

--- a/pkg/controllers/trace_controller_test.go
+++ b/pkg/controllers/trace_controller_test.go
@@ -53,7 +53,7 @@ func (f *FakeFactory) Delete(name types.NamespacedName) error {
 	return nil
 }
 
-func (f *FakeFactory) Operation(trace *gadgetv1alpha1.Trace, operation string, params map[string]string) {
+func (f *FakeFactory) Operation(trace *gadgetv1alpha1.Trace, resolver gadgets.Resolver, operation string, params map[string]string) {
 	f.mu.Lock()
 	key := fmt.Sprintf("operation/%s/%s/%s/",
 		trace.ObjectMeta.Namespace,

--- a/pkg/gadgets/biolatency/gadget.go
+++ b/pkg/gadgets/biolatency/gadget.go
@@ -72,7 +72,7 @@ func (f *TraceFactory) Delete(name types.NamespacedName) error {
 	return nil
 }
 
-func (t *Trace) Operation(trace *gadgetv1alpha1.Trace, operation string, params map[string]string) {
+func (t *Trace) Operation(trace *gadgetv1alpha1.Trace, resolver gadgets.Resolver, operation string, params map[string]string) {
 	if trace.ObjectMeta.Namespace != gadgets.TRACE_DEFAULT_NAMESPACE {
 		trace.Status.OperationError = fmt.Sprintf("This gadget only accepts operations on traces in the %s namespace", gadgets.TRACE_DEFAULT_NAMESPACE)
 		return

--- a/pkg/gadgets/interface.go
+++ b/pkg/gadgets/interface.go
@@ -20,10 +20,21 @@ import (
 )
 
 type Trace interface {
-	Operation(trace *gadgetv1alpha1.Trace, operation string, params map[string]string)
+	Operation(trace *gadgetv1alpha1.Trace, resolver Resolver, operation string, params map[string]string)
 }
 
 type TraceFactory interface {
 	LookupOrCreate(name types.NamespacedName) Trace
 	Delete(name types.NamespacedName) error
+}
+
+type Resolver interface {
+	// LookupMntnsByContainer returns the mount namespace inode of the container
+	// specified in arguments or zero if not found
+	LookupMntnsByContainer(namespace, pod, container string) uint64
+
+	// LookupMntnsByPod returns the mount namespace inodes of all containers
+	// belonging to the pod specified in arguments, indexed by the name of the
+	// containers
+	LookupMntnsByPod(namespace, pod string) map[string]uint64
 }

--- a/pkg/gadgets/networkpolicy/gadget.go
+++ b/pkg/gadgets/networkpolicy/gadget.go
@@ -76,7 +76,7 @@ func (f *TraceFactory) Delete(name types.NamespacedName) error {
 	return nil
 }
 
-func (f *Trace) Operation(trace *gadgetv1alpha1.Trace, operation string, params map[string]string) {
+func (f *Trace) Operation(trace *gadgetv1alpha1.Trace, resolver gadgets.Resolver, operation string, params map[string]string) {
 	if trace.ObjectMeta.Namespace != gadgets.TRACE_DEFAULT_NAMESPACE {
 		trace.Status.OperationError = fmt.Sprintf("This gadget only accepts operations on traces in the %s namespace", gadgets.TRACE_DEFAULT_NAMESPACE)
 		return

--- a/pkg/gadgettracermanager/gadgettracermanager.go
+++ b/pkg/gadgettracermanager/gadgettracermanager.go
@@ -267,6 +267,41 @@ func (g *GadgetTracerManager) RemoveContainer(ctx context.Context, containerDefi
 	return &pb.RemoveContainerResponse{}, nil
 }
 
+// LookupMntnsByContainer returns the mount namespace inode of the container
+// specified in arguments or zero if not found
+func (g *GadgetTracerManager) LookupMntnsByContainer(namespace, pod, container string) uint64 {
+	for _, c := range g.containers {
+		if namespace != c.Namespace {
+			continue
+		}
+		if pod != c.Podname {
+			continue
+		}
+		if container != c.ContainerName {
+			continue
+		}
+		return c.Mntns
+	}
+	return 0
+}
+
+// LookupMntnsByPod returns the mount namespace inodes of all containers
+// belonging to the pod specified in arguments, indexed by the name of the
+// containers
+func (g *GadgetTracerManager) LookupMntnsByPod(namespace, pod string) map[string]uint64 {
+	ret := make(map[string]uint64)
+	for _, c := range g.containers {
+		if namespace != c.Namespace {
+			continue
+		}
+		if pod != c.Podname {
+			continue
+		}
+		ret[c.ContainerName] = c.Mntns
+	}
+	return ret
+}
+
 func (g *GadgetTracerManager) DumpState(ctx context.Context, req *pb.DumpStateRequest) (*pb.Dump, error) {
 	out := "List of containers:\n"
 	for i, c := range g.containers {

--- a/pkg/gadgettracermanager/gadgettracermanager_test.go
+++ b/pkg/gadgettracermanager/gadgettracermanager_test.go
@@ -17,6 +17,7 @@ package gadgettracermanager
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"testing"
 
 	pb "github.com/kinvolk/inspektor-gadget/pkg/gadgettracermanager/api"
@@ -247,5 +248,29 @@ func TestContainer(t *testing.T) {
 	_, ok = g.containers["abcde2"]
 	if !ok {
 		t.Fatalf("Error while checking container %s: not found", "abcde2")
+	}
+
+	// Check content using LookupMntnsByPod
+	mntnsByContainer := g.LookupMntnsByPod("this-namespace", "my-pod")
+	if !reflect.DeepEqual(mntnsByContainer, map[string]uint64{"container0": 55555, "container2": 55557}) {
+		t.Fatalf("Error while looking up: unexpected %v", mntnsByContainer)
+	}
+	mntnsByContainer = g.LookupMntnsByPod("this-namespace", "this-other-pod")
+	if !reflect.DeepEqual(mntnsByContainer, map[string]uint64{}) {
+		t.Fatalf("Error while looking up: unexpected %v", mntnsByContainer)
+	}
+
+	// Check content using LookupMntnsByContainer
+	mntns := g.LookupMntnsByContainer("this-namespace", "my-pod", "container0")
+	if mntns != 55555 {
+		t.Fatalf("Error while looking up container0: unexpected mntns %v", mntns)
+	}
+	mntns = g.LookupMntnsByContainer("this-namespace", "my-pod", "container1")
+	if mntns != 0 {
+		t.Fatalf("Error while looking up container1: unexpected mntns %v", mntns)
+	}
+	mntns = g.LookupMntnsByContainer("this-namespace", "my-pod", "container2")
+	if mntns != 55557 {
+		t.Fatalf("Error while looking up container1: unexpected mntns %v", mntns)
 	}
 }


### PR DESCRIPTION
# New Resolver interface for gadgets to call back the GadgetTracerManager

Before this patch, the process gadgettracermanager started two main independent components:
1. GadgetTracerManager, the gRPC server
2. TraceReconciler, a Controller Manager for the Trace custom resource

The TraceReconciler calls methods on TraceFactory and Trace interfaces.  But sometimes, a Trace needs to do a lookup on the GadgetTracerManager to match a mntns and a container.

This patch passes a GadgetTracerManager reference to the Trace.Operation() method, so it can do lookups. The reference is not passed directly but via a Resolver interface, so it limits the API exposed to gadgets.

## How to use

The seccomp PR #208 will use this.

## Testing done

```
make test
```

## TODO

- [x] Based on #211
- [x] Based on #213