### PR TITLE
New DNS gadget

### DIFF
--- a/cmd/kubectl-gadget/collector.go
+++ b/cmd/kubectl-gadget/collector.go
@@ -142,6 +142,6 @@ func collectorCmdRun(subCommand string) func(*cobra.Command, []string) {
 		}
 	}
 	return func(cmd *cobra.Command, args []string) {
-		utils.GenericTraceCommand(subCommand, &collectorParams, args, callback, nil)
+		utils.GenericTraceCommand(subCommand, &collectorParams, args, "Status", callback, nil)
 	}
 }

--- a/cmd/kubectl-gadget/dns.go
+++ b/cmd/kubectl-gadget/dns.go
@@ -1,0 +1,81 @@
+// Copyright 2019-2021 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/kinvolk/inspektor-gadget/cmd/kubectl-gadget/utils"
+	dnstypes "github.com/kinvolk/inspektor-gadget/pkg/gadgets/dns/types"
+)
+
+var (
+	dnsParams utils.CommonFlags
+)
+
+const (
+	FMT_ALL   = "%-16.16s %-16.16s %-30.30s %-9.9s %s"
+	FMT_SHORT = "%-30.30s %-9.9s %s"
+)
+
+var dnsCmd = &cobra.Command{
+	Use:   "dns",
+	Short: "Trace DNS requests",
+	Run: func(cmd *cobra.Command, args []string) {
+		if !dnsParams.JsonOutput {
+			if dnsParams.AllNamespaces {
+				fmt.Printf(FMT_ALL+"\n",
+					"NODE",
+					"NAMESPACE",
+					"POD",
+					"TYPE",
+					"NAME",
+				)
+			} else {
+				fmt.Printf(FMT_SHORT+"\n",
+					"POD",
+					"TYPE",
+					"NAME",
+				)
+			}
+		}
+
+		utils.GenericTraceCommand("dns", &dnsParams, args, "Stream", nil, transformLine)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(dnsCmd)
+	utils.AddCommonFlags(dnsCmd, &dnsParams)
+}
+
+func transformLine(line string) string {
+	event := &dnstypes.Event{}
+	json.Unmarshal([]byte(line), event)
+	if event.Err != "" {
+		return fmt.Sprintf("Error on node %s: %s: %s", event.Node, event.Notice, event.Err)
+	}
+	if event.Notice != "" {
+		return fmt.Sprintf("Notice on node %s %s/%s: %s", event.Node, event.Namespace, event.Pod, event.Notice)
+	}
+	if dnsParams.AllNamespaces {
+		return fmt.Sprintf(FMT_ALL, event.Node, event.Namespace, event.Pod, event.PktType, event.DNSName)
+	} else {
+		return fmt.Sprintf(FMT_SHORT, event.Pod, event.PktType, event.DNSName)
+	}
+}

--- a/cmd/kubectl-gadget/utils/trace.go
+++ b/cmd/kubectl-gadget/utils/trace.go
@@ -81,7 +81,8 @@ func GenericTraceCommand(
 	subCommand string,
 	params *CommonFlags,
 	args []string,
-	displayResults func(contextLogger *log.Entry, nodes *corev1.NodeList, results *gadgetv1alpha1.TraceList),
+	outputMode string,
+	customResultsDisplay func(contextLogger *log.Entry, nodes *corev1.NodeList, results *gadgetv1alpha1.TraceList),
 	transformLine func(string) string,
 ) {
 
@@ -161,7 +162,7 @@ func GenericTraceCommand(
 					Labels:        labelsSelector,
 				},
 				RunMode:    "Manual",
-				OutputMode: "Status",
+				OutputMode: outputMode,
 			},
 		}
 
@@ -248,10 +249,13 @@ RetryLoop:
 		break RetryLoop
 	}
 
-	if displayResults == nil {
+	if customResultsDisplay == nil {
+		if outputMode != "Stream" {
+			panic(fmt.Errorf("OutputMode=%q needs a custom display function", outputMode))
+		}
 		genericStreamsDisplay(contextLogger, client, params, &results, transformLine)
 	} else {
-		displayResults(contextLogger, nodes, &results)
+		customResultsDisplay(contextLogger, nodes, &results)
 	}
 	deleteTraces(contextLogger, traceRestClient, traceID)
 }

