### PR TITLE
New hook mode: runcfanotify

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ minikube-install: gadget-container
 	# because of Finalizers.
 	kubectl delete crd traces.gadget.kinvolk.io || true
 	./kubectl-gadget-linux-amd64 deploy | kubectl delete -f - || true
-	./kubectl-gadget-linux-amd64 deploy --traceloop=false | \
+	./kubectl-gadget-linux-amd64 deploy --traceloop=false --hook-mode=fanotify | \
 		sed 's/imagePullPolicy: Always/imagePullPolicy: Never/g' | \
 		sed 's/initialDelaySeconds: 10/initialDelaySeconds: '$(LIVENESS_PROBE_INITIAL_DELAY_SECONDS)'/g' | \
 		kubectl apply -f -

--- a/cmd/kubectl-gadget/deploy.go
+++ b/cmd/kubectl-gadget/deploy.go
@@ -62,7 +62,7 @@ func init() {
 		&hookMode,
 		"hook-mode", "",
 		"auto",
-		"how to get containers start/stop notifications (auto, crio, ldpreload, podinformer, nri)")
+		"how to get containers start/stop notifications (auto, crio, ldpreload, podinformer, nri, fanotify)")
 	deployCmd.PersistentFlags().BoolVarP(
 		&livenessProbe,
 		"liveness-probe", "",
@@ -238,8 +238,9 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 		hookMode != "crio" &&
 		hookMode != "ldpreload" &&
 		hookMode != "podinformer" &&
-		hookMode != "nri" {
-		return fmt.Errorf("invalid argument %q for --hook-mode=[auto,crio,ldpreload,podinformer,nri]", hookMode)
+		hookMode != "nri" &&
+		hookMode != "fanotify" {
+		return fmt.Errorf("invalid argument %q for --hook-mode=[auto,crio,ldpreload,podinformer,nri,fanotify]", hookMode)
 	}
 
 	if toolsMode != "auto" && toolsMode != "core" && toolsMode != "standard" {

--- a/gadget-container/entrypoint.sh
+++ b/gadget-container/entrypoint.sh
@@ -149,9 +149,11 @@ if [ "$HOOK_MODE" = "nri" ] ; then
   fi
 fi
 
-POD_INFORMER_PARAM=""
+GADGET_EXTRA_PARAMS=""
 if [ "$HOOK_MODE" = "podinformer" ] ; then
-  POD_INFORMER_PARAM="-podinformer"
+  GADGET_EXTRA_PARAMS="-podinformer"
+elif [ "$HOOK_MODE" = "fanotify" ] ; then
+  GADGET_EXTRA_PARAMS="-runcfanotify"
 fi
 
 ## Hooks Ends ##
@@ -198,7 +200,7 @@ fi
 
 echo "Starting the Gadget Tracer Manager in the background..."
 rm -f /run/gadgettracermanager.socket
-/bin/gadgettracermanager -serve $POD_INFORMER_PARAM -controller &
+/bin/gadgettracermanager -serve $GADGET_EXTRA_PARAMS -controller &
 
 if [ "$INSPEKTOR_GADGET_OPTION_TRACELOOP" = "true" ] ; then
   rm -f /run/traceloop.socket

--- a/gadget-container/gadgettracermanager/main.go
+++ b/gadget-container/gadgettracermanager/main.go
@@ -44,6 +44,7 @@ var (
 	dump          bool
 	liveness      bool
 	podInformer   bool
+	runcFanotify  bool
 	socketfile    string
 	method        string
 	label         string
@@ -67,6 +68,7 @@ func init() {
 	flag.BoolVar(&serve, "serve", false, "Start server")
 	flag.BoolVar(&controller, "controller", false, "Enable the controller for custom resources")
 	flag.BoolVar(&podInformer, "podinformer", false, "Enable a Pod Informer to get Pod events from k8s API server")
+	flag.BoolVar(&runcFanotify, "runcfanotify", false, "Enable runc fanotify to get events")
 
 	flag.StringVar(&method, "call", "", "Call a method (add-tracer, remove-tracer, receive-stream, add-container, remove-container)")
 	flag.StringVar(&label, "label", "", "key=value,key=value labels to use in add-tracer")
@@ -253,6 +255,8 @@ func main() {
 
 		if podInformer {
 			tracerManager, err = gadgettracermanager.NewServerWithPodInformer(node)
+		} else if runcFanotify {
+			tracerManager, err = gadgettracermanager.NewServerWithRuncFanotify(node)
 		} else {
 			tracerManager, err = gadgettracermanager.NewServer(node)
 		}

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/onsi/ginkgo v1.16.4
 	github.com/onsi/gomega v1.14.0
 	github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417
+	github.com/s3rj1k/go-fanotify/fanotify v0.0.0-20201224085348-500f21fac20a
 	github.com/seccomp/libseccomp-golang v0.9.2-0.20200616122406-847368b35ebf
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/cobra v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -1017,6 +1017,8 @@ github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryancurrah/gomodguard v1.0.2/go.mod h1:9T/Cfuxs5StfsocWr4WzDL36HqnX0fVb9d5fSEaLhoE=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
+github.com/s3rj1k/go-fanotify/fanotify v0.0.0-20201224085348-500f21fac20a h1:1JW3hIySH3x0IQ547qy7EGGu4aZBfC1VsoFdmZLNzP0=
+github.com/s3rj1k/go-fanotify/fanotify v0.0.0-20201224085348-500f21fac20a/go.mod h1:wiP6GQ2T378F+YIyuNw7yXtBxJZR+fqrrn1Z6UHZi0Q=
 github.com/safchain/ethtool v0.0.0-20190326074333-42ed695e3de8/go.mod h1:Z0q5wiBQGYcxhMZ6gUqHn6pYNLypFAvaL3UvgZLR0U4=
 github.com/saschagrunert/ccli v1.0.2-0.20200423111659-b68f755cc0f5/go.mod h1:nF6F8YjOZIYqRQ2GVOi43O13vaN2W1OQq1LcxUGdAfw=
 github.com/saschagrunert/go-modiff v1.2.0/go.mod h1:YHrztU7folCi4YSHksLOYTX5KFGdHNr9O9DVKjpINMs=

--- a/pkg/gadgettracermanager/gadgettracermanager_test.go
+++ b/pkg/gadgettracermanager/gadgettracermanager_test.go
@@ -110,7 +110,7 @@ func TestSelector(t *testing.T) {
 }
 
 func TestTracer(t *testing.T) {
-	g, err := newServer("fake-node", false, false, false)
+	g, err := newServer("fake-node", false, false, false, false)
 	if err != nil {
 		t.Fatalf("Failed to create new server: %v", err)
 	}
@@ -185,7 +185,7 @@ func TestTracer(t *testing.T) {
 }
 
 func TestContainer(t *testing.T) {
-	g, err := newServer("fake-node", false, false, false)
+	g, err := newServer("fake-node", false, false, false, false)
 	if err != nil {
 		t.Fatalf("Failed to create new server: %v", err)
 	}
@@ -195,12 +195,14 @@ func TestContainer(t *testing.T) {
 	// Add 3 Containers
 	for i := 0; i < 3; i++ {
 		respAddContainer, err := g.AddContainer(ctx, &pb.ContainerDefinition{
-			Id:        fmt.Sprintf("abcde%d", i),
-			Namespace: "this-namespace",
-			Podname:   "my-pod",
-			Name:      fmt.Sprintf("container%d", i),
-			Mntns:     55555 + uint64(i),
-			Pid:       uint32(100 + i),
+			Id:         fmt.Sprintf("abcde%d", i),
+			Namespace:  "this-namespace",
+			Podname:    "my-pod",
+			Name:       fmt.Sprintf("container%d", i),
+			Mntns:      55555 + uint64(i),
+			Pid:        uint32(100 + i),
+			CgroupPath: "/none",
+			CgroupId:   1,
 		})
 		if err != nil {
 			t.Fatalf("Failed to add container: %v", err)
@@ -313,6 +315,9 @@ func TestContainer(t *testing.T) {
 			{Key: "key1", Value: "value1"},
 			{Key: "key2", Value: "value2"},
 		},
+		CgroupPath: "/none",
+		CgroupId:   1,
+		Mntns:      1,
 	})
 	if err != nil {
 		t.Fatalf("Failed to add container: %v", err)

--- a/pkg/runcfanotify/runcfanotify.go
+++ b/pkg/runcfanotify/runcfanotify.go
@@ -1,0 +1,369 @@
+// Copyright 2021 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runcfanotify
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	ocispec "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/s3rj1k/go-fanotify/fanotify"
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/sys/unix"
+)
+
+type EventType int
+
+const (
+	EVENT_TYPE_ADD_CONTAINER EventType = iota
+	EVENT_TYPE_REMOVE_CONTAINER
+)
+
+// ContainerEvent is the notification for container creation or termination
+type ContainerEvent struct {
+	// Type is whether the container was added or removed
+	Type EventType
+
+	// ContainerID is the container id, typically a 64 hexadecimal string
+	ContainerID string
+
+	// ContainerPID is the process id of the container
+	ContainerPID uint32
+
+	// Container's configuration is the config.json from the OCI runtime
+	// spec
+	ContainerConfig *ocispec.Spec
+}
+
+type RuncNotifyFunc func(notif ContainerEvent)
+
+type RuncNotifier struct {
+	runcBinaryNotify *fanotify.NotifyFD
+	callback         RuncNotifyFunc
+}
+
+// runcPaths is the list of paths where runc could be installed. Depending on
+// the Linux distribution, it could be in different locations.
+//
+// When this package is executed in a container, it looks at the /host volume.
+var runcPaths = []string{
+	"/usr/bin/runc",
+	"/usr/sbin/runc",
+	"/usr/local/sbin/runc",
+	"/run/torcx/unpack/docker/bin/runc",
+
+	"/host/usr/bin/runc",
+	"/host/usr/sbin/runc",
+	"/host/usr/local/sbin/runc",
+	"/host/run/torcx/unpack/docker/bin/runc",
+}
+
+// NewRuncNotifier uses fanotify to detect when runc containers are created
+// or terminated, and call the callback on such event.
+//
+// Limitations:
+// - runc must be installed in one of the paths listed by runcPaths
+// - Linux >= 5.3 (for pidfd_open)
+func NewRuncNotifier(callback RuncNotifyFunc) (*RuncNotifier, error) {
+	n := &RuncNotifier{
+		callback: callback,
+	}
+
+	fanotifyFlags := uint(unix.FAN_CLOEXEC | unix.FAN_CLASS_CONTENT | unix.FAN_UNLIMITED_QUEUE | unix.FAN_UNLIMITED_MARKS)
+	openFlags := os.O_RDONLY | unix.O_LARGEFILE | unix.O_CLOEXEC
+
+	runcBinaryNotify, err := fanotify.Initialize(fanotifyFlags, openFlags)
+	if err != nil {
+		return nil, err
+	}
+	n.runcBinaryNotify = runcBinaryNotify
+
+	for _, file := range runcPaths {
+		err = runcBinaryNotify.Mark(unix.FAN_MARK_ADD, unix.FAN_OPEN_EXEC_PERM, unix.AT_FDCWD, file)
+		if err == nil {
+			log.Debugf("Checking %q: done", file)
+		} else {
+			log.Debugf("Checking %q: %s", file, err)
+		}
+	}
+
+	go n.watchRunc()
+
+	return n, nil
+}
+
+func commFromPid(pid int) string {
+	comm, _ := ioutil.ReadFile(fmt.Sprintf("/proc/%d/comm", pid))
+	return strings.TrimSuffix(string(comm), "\n")
+}
+
+func cmdlineFromPid(pid int) []string {
+	cmdline, _ := ioutil.ReadFile(fmt.Sprintf("/proc/%d/cmdline", pid))
+	return strings.Split(string(cmdline), "\x00")
+}
+
+func (n *RuncNotifier) watchPidFileIterate(pidFileDirNotify *fanotify.NotifyFD, bundleDir string, pidFile string, pidFileDir string) (bool, error) {
+	// Get the next event from fanotify.
+	// Even though the API allows to pass skipPIDs, we cannot use
+	// it here because ResponseAllow would not be called.
+	data, err := pidFileDirNotify.GetEvent()
+	if err != nil {
+		return false, fmt.Errorf("%w", err)
+	}
+
+	// data can be nil if the event received is from a process in skipPIDs.
+	// In that case, skip and get the next event.
+	if data == nil {
+		return false, nil
+	}
+
+	// Don't leak the fd received by GetEvent
+	defer data.Close()
+
+	if !data.MatchMask(unix.FAN_ACCESS_PERM) {
+		// This should not happen: FAN_ACCESS_PERM is the only mask Marked
+		return false, fmt.Errorf("fanotify: unknown event on runc: mask=%d pid=%d", data.Mask, data.Pid)
+	}
+
+	// This unblocks whoever is accessing the pidfile
+	defer pidFileDirNotify.ResponseAllow(data)
+
+	pid := data.GetPID()
+
+	// Skip events triggered by ourselves
+	if pid == os.Getpid() {
+		return false, nil
+	}
+
+	path, err := data.GetPath()
+	if err != nil {
+		return false, err
+	}
+	if path != pidFile {
+		return false, nil
+	}
+
+	pidFileContent, err := ioutil.ReadAll(data.File())
+	if err != nil {
+		return false, err
+	}
+	if len(pidFileContent) == 0 {
+		return false, fmt.Errorf("empty pid file")
+	}
+	containerPID, err := strconv.Atoi(string(pidFileContent))
+	if err != nil {
+		return false, err
+	}
+
+	// Unfortunately, Linux 5.4 doesn't respect ignore masks
+	// See fix in Linux 5.9:
+	// https://github.com/torvalds/linux/commit/497b0c5a7c0688c1b100a9c2e267337f677c198e
+	// Workaround: remove parent mask. We don't need it anymore :)
+	err = pidFileDirNotify.Mark(unix.FAN_MARK_REMOVE, unix.FAN_ACCESS_PERM|unix.FAN_EVENT_ON_CHILD, unix.AT_FDCWD, pidFileDir)
+	if err != nil {
+		return false, nil
+	}
+
+	pidfd, _, errno := unix.Syscall(unix.SYS_PIDFD_OPEN, uintptr(containerPID), 0, 0)
+	if errno != 0 {
+		return false, fmt.Errorf("pidfd_open returned %v", errno)
+	}
+
+	bundleConfigJson, err := ioutil.ReadFile(filepath.Join(bundleDir, "config.json"))
+	if err != nil {
+		return false, err
+	}
+	containerConfig := &ocispec.Spec{}
+	err = json.Unmarshal(bundleConfigJson, containerConfig)
+	if err != nil {
+		return false, err
+	}
+
+	containerID := filepath.Base(filepath.Clean(bundleDir))
+
+	go func() {
+		defer unix.Close(int(pidfd))
+		for {
+			fds := []unix.PollFd{
+				unix.PollFd{
+					Fd:      int32(pidfd),
+					Events:  unix.POLLIN,
+					Revents: 0,
+				},
+			}
+			count, err := unix.Poll(fds, -1)
+			if err == nil && count == 1 {
+				n.callback(ContainerEvent{
+					Type:            EVENT_TYPE_REMOVE_CONTAINER,
+					ContainerID:     containerID,
+					ContainerPID:    uint32(containerPID),
+					ContainerConfig: containerConfig,
+				})
+				return
+			}
+		}
+	}()
+
+	n.callback(ContainerEvent{
+		Type:            EVENT_TYPE_ADD_CONTAINER,
+		ContainerID:     containerID,
+		ContainerPID:    uint32(containerPID),
+		ContainerConfig: containerConfig,
+	})
+	return true, nil
+
+}
+
+func (n *RuncNotifier) monitorRuncInstance(bundleDir string, pidFile string) error {
+	fanotifyFlags := uint(unix.FAN_CLOEXEC | unix.FAN_CLASS_CONTENT | unix.FAN_UNLIMITED_QUEUE | unix.FAN_UNLIMITED_MARKS)
+	openFlags := os.O_RDONLY | unix.O_LARGEFILE | unix.O_CLOEXEC
+
+	pidFileDirNotify, err := fanotify.Initialize(fanotifyFlags, openFlags)
+	if err != nil {
+		return err
+	}
+
+	// The pidfile does not exist yet, so we cannot monitor it directly.
+	// Instead we monitor its parent directory with FAN_EVENT_ON_CHILD to
+	// get events on the directory's children.
+	pidFileDir := filepath.Dir(pidFile)
+	err = pidFileDirNotify.Mark(unix.FAN_MARK_ADD, unix.FAN_ACCESS_PERM|unix.FAN_EVENT_ON_CHILD, unix.AT_FDCWD, pidFileDir)
+	if err != nil {
+		pidFileDirNotify.File.Close()
+		return fmt.Errorf("cannot mark %s: %w", bundleDir, err)
+	}
+
+	// watchPidFileIterate() will read config.json and it might be in the
+	// same directory as the pid file. To avoid getting events unrelated to
+	// the pidfile, add an ignore mask.
+	//
+	// This is best effort because the ignore mask is unfortunately not
+	// respected until a fix in Linux 5.9:
+	// https://github.com/torvalds/linux/commit/497b0c5a7c0688c1b100a9c2e267337f677c198e
+	configJsonPath := filepath.Join(bundleDir, "config.json")
+	err = pidFileDirNotify.Mark(unix.FAN_MARK_ADD|unix.FAN_MARK_IGNORED_MASK, unix.FAN_ACCESS_PERM, unix.AT_FDCWD, configJsonPath)
+	if err != nil {
+		pidFileDirNotify.File.Close()
+		return fmt.Errorf("cannot ignore %s: %w", configJsonPath, err)
+	}
+
+	go func() {
+		for {
+			stop, err := n.watchPidFileIterate(pidFileDirNotify, bundleDir, pidFile, pidFileDir)
+			if err != nil {
+				log.Errorf("error: %v\n", err)
+			}
+			if stop {
+				pidFileDirNotify.File.Close()
+				return
+			}
+		}
+	}()
+
+	return nil
+}
+
+func (n *RuncNotifier) watchRunc() {
+	for {
+		stop, err := n.watchRuncIterate()
+		if err != nil {
+			log.Errorf("error: %v\n", err)
+		}
+		if stop {
+			n.runcBinaryNotify.File.Close()
+			return
+		}
+	}
+}
+
+func (n *RuncNotifier) watchRuncIterate() (bool, error) {
+	// Get the next event from fanotify.
+	// Even though the API allows to pass skipPIDs, we cannot use it here
+	// because ResponseAllow would not be called.
+	data, err := n.runcBinaryNotify.GetEvent()
+	if err != nil {
+		return true, fmt.Errorf("%w", err)
+	}
+
+	// data can be nil if the event received is from a process in skipPIDs.
+	// In that case, skip and get the next event.
+	if data == nil {
+		return false, nil
+	}
+
+	// Don't leak the fd received by GetEvent
+	defer data.Close()
+
+	if !data.MatchMask(unix.FAN_OPEN_EXEC_PERM) {
+		// This should not happen: FAN_OPEN_EXEC_PERM is the only mask Marked
+		return false, fmt.Errorf("fanotify: unknown event on runc: mask=%d pid=%d", data.Mask, data.Pid)
+	}
+
+	// This unblocks the execution
+	defer n.runcBinaryNotify.ResponseAllow(data)
+
+	pid := data.GetPID()
+
+	// Skip events triggered by ourselves
+	if pid == os.Getpid() {
+		return false, nil
+	}
+
+	// runc is executing itself with unix.Exec(), so fanotify receives two
+	// FAN_OPEN_EXEC_PERM events:
+	//   1. from containerd-shim (or similar)
+	//   2. from runc, by this re-execution.
+	// This filter skips the first one and handles the second one.
+	if commFromPid(pid) != "runc" {
+		return false, nil
+	}
+
+	// Parse runc command line
+	cmdlineArr := cmdlineFromPid(pid)
+	createFound := false
+	bundleDir := ""
+	pidFile := ""
+	for i := 0; i < len(cmdlineArr); i++ {
+		if cmdlineArr[i] == "create" {
+			createFound = true
+			continue
+		}
+		if cmdlineArr[i] == "--bundle" && i+1 < len(cmdlineArr) {
+			i++
+			bundleDir = cmdlineArr[i]
+			continue
+		}
+		if cmdlineArr[i] == "--pid-file" && i+1 < len(cmdlineArr) {
+			i++
+			pidFile = cmdlineArr[i]
+			continue
+		}
+	}
+
+	if createFound && bundleDir != "" && pidFile != "" {
+		err := n.monitorRuncInstance(bundleDir, pidFile)
+		if err != nil {
+			log.Errorf("error: %v\n", err)
+		}
+	}
+
+	return false, nil
+
+}


### PR DESCRIPTION
# New hook mode: runcfanotify

This hook gets new container creation events in a synchronous way thanks to fanotify's FAN_OPEN_EXEC_PERM and FAN_ACCESS_PERM features which work in a synchronous way. 

* Use fanotify_mark FAN_OPEN_EXEC_PERM on the runc binary and parse its command line parameters, in particular the --bundle and --pid-file parameters.
* Before letting runc executing, use fanotify_mark FAN_ACCESS_PERM on the pid file to notice when `containerd-shim` reads the file.
* Let `runc create` resume.
* Before letting `containerd-shim` read the file, add the container in the Gadget Tracer Manager
* Let `containerd-shim` resume and start the container

## How to use

```
kubectl gadget deploy --hook-mode=fanotify
```

## Testing done

Tested on:
* Minikube with the docker driver and Linux 5.12.6-300.fc34.x86_64.
* AKS with Linux 5.4.0-1055-azure

I tested with this pod:
```
apiVersion: apps/v1
kind: DaemonSet
metadata:
  name: normal-pod
  namespace: default
  labels:
    k8s-app: normal-pod
spec:
  selector:
    matchLabels:
      name: normal-pod
  template:
    metadata:
      labels:
        name: normal-pod
        role: demo
    spec:
      containers:
      - name: normal-pod
        image: busybox
        command: [ "sleep", "100000" ]
```

And I restart the pod with:
```
kubectl delete pod -l name=normal-pod --force
```

With the following gadgets running:
```
./kubectl-gadget-linux-amd64 execsnoop -n default
NODE             NAMESPACE        PODNAME          CONTAINERNAME   PCOMM            PID    PPID   RET ARGS
minikube         default          normal-pod-ks8hs normal-pod      sleep            3131505 3131488   0 /bin/sleep 100000 
```

```
./kubectl-gadget-linux-amd64 opensnoop -n default
NODE             NAMESPACE        PODNAME          CONTAINERNAME   PID    COMM              FD ERR PATH
minikube         default          normal-pod-vtlh5 normal-pod      3131505 runc:[2:INIT]      6   0 /proc/sys/kernel/cap_last_cap
minikube         default          normal-pod-vtlh5 normal-pod      3131505 runc:[2:INIT]      6   0 /proc/cpuinfo
minikube         default          normal-pod-vtlh5 normal-pod      3131505 runc:[2:INIT]      6   0 /proc/self/mountinfo
minikube         default          normal-pod-vtlh5 normal-pod      3131505 runc:[2:INIT]      6   0 /sys/kernel/mm/hugepages
minikube         default          normal-pod-vtlh5 normal-pod      3131505 runc:[2:INIT]      6   0 /proc/filesystems
minikube         default          normal-pod-vtlh5 normal-pod      3131505 runc:[2:INIT]      6   0 /proc/self/mountinfo
minikube         default          normal-pod-vtlh5 normal-pod      3131505 runc:[2:INIT]      6   0 /proc/self/mountinfo
minikube         default          normal-pod-vtlh5 normal-pod      3131505 runc:[2:INIT]      6   0 /proc/self/mountinfo
minikube         default          normal-pod-vtlh5 normal-pod      3131505 runc:[2:INIT]      8   0 /proc/self/cgroup
minikube         default          normal-pod-vtlh5 normal-pod      3131505 runc:[2:INIT]      6   0 /proc/self/cgroup
minikube         default          normal-pod-vtlh5 normal-pod      3131505 runc:[2:INIT]      6   0 /dev/null
minikube         default          normal-pod-vtlh5 normal-pod      3131505 runc:[2:INIT]      6   0 /proc/self/fd
minikube         default          normal-pod-vtlh5 normal-pod      3131505 runc:[2:INIT]      6   0 /var/lib/docker/overlay2/0ff294128cb6e8c393a89ef9475b3c322fcf5d2bb19e27755afa18ec83cc1996/merged/dev/termination-log
minikube         default          normal-pod-vtlh5 normal-pod      3131505 runc:[2:INIT]      6   0 /proc/self/uid_map
minikube         default          normal-pod-vtlh5 normal-pod      3131505 runc:[2:INIT]      6   0 /
minikube         default          normal-pod-vtlh5 normal-pod      3131505 runc:[2:INIT]      8   0 /var/lib/docker/overlay2/0ff294128cb6e8c393a89ef9475b3c322fcf5d2bb19e27755afa18ec83cc1996/merged
minikube         default          normal-pod-vtlh5 normal-pod      3131505 runc:[2:INIT]      6   0 /proc/self/status
minikube         default          normal-pod-vtlh5 normal-pod      3131505 runc:[2:INIT]      6   0 /etc/passwd
minikube         default          normal-pod-vtlh5 normal-pod      3131505 runc:[2:INIT]      8   0 /etc/group
minikube         default          normal-pod-vtlh5 normal-pod      3131505 runc:[2:INIT]      6   0 /etc/group
minikube         default          normal-pod-vtlh5 normal-pod      3131505 runc:[2:INIT]      6   0 /proc/self/setgroups
minikube         default          normal-pod-ks8hs normal-pod      3131505 runc:[2:INIT]      3   0 /proc/self/fd/5
```

```
kubectl run -ti --rm --restart=Never --image=ubuntu ubuntu  -- sh -c 'echo 42|cat|cat'
```

```
$ ./kubectl-gadget-linux-amd64 execsnoop -n default
NODE             NAMESPACE        PODNAME          CONTAINERNAME   PCOMM            PID    PPID   RET ARGS
minikube         default          ubuntu           ubuntu          sh               3135695 3135678   0 /usr/bin/sh -c echo 42|cat|cat 
minikube         default          ubuntu           ubuntu          cat              3135710 3135695   0 /usr/bin/cat 
minikube         default          ubuntu           ubuntu          cat              3135709 3135695   0 /usr/bin/cat 
```

```
$ ./kubectl-gadget-linux-amd64 opensnoop -n default
minikube         default          ubuntu           ubuntu          3135695 runc:[2:INIT]      7   0 /proc/sys/kernel/cap_last_cap
minikube         default          ubuntu           ubuntu          3135695 runc:[2:INIT]      7   0 /proc/cpuinfo
minikube         default          ubuntu           ubuntu          3135695 runc:[2:INIT]      7   0 /proc/self/mountinfo
minikube         default          ubuntu           ubuntu          3135695 runc:[2:INIT]      7   0 /sys/kernel/mm/hugepages
minikube         default          ubuntu           ubuntu          3135695 runc:[2:INIT]      7   0 /proc/filesystems
minikube         default          ubuntu           ubuntu          3135695 runc:[2:INIT]      7   0 /proc/self/mountinfo
minikube         default          ubuntu           ubuntu          3135695 runc:[2:INIT]      7   0 /proc/self/mountinfo
minikube         default          ubuntu           ubuntu          3135695 runc:[2:INIT]      7   0 /proc/self/mountinfo
minikube         default          ubuntu           ubuntu          3135695 runc:[2:INIT]      9   0 /proc/self/cgroup
minikube         default          ubuntu           ubuntu          3135695 runc:[2:INIT]      7   0 /proc/self/cgroup
minikube         default          ubuntu           ubuntu          3135695 runc:[2:INIT]      7   0 /var/lib/docker/overlay2/f771894138826830619fd9d3e9aef0685876ecabd5d44a4e04936033e0d1ac45/merged/dev/termination-log
minikube         default          ubuntu           ubuntu          3135695 runc:[2:INIT]      7   0 /proc/self/uid_map
minikube         default          ubuntu           ubuntu          3135695 runc:[2:INIT]      7   0 /
minikube         default          ubuntu           ubuntu          3135695 runc:[2:INIT]      9   0 /var/lib/docker/overlay2/f771894138826830619fd9d3e9aef0685876ecabd5d44a4e04936033e0d1ac45/merged
minikube         default          ubuntu           ubuntu          3135695 runc:[2:INIT]      7   0 /dev/null
minikube         default          ubuntu           ubuntu          3135695 runc:[2:INIT]      7   0 /dev/ptmx
minikube         default          ubuntu           ubuntu          3135695 runc:[2:INIT]      9   0 /dev/console
minikube         default          ubuntu           ubuntu          3135695 runc:[2:INIT]      9   0 /dev/pts/0
minikube         default          ubuntu           ubuntu          3135695 runc:[2:INIT]      3   0 /proc/self/fd
minikube         default          ubuntu           ubuntu          3135695 runc:[2:INIT]      3   0 /proc/self/status
minikube         default          ubuntu           ubuntu          3135695 runc:[2:INIT]      3   0 /etc/passwd
minikube         default          ubuntu           ubuntu          3135695 runc:[2:INIT]      7   0 /etc/group
minikube         default          ubuntu           ubuntu          3135695 runc:[2:INIT]      3   0 /proc/self/setgroups
minikube         default          ubuntu           ubuntu          3135695 runc:[2:INIT]      3   0 /proc/self/fd/6
minikube         default          ubuntu           ubuntu          3135695 sh                 3   0 /etc/ld.so.cache
minikube         default          ubuntu           ubuntu          3135695 sh                 3   0 /lib/x86_64-linux-gnu/libc.so.6
minikube         default          ubuntu           ubuntu          3135709 cat                3   0 /etc/ld.so.cache
minikube         default          ubuntu           ubuntu          3135709 cat                3   0 /lib/x86_64-linux-gnu/libc.so.6
minikube         default          ubuntu           ubuntu          3135710 cat                3   0 /etc/ld.so.cache
minikube         default          ubuntu           ubuntu          3135710 cat                3   0 /lib/x86_64-linux-gnu/libc.so.6
```