### PR TITLE
kubectl-gadget process-collector: Improve output for empty case

### DIFF
--- a/cmd/kubectl-gadget/collector.go
+++ b/cmd/kubectl-gadget/collector.go
@@ -320,15 +320,15 @@ func collectorCmdRun(subCommand string) func(*cobra.Command, []string) {
 			KubernetesPod       string `json:"kubernetes_pod,omitempty"`
 			KubernetesContainer string `json:"kubernetes_container,omitempty"`
 		}
-		var allProcesses []Process
+		allProcesses := []Process{}
 
 		for _, i := range results.Items {
-			var processes []Process
+			processes := []Process{}
 			json.Unmarshal([]byte(i.Status.Output), &processes)
 			allProcesses = append(allProcesses, processes...)
 		}
 		if !collectorParamThreads {
-			var allProcessesTrimmed []Process
+			allProcessesTrimmed := []Process{}
 			for _, i := range allProcesses {
 				if i.Tgid == i.Pid {
 					allProcessesTrimmed = append(allProcessesTrimmed, i)


### PR DESCRIPTION
# Improve output for empty case

Initialise Process slices so that we get an empty JSON instead of null.

## Testing done
I tested this by intentionally omitting `-A` option and with a pod that is not in the `default` namespace so that the `process-collector` doesn't find any match and `status.output` is empty.  

Before this commit:
```
$ ./kubectl-gadget-linux-amd64 process-collector -p mypod -j
null
```
After this commit:
```
$ ./kubectl-gadget-linux-amd64 process-collector -p mypod -j
[]
```

Please notice that there is an ongoing discussion to improve user experience in this kind of cases. 