--- a/gadget-container/gadgettracermanager/controller.go
+++ b/gadget-container/gadgettracermanager/controller.go
@@ -33,6 +33,7 @@ import (
 	"github.com/kinvolk/inspektor-gadget/pkg/controllers"
 	"github.com/kinvolk/inspektor-gadget/pkg/gadgets"
 	"github.com/kinvolk/inspektor-gadget/pkg/gadgets/biolatency"
+	"github.com/kinvolk/inspektor-gadget/pkg/gadgets/dns"
 	networkpolicyadvisor "github.com/kinvolk/inspektor-gadget/pkg/gadgets/networkpolicy"
 	processcollector "github.com/kinvolk/inspektor-gadget/pkg/gadgets/process-collector"
 	"github.com/kinvolk/inspektor-gadget/pkg/gadgets/seccomp"
@@ -50,6 +51,7 @@ func startController(node string, tracerManager *gadgettracermanager.GadgetTrace
 
 	traceFactories := make(map[string]gadgets.TraceFactory)
 	traceFactories["biolatency"] = &biolatency.TraceFactory{}
+	traceFactories["dns"] = &dns.TraceFactory{}
 	traceFactories["process-collector"] = &processcollector.TraceFactory{}
 	traceFactories["socket-collector"] = &socketcollector.TraceFactory{}
 	traceFactories["seccomp"] = &seccomp.TraceFactory{}

--- a/pkg/api/v1alpha1/trace_types.go
+++ b/pkg/api/v1alpha1/trace_types.go
@@ -56,13 +56,13 @@ type TraceSpec struct {
 	// pod name, labels or container name
 	Filter *ContainerFilter `json:"filter,omitempty"`
 
-	// OutputMode is "Status", "File" or "ExternalResource"
-	// +kubebuilder:validation:Enum=Status;File;ExternalResource
+	// OutputMode is "Status", "Stream, ""File" or "ExternalResource"
+	// +kubebuilder:validation:Enum=Status;Stream;File;ExternalResource
 	OutputMode string `json:"outputMode,omitempty"`
 
 	// Output allows a gadget to output the results in the specified
 	// location.
-	// * With OutputMode=Status, Output is unused
+	// * With OutputMode=Status|Stream, Output is unused
 	// * With OutputMode=File, Output specifies the file path
 	// * With OutputMode=ExternalResource, Output specifies the external
 	//   resource (such as

--- a/pkg/gadgets/dns/gadget.go
+++ b/pkg/gadgets/dns/gadget.go
@@ -1,0 +1,265 @@
+// Copyright 2019-2021 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dns
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+
+	log "github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	gadgetv1alpha1 "github.com/kinvolk/inspektor-gadget/pkg/api/v1alpha1"
+	"github.com/kinvolk/inspektor-gadget/pkg/gadgets"
+	dnstracer "github.com/kinvolk/inspektor-gadget/pkg/gadgets/dns/tracer"
+	dnstypes "github.com/kinvolk/inspektor-gadget/pkg/gadgets/dns/types"
+	"github.com/kinvolk/inspektor-gadget/pkg/gadgettracermanager/containerutils"
+	"github.com/kinvolk/inspektor-gadget/pkg/gadgettracermanager/pubsub"
+	eventtypes "github.com/kinvolk/inspektor-gadget/pkg/types"
+)
+
+type Trace struct {
+	resolver gadgets.Resolver
+	client   client.Client
+
+	started bool
+
+	tracer *dnstracer.Tracer
+}
+
+type TraceFactory struct {
+	gadgets.BaseFactory
+
+	mu     sync.Mutex
+	traces map[string]*Trace
+}
+
+func (f *TraceFactory) SupportsOutputMode(outputMode string) bool {
+	return outputMode == "Stream"
+}
+
+func (f *TraceFactory) LookupOrCreate(name types.NamespacedName) gadgets.Trace {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.traces == nil {
+		f.traces = make(map[string]*Trace)
+	}
+	trace, ok := f.traces[name.String()]
+	if ok {
+		return trace
+	}
+	trace = &Trace{
+		client:   f.Client,
+		resolver: f.Resolver,
+	}
+	f.traces[name.String()] = trace
+
+	return trace
+}
+
+func (f *TraceFactory) Delete(name types.NamespacedName) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	t, ok := f.traces[name.String()]
+	if !ok {
+		log.Infof("Deleting %s: does not exist", name.String())
+		return nil
+	}
+	if t.started {
+		t.resolver.Unsubscribe(genPubSubKey(name.Namespace, name.Name))
+		t.tracer.Close()
+		t.tracer = nil
+	}
+	log.Infof("Deleting %s", name.String())
+	delete(f.traces, name.String())
+	return nil
+}
+
+func (t *Trace) Operation(trace *gadgetv1alpha1.Trace,
+	operation string,
+	params map[string]string) {
+
+	if trace.ObjectMeta.Namespace != gadgets.TRACE_DEFAULT_NAMESPACE {
+		trace.Status.OperationError = fmt.Sprintf("This gadget only accepts operations on traces in the %s namespace", gadgets.TRACE_DEFAULT_NAMESPACE)
+		return
+	}
+	switch operation {
+	case "start":
+		t.Start(trace)
+	case "stop":
+		t.Stop(trace)
+	default:
+		trace.Status.OperationError = fmt.Sprintf("Unknown operation %q", operation)
+	}
+}
+
+type pubSubKey string
+
+func genPubSubKey(namespace, name string) pubSubKey {
+	return pubSubKey(fmt.Sprintf("gadget/dns/%s/%s", namespace, name))
+}
+
+func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
+	if t.started {
+		trace.Status.OperationError = ""
+		trace.Status.Output = ""
+		trace.Status.State = "Started"
+		return
+	}
+
+	var err error
+	t.tracer, err = dnstracer.NewTracer()
+	if err != nil {
+		trace.Status.OperationError = fmt.Sprintf("Failed to start dns tracer: %s", err)
+		return
+	}
+
+	printEvent := func(notice, err, key, name, pktType string) string {
+		event := &dnstypes.Event{
+			Event: eventtypes.Event{
+				Notice: notice,
+				Err:    err,
+				Node:   trace.Spec.Node,
+			},
+			DNSName: name,
+			PktType: pktType,
+		}
+
+		keyParts := strings.SplitN(key, "/", 2)
+		if len(keyParts) == 2 {
+			event.Namespace = keyParts[0]
+			event.Pod = keyParts[1]
+		} else if key == "host" {
+			event.Host = true
+		} else if key != "" {
+			event.Err = fmt.Sprintf("unknown key %s", key)
+		}
+
+		b, e := json.Marshal(event)
+		if e != nil {
+			return `{"err": "cannot marshal event"}`
+		}
+		return string(b)
+	}
+
+	traceName := gadgets.TraceName(trace.ObjectMeta.Namespace, trace.ObjectMeta.Name)
+
+	newDNSRequestCallback := func(key string) func(name, pktType string) {
+		return func(name, pktType string) {
+			t.resolver.PublishEvent(
+				traceName,
+				printEvent("", "", key, name, pktType),
+			)
+		}
+	}
+
+	genKey := func(namespace, podname string, pid uint32) (key string, err error) {
+		key = namespace + "/" + podname
+
+		var netns1, netns2 uint64
+		netns1, err = containerutils.GetNetNs(int(pid))
+		if err == nil {
+			netns2, err = containerutils.GetNetNs(os.Getpid())
+		}
+		if err == nil {
+			if netns1 == netns2 {
+				key = "host"
+			}
+		}
+		log.Infof("DNS gadget: generate key %q from pod (%q %q pid:%d) (netns:%v host-netns:%v)", key, namespace, podname, pid, netns1, netns2)
+		return key, err
+	}
+
+	attachContainerFunc := func(namespace, podname string, pid uint32) error {
+		key, err := genKey(namespace, podname, pid)
+		errMsg := ""
+		if err == nil {
+			err = t.tracer.Attach(key, pid, newDNSRequestCallback(key))
+		}
+		if err != nil {
+			errMsg = err.Error()
+		}
+		t.resolver.PublishEvent(
+			traceName,
+			printEvent("attaching dns tracer", errMsg, key, "", ""),
+		)
+		return nil
+	}
+
+	detachContainerFunc := func(namespace, podname string, pid uint32) {
+		key, err := genKey(namespace, podname, pid)
+
+		if err == nil {
+			err = t.tracer.Detach(key)
+		}
+		errMsg := ""
+		if err != nil {
+			errMsg = err.Error()
+		}
+		t.resolver.PublishEvent(
+			traceName,
+			printEvent("detaching dns tracer", errMsg, key, "", ""),
+		)
+	}
+
+	containerEventCallback := func(event pubsub.PubSubEvent) {
+		switch event.Type {
+		case pubsub.EVENT_TYPE_ADD_CONTAINER:
+			attachContainerFunc(event.Container.Namespace, event.Container.Podname, event.Container.Pid)
+		case pubsub.EVENT_TYPE_REMOVE_CONTAINER:
+			detachContainerFunc(event.Container.Namespace, event.Container.Podname, event.Container.Pid)
+		}
+	}
+
+	existingContainers := t.resolver.Subscribe(
+		genPubSubKey(trace.ObjectMeta.Namespace, trace.ObjectMeta.Name),
+		*gadgets.ContainerSelectorFromContainerFilter(trace.Spec.Filter),
+		containerEventCallback,
+	)
+
+	for _, c := range existingContainers {
+		err := attachContainerFunc(c.Namespace, c.Podname, c.Pid)
+		if err != nil {
+			log.Warnf("Warning: couldn't attach BPF program: %s", err)
+			break
+		}
+	}
+	t.started = true
+
+	trace.Status.OperationError = ""
+	trace.Status.Output = ""
+	trace.Status.State = "Started"
+	return
+}
+
+func (t *Trace) Stop(trace *gadgetv1alpha1.Trace) {
+	if !t.started {
+		trace.Status.OperationError = "Not started"
+		return
+	}
+
+	t.resolver.Unsubscribe(genPubSubKey(trace.ObjectMeta.Namespace, trace.ObjectMeta.Name))
+	t.tracer.Close()
+	t.tracer = nil
+	t.started = false
+
+	trace.Status.OperationError = ""
+	trace.Status.State = "Stopped"
+	return
+}

