### PR TITLE
cmd: set default of "tools-mode" to standard

### DIFF
--- a/cmd/kubectl-gadget/deploy.go
+++ b/cmd/kubectl-gadget/deploy.go
@@ -71,7 +71,7 @@ func init() {
 	deployCmd.PersistentFlags().StringVarP(
 		&toolsMode,
 		"tools-mode", "",
-		"auto",
+		"standard",
 		"which kind of tools to use (auto, core, standard)")
 
 	rootCmd.AddCommand(deployCmd)


### PR DESCRIPTION
We're hitting an issue (#230) when using CO-RE based tools. Let's set
the default to "standard" until we found out the reason of that issue.
