### PR TITLE
GitHub Action: fix cache on external dependencies

### DIFF
--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -25,12 +25,14 @@ jobs:
     - name: Cache external deps
       uses: actions/cache@v2
       with:
+        # - Tests (tests.mk) need etcd, kube-apiserver, kubectl
+        # - Generating code (crd.mk) needs controller-gen
         path: |
-          bin/etcd            # For tests, by tests.mk
-          bin/kube-apiserver  # ditto
-          bin/kubectl         # ditto
-          bin/controller-gen  # For generating code, by crd.mk
-        key: ${{ runner.os }}-${{ hashFiles('tests.mk', 'crd.mk') }}
+          bin/etcd
+          bin/kube-apiserver
+          bin/kubectl
+          bin/controller-gen
+        key: ${{ runner.os }}-${{ hashFiles('tests.mk', 'crd.mk', '.github/workflows/inspektor-gadget.yml') }}
 
     - name: Cache deb packages
       uses: actions/cache@v2


### PR DESCRIPTION
Comments in yaml strings are not removed, so the paths were not valid.

See example of mistaken cache handling:
https://github.com/kinvolk/inspektor-gadget/runs/3235399299?check_suite_focus=true

```
Received 22 of 22 (100.0%), 0.0 MBs/sec
Cache Size: ~0 MB (22 B)
/usr/bin/tar --use-compress-program zstd -d -xf /home/runner/work/_temp/db306363-4ac2-4195-8a9a-86767fdeeebd/cache.tzst -P -C /home/runner/work/inspektor-gadget/inspektor-gadget
Cache restored successfully
Cache restored from key: Linux-f0c82c52096f1cb0197fae8668e8e32debc2d25f7dbbc9523abc34da004b1b8d
Cache deb packages
```

```
Post job cleanup.
Cache hit occurred on the primary key Linux-f0c82c52096f1cb0197fae8668e8e32debc2d25f7dbbc9523abc34da004b1b8d, not saving cache.
Complete job
```

After this patch, the cache works in the following way:

1. On cache miss
https://github.com/kinvolk/inspektor-gadget/runs/3240253038?check_suite_focus=true
```
Cache not found for input keys: Linux-2411914435e5529c713b3fdbf70e69eff41a6232d3a300a244219b2062ed6f74
```

```
Post job cleanup.
/usr/bin/tar --posix --use-compress-program zstd -T0 -cf cache.tzst -P -C /home/runner/work/inspektor-gadget/inspektor-gadget --files-from manifest.txt
Cache Size: ~52 MB (54847875 B)
Cache saved successfully
Cache saved with key: Linux-2411914435e5529c713b3fdbf70e69eff41a6232d3a300a244219b2062ed6f74
Complete job
```

2. On cache hit
https://github.com/kinvolk/inspektor-gadget/runs/3240332451?check_suite_focus=true
```
Received 54847875 of 54847875 (100.0%), 92.9 MBs/sec
Cache Size: ~52 MB (54847875 B)
/usr/bin/tar --use-compress-program zstd -d -xf /home/runner/work/_temp/0451edee-8a08-43f4-abb1-daa53173a4a9/cache.tzst -P -C /home/runner/work/inspektor-gadget/inspektor-gadget
Cache restored successfully
Cache restored from key: Linux-2411914435e5529c713b3fdbf70e69eff41a6232d3a300a244219b2062ed6f74
```

```
Post job cleanup.
Cache hit occurred on the primary key Linux-2411914435e5529c713b3fdbf70e69eff41a6232d3a300a244219b2062ed6f74, not saving cache.
Complete job
```