--- a/pkg/gadgets/dns/tracer/bpf/Makefile
+++ b/pkg/gadgets/dns/tracer/bpf/Makefile
@@ -1,0 +1,29 @@
+.PHONY: all
+all: dns.o
+
+# See Linux' Makefile: when ARCH is i386 or x86_64, then SRCARCH is x86
+# It needs to match tests in bpf/bpf_tracing.h
+SRCARCH ?= x86
+
+# We need <asm/types.h> and depending on Linux distributions, it is installed
+# at different paths:
+#
+# * Ubuntu, package linux-libc-dev:
+#   /usr/include/x86_64-linux-gnu/asm/types.h
+#
+# * Fedora, package kernel-headers
+#   /usr/include/asm/types.h
+#
+# Since Ubuntu does not install it in a standard path, add a compiler flag for
+# it.
+CLANG_OS_FLAGS=
+ifeq ($(shell grep -oP '^NAME="\K\w+(?=")' /etc/os-release), Ubuntu)
+	CLANG_OS_FLAGS="-I/usr/include/$(shell uname -m)-linux-gnu"
+endif
+
+dns.o: dns.c
+	clang -Werror $(CLANG_OS_FLAGS) -target bpf -O2 -g -c -x c $< -o $@ \
+		-D__KERNEL__ -D__TARGET_ARCH_$(SRCARCH)
+
+clean:
+	rm -f dns.o

