### PR TITLE
GadgetTracerManager: add pubsub in preparation for future network and uprobe gadgets

### DIFF
--- a/pkg/gadgets/interface.go
+++ b/pkg/gadgets/interface.go
@@ -16,6 +16,9 @@ package gadgets
 
 import (
 	gadgetv1alpha1 "github.com/kinvolk/inspektor-gadget/pkg/api/v1alpha1"
+	pb "github.com/kinvolk/inspektor-gadget/pkg/gadgettracermanager/api"
+	"github.com/kinvolk/inspektor-gadget/pkg/gadgettracermanager/pubsub"
+
 	apimachineryruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -76,6 +79,14 @@ type Resolver interface {
 	// the pod specified in arguments, indexed by the name of the
 	// containers or an empty map if not found
 	LookupPIDByPod(namespace, pod string) map[string]uint32
+
+	// Subscribe returns the list of existing containers and registers a
+	// callback for notifications about additions and deletions of
+	// containers
+	Subscribe(key interface{}, f pubsub.FuncNotify) []pb.ContainerDefinition
+
+	// Unsubscribe undoes a previous call to Subscribe
+	Unsubscribe(key interface{})
 }
 
 type BaseFactory struct {

--- a/pkg/gadgettracermanager/pubsub/pubsub.go
+++ b/pkg/gadgettracermanager/pubsub/pubsub.go
@@ -1,0 +1,91 @@
+// Copyright 2019-2021 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pubsub
+
+import (
+	"sync"
+
+	pb "github.com/kinvolk/inspektor-gadget/pkg/gadgettracermanager/api"
+)
+
+type EventType int
+
+type FuncNotify func(event PubSubEvent)
+
+const (
+	EVENT_TYPE_ADD_CONTAINER EventType = iota
+	EVENT_TYPE_REMOVE_CONTAINER
+)
+
+type PubSubEvent struct {
+	Type      EventType
+	Container pb.ContainerDefinition
+}
+
+// GadgetPubSub provides a synchronous publish subscribe mechanism for gadgets
+// to be informed of container creation and deletion. It needs to be
+// synchronous so that gadgets have time to attach their tracer before the
+// container is started.
+type GadgetPubSub struct {
+	mu sync.RWMutex
+
+	// subs is the set of subscribers
+	subs map[interface{}]FuncNotify
+}
+
+func NewGadgetPubSub() *GadgetPubSub {
+	return &GadgetPubSub{
+		subs: make(map[interface{}]FuncNotify),
+	}
+}
+
+func (g *GadgetPubSub) Subscribe(key interface{}, f FuncNotify) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	g.subs[key] = f
+}
+
+func (g *GadgetPubSub) Unsubscribe(key interface{}) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	delete(g.subs, key)
+}
+
+func (g *GadgetPubSub) Publish(eventType EventType, container pb.ContainerDefinition) {
+	// Make a copy so we don't keep the lock while actually publishing
+	g.mu.RLock()
+	copiedSubs := []FuncNotify{}
+	for _, callback := range g.subs {
+		copiedSubs = append(copiedSubs, callback)
+	}
+	g.mu.RUnlock()
+
+	var wg sync.WaitGroup
+	for _, callback := range copiedSubs {
+		wg.Add(1)
+		go func(callback FuncNotify) {
+			event := PubSubEvent{
+				Type:      eventType,
+				Container: container,
+			}
+			callback(event)
+			wg.Done()
+		}(callback)
+	}
+
+	wg.Wait()
+}

--- a/pkg/gadgettracermanager/pubsub/pubsub_test.go
+++ b/pkg/gadgettracermanager/pubsub/pubsub_test.go
@@ -1,0 +1,59 @@
+// Copyright 2019-2021 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pubsub
+
+import (
+	"testing"
+
+	pb "github.com/kinvolk/inspektor-gadget/pkg/gadgettracermanager/api"
+)
+
+func TestPubSub(t *testing.T) {
+	p := NewGadgetPubSub()
+	if p == nil {
+		t.Fatalf("Failed to create new pubsub")
+	}
+
+	var event PubSubEvent
+	done := make(chan struct{}, 1)
+	counter := 0
+	key := "callback1"
+	callback := func(e PubSubEvent) {
+		event = e
+		counter++
+		done <- struct{}{}
+	}
+
+	p.Subscribe(key, callback)
+
+	p.Publish(EVENT_TYPE_REMOVE_CONTAINER, pb.ContainerDefinition{Id: "container1"})
+	_, ok := <-done
+	if !ok {
+		t.Fatalf("Failed to receive event from callback")
+	}
+
+	if event.Type != EVENT_TYPE_REMOVE_CONTAINER {
+		t.Fatalf("Failed to receive correct event of type EVENT_TYPE_REMOVE_CONTAINER")
+	}
+	if event.Container.Id != "container1" {
+		t.Fatalf("Failed to receive correct event")
+	}
+
+	p.Unsubscribe(key)
+	p.Publish(EVENT_TYPE_REMOVE_CONTAINER, pb.ContainerDefinition{Id: "container2"})
+	if counter != 1 {
+		t.Fatalf("Callback called too many times")
+	}
+}


### PR DESCRIPTION
# GadgetTracerManager: add pubsub in preparation for future network and uprobe gadgets

GadgetTracerManager's pubsub provides a synchronous publish subscribe mechanism for gadgets to be informed of container creation and deletion. It needs to be synchronous so that gadgets have time to attach their tracer before the container is started.

Examples of possible gadgets that would need this:
- a gadget that listens on the network traffic of containers. It needs to have access to the netns of the container before it is started.
- a gadget that installs uprobes on programs of containers. It needs to have access to the mntns of the container before it is started.

## gadgettracermanager: fix mutex usage

The methods to add/remove containers and tracers can be called concurrently from different threads and they read/update the
'containers' and 'tracers' maps respectively. This patch makes use of the existing mutex to protect them.

Additionally, the field containerIDsByKey is removed from GadgetTracerManager and instead moved as a local variable to run().
Since it is only used from the same thread, it does not need to be protected by the mutex.

## How to use

https://github.com/kinvolk/inspektor-gadget/pull/225 is a DNS gadget that makes use of this. You can see how it makes use of the Subscribe method to dynamically and synchronously (except with the podinformer hook mode) add probes in new network namespaces as they are created.

## Testing done

Tested with the dns gadget from #225 on Minikube with the docker driver on 5.12.6-300.fc34.x86_64.