### PR TITLE
kubectl-gadget socket-collector: Implement client side

### DIFF
--- a/pkg/gadgets/socket-collector/gadget.go
+++ b/pkg/gadgets/socket-collector/gadget.go
@@ -128,7 +128,9 @@ func (t *Trace) Operation(trace *gadgetv1alpha1.Trace,
 func (t *Trace) Start(trace *gadgetv1alpha1.Trace, pid uint32) {
 	output, err := tracer.RunCollector(
 		pid,
-		trace.Spec.Filter,
+		trace.Spec.Filter.Podname,
+		trace.Spec.Filter.Namespace,
+		trace.Spec.Node,
 	)
 	if err != nil {
 		gadgets.SetStatusError(trace, err.Error())

--- a/pkg/gadgets/socket-collector/types/socket-collector.go
+++ b/pkg/gadgets/socket-collector/types/socket-collector.go
@@ -1,0 +1,30 @@
+// Copyright 2021 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import (
+	eventtypes "github.com/kinvolk/inspektor-gadget/pkg/types"
+)
+
+type Event struct {
+	eventtypes.Event
+
+	Protocol      string `json:"protocol"`
+	LocalAddress  string `json:"local_address"`
+	LocalPort     uint16 `json:"local_port"`
+	RemoteAddress string `json:"remote_address"`
+	RemotePort    uint16 `json:"remote_port"`
+	Status        string `json:"status"`
+}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -40,5 +40,5 @@ type Event struct {
 
 	// Container where the event comes from, or empty for host-level or
 	// pod-level event
-	Container string `json:"contaienr,omitempty"`
+	Container string `json:"container,omitempty"`
 }


### PR DESCRIPTION
#  kubectl-gadget socket-collector: Implement client side

This PR implements the client side of socket-collector gadget introduced by PR kinvolk/inspektor-gadget#227.

Sockets are sorted in the following decreasing order:
- Node
- Namespace
- Pod
- Protocol
- Status
- Local Address
- Remote Address
- Local Port
- Remote Port

Notice that it is not yet possible to filter by labels or only by namespace.

## Testing done

Output in columns:

```
$ kubectl gadget socket-collector -n demo -p mypod
NODE      NAMESPACE    POD      PROTOCOL    LOCAL               REMOTE              STATUS
mynode    demo         mypod    TCP         10.0.0.187:44928    10.0.0.191:27017    ESTABLISHED
mynode    demo         mypod    TCP         0.0.0.0:8081        0.0.0.0:0           LISTEN
```

In JSON format:

```
$ kubectl gadget socket-collector -n demo -p mypod -j
[
  {
    "node": "mynode",
    "namespace": "demo",
    "pod": "mypod",
    "protocol": "TCP",
    "local_address": "10.0.0.187",
    "local_port": 44928,
    "remote_address": "10.0.0.191",
    "remote_port": 27017,
    "status": "ESTABLISHED"
  },
  {
    "node": "mynode",
    "namespace": "demo",
    "pod": "mypod",
    "protocol": "TCP",
    "local_address": "0.0.0.0",
    "local_port": 8081,
    "remote_address": "0.0.0.0",
    "remote_port": 0,
    "status": "LISTEN"
  }
]
```

## TODO for this PR:

- [x] Define `type Socket struct` in a place where can be used by `pkg/gadgets/socket-collector/tracer/tracer.go` and `cmd/kubectl-gadget/collector.go` to avoid defining it twice. Currently I am importing tracer on collector but it makes `kubectl-gadget-windows-amd64` compilation to fail because of incompatibility of `import "github.com/vishvananda/netns"` in `GOOS=windows`.