--- a/pkg/gadgets/dns/tracer/bpf/dns-common.h
+++ b/pkg/gadgets/dns/tracer/bpf/dns-common.h
@@ -1,0 +1,13 @@
+#ifndef GADGET_DNS_COMMON_H
+#define GADGET_DNS_COMMON_H
+
+// Max DNS name length: 255
+// https://datatracker.ietf.org/doc/html/rfc1034#section-3.1
+#define MAX_DNS_NAME 255
+
+struct event_t {
+	char name[MAX_DNS_NAME];
+	unsigned char pkt_type;
+};
+
+#endif

--- a/pkg/gadgets/dns/tracer/bpf/dns.c
+++ b/pkg/gadgets/dns/tracer/bpf/dns.c
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: GPL-2.0
+/* Copyright (c) 2021 The Inspektor Gadget authors */
+
+#include <linux/bpf.h>
+#include <linux/if_ether.h>
+#include <linux/ip.h>
+#include <linux/in.h>
+#include <linux/udp.h>
+
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_endian.h>
+
+#include "dns-common.h"
+
+#define DNS_OFF (ETH_HLEN + sizeof(struct iphdr) + sizeof(struct udphdr))
+
+/* llvm builtin functions that eBPF C program may use to
+ * emit BPF_LD_ABS and BPF_LD_IND instructions
+ */
+unsigned long long load_byte(void *skb,
+			     unsigned long long off) asm("llvm.bpf.load.byte");
+unsigned long long load_half(void *skb,
+			     unsigned long long off) asm("llvm.bpf.load.half");
+unsigned long long load_word(void *skb,
+			     unsigned long long off) asm("llvm.bpf.load.word");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PERF_EVENT_ARRAY);
+} events SEC(".maps");
+
+// https://datatracker.ietf.org/doc/html/rfc1035#section-4.1.1
+union dnsflags {
+	struct {
+		__u8 rd :1;	// recursion desired
+		__u8 tc :1;	// truncation
+		__u8 aa :1;	// authoritive answer
+		__u8 opcode :4;	// kind of query
+		__u8 qr :1;	// 0=query; 1=response
+
+		__u8 rcode :4;	// response code
+		__u8 z :3;	// reserved
+		__u8 ra :1;	// recursion available
+	};
+	__u16 flags;
+};
+
+struct dnshdr {
+	__u16 id;
+
+	union dnsflags flags;
+
+	__u16 qdcount; // number of question entries
+	__u16 ancount; // number of answer entries
+	__u16 nscount; // number of authority records
+	__u16 arcount; // number of additional records
+};
+
+SEC("socket1")
+int bpf_prog1(struct __sk_buff *skb)
+{
+	// Skip non-IP packets
+	if (load_half(skb, offsetof(struct ethhdr, h_proto)) != ETH_P_IP)
+		return 0;
+
+	// Skip non-UDP packets
+	if (load_byte(skb, ETH_HLEN + offsetof(struct iphdr, protocol)) != IPPROTO_UDP)
+		return 0;
+
+	// Skip non DNS Query packets
+	union dnsflags flags;
+	flags.flags = load_half(skb, DNS_OFF + offsetof(struct dnshdr, flags));
+
+	// Capture questions and ignore answers
+	if (flags.qr)
+		return 0;
+
+	// Skip DNS packets with more than 1 question
+	if (load_half(skb, DNS_OFF + offsetof(struct dnshdr, qdcount)) != 1)
+		return 0;
+
+	// Skip DNS packets with answers
+	if (load_half(skb, DNS_OFF + offsetof(struct dnshdr, ancount)) != 0)
+		return 0;
+
+	// Skip DNS packets with authority records
+	if (load_half(skb, DNS_OFF + offsetof(struct dnshdr, nscount)) != 0)
+		return 0;
+
+	// This loop iterates over the DNS labels to find the total DNS name
+	// length.
+	unsigned int i;
+	unsigned int skip = 0;
+	for (i = 0; i < MAX_DNS_NAME ; i++) {
+		if (skip != 0) {
+			skip--;
+		} else {
+			int label_len = load_byte(skb, DNS_OFF + 12 + i);
+			if (label_len == 0)
+				break;
+			// The simple solution "i += label_len" gives verifier
+			// errors, so work around with skip.
+			skip = label_len;
+		}
+	}
+
+	__u32 len = i < MAX_DNS_NAME ? i : MAX_DNS_NAME;
+
+	struct event_t event = {0,};
+	if (len > 0)
+		bpf_skb_load_bytes(skb, DNS_OFF + 12, event.name, len);
+
+	event.pkt_type = skb->pkt_type;
+
+	// TODO: we should not send the event when len == 0. But the verifier
+	// won't let us.
+	bpf_perf_event_output(skb, &events, BPF_F_CURRENT_CPU, &event, sizeof(event));
+
+	return 0;
+}
+
+char _license[] SEC("license") = "GPL";

