### PR TITLE
Use btfhub

### DIFF
--- a/gadget.Dockerfile
+++ b/gadget.Dockerfile
@@ -42,8 +42,8 @@ RUN set -ex; \
 	export DEBIAN_FRONTEND=noninteractive; \
 	apt-get update && \
 	apt-get install -y --no-install-recommends \
-		ca-certificates curl jq && \
-        rmdir /usr/src && ln -sf /host/usr/src /usr/src
+		ca-certificates curl jq wget xz-utils binutils && \
+		rmdir /usr/src && ln -sf /host/usr/src /usr/src
 
 COPY gadget-container/entrypoint.sh gadget-container/cleanup.sh /
 


### PR DESCRIPTION
This PR is an experiment that uses https://github.com/aquasecurity/btfhub to run CO-RE based tools in systems without `CONFIG_DEBUG_INFO_BTF=y`.

## How does it work?

The entrypoint script tries to download the BTF file for the current kernel, if it's successful it creates an ELF file with a .BTF section containing the BTF debug info and stores it at `/boot/vmlinux-$(uname -r)`

## Testing done

I created a test cluster in ubuntu focal (using kubeadm) and tried to run some of the tools. 

```
$ cat /boot/config-$(uname -r) | grep BTF
CONFIG_VIDEO_SONY_BTF_MPX=m
# CONFIG_DEBUG_INFO_BTF is not set

$ kubectl -n kube-system logs $PODNAME 
OS detected: "Ubuntu 20.04.1 LTS"
Kernel detected: 5.4.0-80-generic
bcc detected: 0.21.0-1
Gadget image: docker.io/kinvolk/gadget:mauricio-btf-hub-poc
Deployment options:
INSPEKTOR_GADGET_OPTION_TRACELOOP_LOGLEVEL=info,json
INSPEKTOR_GADGET_OPTION_TRACELOOP=false
INSPEKTOR_GADGET_OPTION_TOOLS_MODE=auto
INSPEKTOR_GADGET_OPTION_HOOK_MODE=auto
Inspektor Gadget version: v0.2.1-115-g16a413c-dirty
Falling back to podinformer hook.
BTF is not available: Trying btfhub
Trying to download vmlinux from https://github.com/aquasecurity/btfhub/raw/main/ubuntu/20.04/5.4.0-80-generic.btf.tar.xz
vmlinux downloaded. Using CO-RE based tools
Starting the Gadget Tracer Manager in the background...
Ready.
time="2021-08-11T01:17:18Z" level=info msg="Creating BPF map: /sys/fs/bpf/gadget/containers"
time="2021-08-11T01:17:18Z" level=info msg="Serving on gRPC socket /run/gadgettracermanager.socket"
time="2021-08-11T01:17:18Z" level=info msg="Starting Pod controller"
time="2021-08-11T01:17:18Z" level=info msg="starting trace controller manager

$ ./kubectl-gadget-linux-amd64 execsnoop
NODE             NAMESPACE        PODNAME          CONTAINERNAME   PCOMM            PID    PPID   RET ARGS
ubuntu-focal     default          mypod            mypod           cat              55050  29204    0 /bin/cat /dev/null
```
