### PR TITLE
 gadgettracermanager: Add helper function to get containers by selectors 

### DIFF
--- a/pkg/gadgets/interface.go
+++ b/pkg/gadgets/interface.go
@@ -80,6 +80,10 @@ type Resolver interface {
 	// containers or an empty map if not found
 	LookupPIDByPod(namespace, pod string) map[string]uint32
 
+	// GetContainersBySelector returns a slice of containers that match
+	// the selector or an empty slice if there are not matches
+	GetContainersBySelector(containerSelector *pb.ContainerSelector) []pb.ContainerDefinition
+
 	// Subscribe returns the list of existing containers and registers a
 	// callback for notifications about additions and deletions of
 	// containers

--- a/pkg/gadgettracermanager/gadgettracermanager.go
+++ b/pkg/gadgettracermanager/gadgettracermanager.go
@@ -421,6 +421,21 @@ func (g *GadgetTracerManager) LookupPIDByPod(namespace, pod string) map[string]u
 	return ret
 }
 
+// GetContainersBySelector returns a slice of containers that match
+// the selector or an empty slice if there are not matches
+func (g *GadgetTracerManager) GetContainersBySelector(containerSelector *pb.ContainerSelector) []pb.ContainerDefinition {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	selectedContainers := []pb.ContainerDefinition{}
+	for _, c := range g.containers {
+		if containerSelectorMatches(containerSelector, &c) {
+			selectedContainers = append(selectedContainers, c)
+		}
+	}
+	return selectedContainers
+}
+
 func (g *GadgetTracerManager) DumpState(ctx context.Context, req *pb.DumpStateRequest) (*pb.Dump, error) {
 	g.mu.Lock()
 	defer g.mu.Unlock()

--- a/pkg/gadgettracermanager/gadgettracermanager_test.go
+++ b/pkg/gadgettracermanager/gadgettracermanager_test.go
@@ -166,6 +166,9 @@ func TestTracer(t *testing.T) {
 	if err == nil {
 		t.Fatal("Error while removing non-existent tracer: no error detected")
 	}
+	if respRemoveTracer != nil {
+		t.Fatal("Error while removing tracer: invalid response")
+	}
 
 	// Check content
 	if len(g.tracers) != 2 {
@@ -231,7 +234,7 @@ func TestContainer(t *testing.T) {
 		t.Fatal("Error while removing container: invalid response")
 	}
 
-	// Remove non-existent Tracer
+	// Remove non-existent Container
 	_, err = g.RemoveContainer(ctx, &pb.ContainerDefinition{
 		Id: "abcde99",
 	})
@@ -241,7 +244,7 @@ func TestContainer(t *testing.T) {
 
 	// Check content
 	if len(g.containers) != 2 {
-		t.Fatalf("Error while checking tracers: len %d", len(g.tracers))
+		t.Fatalf("Error while checking containers: len %d", len(g.containers))
 	}
 	_, ok := g.containers["abcde0"]
 	if !ok {


### PR DESCRIPTION
#  gadgettracermanager: Add helper function to get containers by selectors 

This PR adds function `GetContainersBySelector` to GadgetTracerManager to be able to retrieve all the containers that match the parameters defined by the `ContainerSelector` data structure. 

This function will be used together with PR #239 to run gadgets on a subset of containers defined by user through filters. Check  gadget socket-collector for an example of usage in coming PRs. 

## Testing done
Check new tests added to `TestContainer`: 
```
$ go test ./pkg/gadgettracermanager/
ok      github.com/kinvolk/inspektor-gadget/pkg/gadgettracermanager     0.011s
```