--- a/pkg/gadgets/dns/tracer/embed-ebpf.go
+++ b/pkg/gadgets/dns/tracer/embed-ebpf.go
@@ -1,0 +1,24 @@
+// +build withebpf
+
+// Copyright 2019-2021 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tracer
+
+import (
+	_ "embed"
+)
+
+//go:embed bpf/dns.o
+var ebpfProg []byte

--- a/pkg/gadgets/dns/tracer/embed-none.go
+++ b/pkg/gadgets/dns/tracer/embed-none.go
@@ -1,0 +1,19 @@
+// +build !withebpf
+
+// Copyright 2019-2021 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tracer
+
+var ebpfProg []byte

--- a/pkg/gadgets/dns/tracer/tracer.go
+++ b/pkg/gadgets/dns/tracer/tracer.go
@@ -1,0 +1,252 @@
+// Copyright 2019-2021 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tracer
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"os"
+	"runtime"
+	"sync"
+	"syscall"
+	"unsafe"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/perf"
+	log "github.com/sirupsen/logrus"
+	"github.com/vishvananda/netns"
+	"golang.org/x/sys/unix"
+)
+
+// #include "bpf/dns-common.h"
+import "C"
+
+const (
+	BPF_PROG_NAME = "bpf_prog1"
+	BPF_MAP_NAME  = "events"
+	SO_ATTACH_BPF = 50
+)
+
+type link struct {
+	collection *ebpf.Collection
+	perfRd     *perf.Reader
+
+	sockFd int
+}
+
+type Tracer struct {
+	mu sync.Mutex
+
+	spec *ebpf.CollectionSpec
+
+	// key: namespace/podname
+	// value: Tracelet
+	attachments map[string]*link
+}
+
+// Both openRawSock and htons are from github.com/cilium/ebpf:
+// MIT License
+// https://github.com/cilium/ebpf/blob/eaa1fe7482d837490c22d9d96a788f669b9e3843/example_sock_elf_test.go#L146-L166
+func openRawSock(pid uint32) (int, error) {
+	if pid != 0 {
+		// Lock the OS Thread so we don't accidentally switch namespaces
+		runtime.LockOSThread()
+		defer runtime.UnlockOSThread()
+
+		// Save the current network namespace
+		origns, _ := netns.Get()
+		defer origns.Close()
+
+		netnsHandle, err := netns.GetFromPid(int(pid))
+		if err != nil {
+			return -1, err
+		}
+		defer netnsHandle.Close()
+		err = netns.Set(netnsHandle)
+		if err != nil {
+			return -1, err
+		}
+
+		// Switch back to the original namespace
+		defer netns.Set(origns)
+	}
+
+	sock, err := syscall.Socket(syscall.AF_PACKET, syscall.SOCK_RAW|syscall.SOCK_NONBLOCK|syscall.SOCK_CLOEXEC, int(htons(syscall.ETH_P_ALL)))
+	if err != nil {
+		return -1, err
+	}
+	sll := syscall.SockaddrLinklayer{
+		Ifindex:  0, // 0 matches any interface
+		Protocol: htons(syscall.ETH_P_ALL),
+	}
+	if err := syscall.Bind(sock, &sll); err != nil {
+		return -1, err
+	}
+	return sock, nil
+}
+
+// htons converts an unsigned short integer from host byte order to network byte order.
+func htons(i uint16) uint16 {
+	b := make([]byte, 2)
+	binary.BigEndian.PutUint16(b, i)
+	return *(*uint16)(unsafe.Pointer(&b[0]))
+}
+
+func NewTracer() (*Tracer, error) {
+	spec, err := ebpf.LoadCollectionSpecFromReader(bytes.NewReader(ebpfProg))
+	if err != nil {
+		return nil, fmt.Errorf("failed to load asset: %w", err)
+	}
+
+	t := &Tracer{
+		spec:        spec,
+		attachments: make(map[string]*link),
+	}
+
+	return t, nil
+}
+
+func (t *Tracer) Attach(key string, pid uint32, f func(name, pktType string)) error {
+	if _, ok := t.attachments[key]; ok {
+		if key == "host" {
+			return nil
+		} else {
+			return fmt.Errorf("key already attached: %q", key)
+		}
+	}
+
+	coll, err := ebpf.NewCollectionWithOptions(t.spec, ebpf.CollectionOptions{Programs: ebpf.ProgramOptions{LogSize: ebpf.DefaultVerifierLogSize * 100}})
+	if err != nil {
+		return fmt.Errorf("failed to create BPF collection: %w", err)
+	}
+
+	rd, err := perf.NewReader(coll.Maps[BPF_MAP_NAME], os.Getpagesize())
+	if err != nil {
+		return fmt.Errorf("failed to get a perf reader: %w", err)
+	}
+
+	prog, ok := coll.Programs[BPF_PROG_NAME]
+	if !ok {
+		return fmt.Errorf("Failed to find BPF program %q", BPF_PROG_NAME)
+	}
+
+	sockFd, err := openRawSock(pid)
+	if err != nil {
+		return fmt.Errorf("Failed to open raw socket: %w", err)
+	}
+
+	if err := syscall.SetsockoptInt(sockFd, syscall.SOL_SOCKET, SO_ATTACH_BPF, prog.FD()); err != nil {
+		return fmt.Errorf("Failed to attach BPF program: %w", err)
+	}
+
+	l := &link{
+		collection: coll,
+		sockFd:     sockFd,
+		perfRd:     rd,
+	}
+	t.attachments[key] = l
+
+	go t.listen(rd, f)
+
+	return nil
+}
+
+// pkt_type definitions:
+// https://github.com/torvalds/linux/blob/v5.14-rc7/include/uapi/linux/if_packet.h#L26
+var pktTypeNames = []string{
+	"HOST",
+	"BROADCAST",
+	"MULTICAST",
+	"OTHERHOST",
+	"OUTGOING",
+	"LOOPBACK",
+	"USER",
+	"KERNEL",
+}
+
+func parseDNSEvent(rawSample []byte) (ret string, pktType string) {
+	// Convert name into a string with dots
+	name := make([]byte, C.MAX_DNS_NAME)
+	copy(name, rawSample)
+
+	for i := 0; i < C.MAX_DNS_NAME; i++ {
+		length := int(name[i])
+		if length == 0 {
+			break
+		}
+		if i+1+length < C.MAX_DNS_NAME {
+			ret += string(name[i+1:i+1+length]) + "."
+		}
+		i += length
+	}
+
+	// Parse the packet type
+	pktType = "UNKNOWN"
+	dnsEvent := (*C.struct_event_t)(unsafe.Pointer(&rawSample[0]))
+	if len(rawSample) < int(unsafe.Sizeof(*dnsEvent)) {
+		return
+	}
+	pktTypeUint := uint(dnsEvent.pkt_type)
+	if pktTypeUint < uint(len(pktTypeNames)) {
+		pktType = pktTypeNames[pktTypeUint]
+	}
+
+	return
+}
+
+func (t *Tracer) listen(rd *perf.Reader, f func(name, pktType string)) {
+	for {
+		record, err := rd.Read()
+		if err != nil {
+			if perf.IsClosed(err) {
+				return
+			}
+			log.Errorf("Error while reading from perf event reader: %s", err)
+		}
+
+		if record.LostSamples != 0 {
+			log.Warnf("Warning: perf event ring buffer full, dropped %d samples", record.LostSamples)
+			continue
+		}
+
+		name, pktType := parseDNSEvent(record.RawSample)
+
+		// TODO: Ideally, messages with name=="" should not be emitted
+		// by the BPF program (see TODO in dns.c).
+		if len(name) > 0 {
+			f(name, pktType)
+		}
+	}
+
+}
+
+func (t *Tracer) Detach(key string) error {
+	if l, ok := t.attachments[key]; ok {
+		l.perfRd.Close()
+		unix.Close(l.sockFd)
+		l.collection.Close()
+		delete(t.attachments, key)
+		return nil
+	} else {
+		return fmt.Errorf("key not attached: %q", key)
+	}
+}
+
+func (t *Tracer) Close() {
+	for key := range t.attachments {
+		t.Detach(key)
+	}
+}

