### PR TITLE
gadget-container/Makefile: stop in case of errors

### DIFF
--- a/gadget-container/Makefile
+++ b/gadget-container/Makefile
@@ -5,7 +5,7 @@ gadget-container-deps: ocihookgadget gadgettracermanager networkpolicyadvisor ru
 
 .PHONY: ebpf-objects
 ebpf-objects:
-	$(foreach dir, $(shell find ../pkg -name bpf -type d), make -C $(dir);)
+	$(foreach dir, $(shell find ../pkg -name bpf -type d), make -C $(dir) && ) true
 
 # Gadgets
 


### PR DESCRIPTION
# gadget-container/Makefile: stop in case of errors

In case of compilation errors in one of the ebpf programs, the makefile was continuing the build instead of stopping. This patch replaces `;` by `&&` in the shell command line to make sure compilations errors are not ignored.
