### PR TITLE
Use bcc libbpf-tools

### DIFF
--- a/cmd/kubectl-gadget/bcck8s.go
+++ b/cmd/kubectl-gadget/bcck8s.go
@@ -38,19 +38,19 @@ import (
 var execsnoopCmd = &cobra.Command{
 	Use:   "execsnoop",
 	Short: "Trace new processes",
-	Run:   bccCmd("execsnoop", "/usr/share/bcc/tools/execsnoop"),
+	Run:   bccCmd("execsnoop", "/bin/gadgets/execsnoop"),
 }
 
 var opensnoopCmd = &cobra.Command{
 	Use:   "opensnoop",
 	Short: "Trace open() system calls",
-	Run:   bccCmd("opensnoop", "/usr/share/bcc/tools/opensnoop"),
+	Run:   bccCmd("opensnoop", "/bin/gadgets/opensnoop"),
 }
 
 var bindsnoopCmd = &cobra.Command{
 	Use:   "bindsnoop",
 	Short: "Trace IPv4 and IPv6 bind() system calls",
-	Run:   bccCmd("bindsnoop", "/usr/share/bcc/tools/bindsnoop"),
+	Run:   bccCmd("bindsnoop", "/bin/gadgets/bindsnoop"),
 }
 
 var profileCmd = &cobra.Command{
@@ -68,7 +68,7 @@ var tcptopCmd = &cobra.Command{
 var tcpconnectCmd = &cobra.Command{
 	Use:   "tcpconnect",
 	Short: "Trace TCP connect() system calls",
-	Run:   bccCmd("tcpconnect", "/usr/share/bcc/tools/tcpconnect"),
+	Run:   bccCmd("tcpconnect", "/bin/gadgets/tcpconnect"),
 }
 
 var tcptracerCmd = &cobra.Command{

--- a/cmd/kubectl-gadget/utils.go
+++ b/cmd/kubectl-gadget/utils.go
@@ -95,7 +95,7 @@ func execPod(client *kubernetes.Clientset, node string, podCmd string, cmdStdout
 			Stdin:     false,
 			Stdout:    true,
 			Stderr:    true,
-			TTY:       false,
+			TTY:       true,
 		}, scheme.ParameterCodec)
 
 	exec, err := remotecommand.NewSPDYExecutor(restConfig, "POST", req.URL())
@@ -107,7 +107,7 @@ func execPod(client *kubernetes.Clientset, node string, podCmd string, cmdStdout
 		Stdin:  nil,
 		Stdout: cmdStdout,
 		Stderr: cmdStderr,
-		Tty:    false,
+		Tty:    true,
 	})
 	return err
 }

--- a/gadget-container/entrypoint.sh
+++ b/gadget-container/entrypoint.sh
@@ -156,6 +156,26 @@ fi
 
 ## Hooks Ends ##
 
+# Choose what kind of tools based on the configuration detected
+TOOLS_MODE="$INSPEKTOR_GADGET_OPTION_TOOLS_MODE"
+
+if [ "$TOOLS_MODE" = "auto" ] || [ -z "$TOOLS_MODE" ] ; then
+  if test -f /sys/kernel/btf/vmlinux; then
+    echo "BTF is available: Using CO-RE based tools"
+    TOOLS_MODE="core"
+  else
+    echo "BTF is not available: Using standard tools"
+    TOOLS_MODE="standard"
+  fi
+fi
+
+# Create symlinks for tools according to the value of TOOLS_MODE
+if [ "$TOOLS_MODE" = "core" ] ; then
+  ln -s /bin/libbpf-tools/ /bin/gadgets
+elif [ "$TOOLS_MODE" = "standard" ] ; then
+  ln -s /usr/share/bcc/tools/ /bin/gadgets
+fi
+
 echo "Starting the Gadget Tracer Manager in the background..."
 rm -f /run/gadgettracermanager.socket
 /bin/gadgettracermanager -serve $POD_INFORMER_PARAM -controller &

--- a/gadget.Dockerfile
+++ b/gadget.Dockerfile
@@ -33,10 +33,10 @@ FROM docker.io/kinvolk/traceloop:202006050210553a5730 as traceloop
 # Main gadget image
 
 # BCC built from the gadget branch in the kinvolk/bcc fork:
-# https://github.com/kinvolk/bcc/commit/8f44a6d076ab04f36ef88dd7f90620708ebc1f6e
+# https://github.com/kinvolk/bcc/commit/fca607f192d6c71ed66baa87178e3aecfab31faa
 # See BCC section in docs/CONTRIBUTING.md for further details.
 
-FROM quay.io/kinvolk/bcc:8f44a6d076ab04f36ef88dd7f90620708ebc1f6e-focal-release
+FROM quay.io/kinvolk/bcc:fca607f192d6c71ed66baa87178e3aecfab31faa-focal-release
 
 RUN set -ex; \
 	export DEBIAN_FRONTEND=noninteractive; \


### PR DESCRIPTION
This PR allows to use the libbpf-based tools from BCC when BTF is available in the host. The entrypoint script of the gadget container checks if BTF is available and then it creates symlinks to the right tools to be used (standard/python vs libbpf-based). It doesn't change anything from the user POV, the tools continue to work the same. 

This PR is rather small as most of the changes needed to make it work are in the BCC repo: https://github.com/kinvolk/bcc/pull/5. 

TODO:
- [x] Is the current way to detect BTF available enough? 
- [x] Should we provide a deploy flag to choose between the kind of tools to use? (auto / core / standard)