--- a/pkg/gadgets/dns/tracer/tracer_test.go
+++ b/pkg/gadgets/dns/tracer/tracer_test.go
@@ -1,0 +1,69 @@
+// Copyright 2019-2021 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tracer
+
+import (
+	"testing"
+)
+
+func TestParsing(t *testing.T) {
+	word10 := []byte{9, 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i'}
+	output10 := "abcdefghi."
+	word250 := []byte{}
+	output250 := ""
+	for i := 0; i < 25; i++ {
+		word250 = append(word250, word10...)
+		output250 += output10
+	}
+
+	table := []struct {
+		input  []byte
+		output string
+	}{
+		{
+			input: []byte{
+				3, 'w', 'w', 'w',
+				7, 'k', 'i', 'n', 'v', 'o', 'l', 'k',
+				2, 'i', 'o',
+				0,
+				// trailing garbage is ignored
+				0x42, 0x42,
+			},
+			output: "www.kinvolk.io.",
+		},
+		{
+			input: []byte{
+				3, 'w', 'w', 'w',
+				255, // overflow
+			},
+			output: "www.",
+		},
+		{
+			input: append(word250,
+				[]byte{
+					3, 'z', 'z', 'z',
+					0,
+				}...),
+			output: output250 + "zzz.",
+		},
+	}
+
+	for _, entry := range table {
+		output, _ := parseDNSEvent(entry.input)
+		if output != entry.output {
+			t.Fatalf("Failed to parse DNS string: got %q, expected %q", output, entry.output)
+		}
+	}
+}

--- a/pkg/gadgets/dns/types/dns.go
+++ b/pkg/gadgets/dns/types/dns.go
@@ -1,0 +1,26 @@
+// Copyright 2019-2021 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import (
+	eventtypes "github.com/kinvolk/inspektor-gadget/pkg/types"
+)
+
+type Event struct {
+	eventtypes.Event
+
+	DNSName string `json:"dns_name,omitempty"`
+	PktType string `json:"pkt_type,omitempty"`
+}

