### PR TITLE
socket-collector: fix access to bpf2go

### DIFF
--- a/pkg/gadgets/socket-collector/tracer/tools.go
+++ b/pkg/gadgets/socket-collector/tracer/tools.go
@@ -1,0 +1,23 @@
+// +build tools
+
+// Copyright 2021 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License
+
+package tracer
+
+import (
+	// Thanks to the build tag on line 1, this file will be ignored for builds, but
+	// included for dependencies
+	_ "github.com/cilium/ebpf/cmd/bpf2go"
+)


### PR DESCRIPTION
When trying to use the socket-collector package, I had an error with
bpf2go:

```
cannot find package "." in:
	/home/alban/go/src/github.com/kinvolk/inspektor-gadget/vendor/github.com/cilium/ebpf/cmd/bpf2go
```

See:
https://github.com/golang/go/issues/29516#issuecomment-454159127
