### PR TITLE
cmd/kubectl-gadget: do not pass --containersmap to profile

### DIFF
--- a/cmd/kubectl-gadget/bcck8s.go
+++ b/cmd/kubectl-gadget/bcck8s.go
@@ -290,7 +290,7 @@ func bccCmd(subCommand, bccScript string) func(*cobra.Command, []string) {
 		gadgetParams := ""
 
 		// add container info to gadgets that support it
-		if subCommand != "tcptop" {
+		if subCommand != "tcptop" && subCommand != "profile" {
 			gadgetParams = "--containersmap /sys/fs/bpf/gadget/containers"
 		}
 


### PR DESCRIPTION
https://github.com/kinvolk/inspektor-gadget/pull/207 extended the tools to print some extra information about the container and pod names. This feature is not supported by profile, hence when that tool is used the `--containersmap` shouldn't be passed to the tool. 

Reported in https://github.com/kinvolk/inspektor-gadget/pull/217#issuecomment-896172487