--- a/pkg/gadgettracermanager/containerutils/containerutils.go
+++ b/pkg/gadgettracermanager/containerutils/containerutils.go
@@ -141,8 +141,8 @@ func GetCgroupPaths(pid int) (string, string, error) {
 	return cgroupPathV1, cgroupPathV2, nil
 }
 
-func GetMntNs(pid int) (uint64, error) {
-	fileinfo, err := os.Stat(filepath.Join("/proc", fmt.Sprintf("%d", pid), "ns/mnt"))
+func getNamespaceInode(pid int, nsType string) (uint64, error) {
+	fileinfo, err := os.Stat(filepath.Join("/proc", fmt.Sprintf("%d", pid), "ns", nsType))
 	if err != nil {
 		return 0, err
 	}
@@ -151,6 +151,14 @@ func GetMntNs(pid int) (uint64, error) {
 		return 0, fmt.Errorf("Not a syscall.Stat_t")
 	}
 	return stat.Ino, nil
+}
+
+func GetMntNs(pid int) (uint64, error) {
+	return getNamespaceInode(pid, "mnt")
+}
+
+func GetNetNs(pid int) (uint64, error) {
+	return getNamespaceInode(pid, "net")
 }
 
 func ParseOCIState(stateBuf []byte) (id string, pid int, err error) {

--- a/pkg/resources/crd/bases/gadget.kinvolk.io_traces.yaml
+++ b/pkg/resources/crd/bases/gadget.kinvolk.io_traces.yaml
@@ -65,15 +65,16 @@ spec:
                 type: string
               output:
                 description: Output allows a gadget to output the results in the specified
-                  location. * With OutputMode=Status, Output is unused * With OutputMode=File,
-                  Output specifies the file path * With OutputMode=ExternalResource,
+                  location. * With OutputMode=Status|Stream, Output is unused * With
+                  OutputMode=File, Output specifies the file path * With OutputMode=ExternalResource,
                   Output specifies the external   resource (such as   seccompprofiles.security-profiles-operator.x-k8s.io
                   for the   seccomp gadget)
                 type: string
               outputMode:
-                description: OutputMode is "Status", "File" or "ExternalResource"
+                description: OutputMode is "Status", "Stream, ""File" or "ExternalResource"
                 enum:
                 - Status
+                - Stream
                 - File
                 - ExternalResource
                 type: string

--- a/pkg/resources/samples/trace-dns.yaml
+++ b/pkg/resources/samples/trace-dns.yaml
@@ -1,0 +1,13 @@
+apiVersion: gadget.kinvolk.io/v1alpha1
+kind: Trace
+metadata:
+  name: dns
+  namespace: gadget
+spec:
+  node: minikube
+  gadget: dns
+  filter:
+    namespace: kube-system
+    podname: etcd-minikube
+  runMode: Manual
+  outputMode: Stream


### PR DESCRIPTION
# New DNS gadget

This PR implements:
* Streams in the Gadget Tracer Manager. Gadgets can now easily publish a stream of events consumable by kubectl-gadget or other clients
* A new DNS gadget in the gadget pod.
* Refactoring the client-side code to help writing new gadgets client-side.
* "kubectl gadget dns" itself.

## How to use

```
$ kubectl gadget dns --namespace default
default/normal-pod-ks8hs: DNS request to kinvolk.io.
default/normal-pod-ks8hs: DNS request to kinvolk.io.
default/normal-pod-ks8hs: DNS request to kinvolk.io.
default/normal-pod-ks8hs: DNS request to kinvolk.io.
```

```
$ kubectl exec -ti normal-pod-ks8hs -- wget kinvolk.io
```

## Testing done

Tested on Minikube with the docker driver.

The internals can also be tested manually with:
```
$ kubectl apply -f pkg/resources/samples/trace-dns.yaml
$ kubectl annotate -n gadget trace/dns gadget.kinvolk.io/operation=start
```

```
$ kubectl exec -ti -n kube-system $(kubectl get pod -n kube-system -l k8s-app=gadget -o name) -- /bin/bash
# gadgettracermanager -dump
List of tracers:
trace_gadget_dns
# gadgettracermanager -call receive-stream -tracerid trace_gadget_dns
...
```

## TODO

- [ ] Filtering does not work yet (it gets the traces from all pods)
- [ ] Printing the type of packets (see `sll_pkttype` in `man 7 packet` and in [if_packet.h](https://github.com/torvalds/linux/blob/v5.14-rc7/include/uapi/linux/if_packet.h))
- [ ] Avoid tracing multiple times on pods with host netns