### PR TITLE
New command: local-gadget

### DIFF
--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -153,6 +153,34 @@ jobs:
       run: |
         make controller-tests
 
+    - name: Unit tests for local-gadget (as root)
+      run: |
+        KERNEL=$(uname -r)
+        ARCH=$(uname -m)
+        if test -f /sys/kernel/btf/vmlinux; then
+          echo "BTF is available at /sys/kernel/btf/vmlinux"
+        else
+          echo "BTF is not available: Trying BTFHub"
+          source /etc/os-release
+          URL="https://github.com/aquasecurity/btfhub/raw/main/archive/$ID/$VERSION_ID/$ARCH/$KERNEL.btf.tar.xz"
+          echo "Trying to download vmlinux from $URL"
+
+          if [[ $(wget -S --spider "$URL" 2>&1 | grep 'HTTP/1.1 200 OK') ]]; then
+            wget -q -O /tmp/vmlinux.btf.tar.xz "$URL"
+            tar -xvf /tmp/vmlinux.btf.tar.xz
+            # Use objcopy to put the btf info in an ELF file as libbpf and cilium/ebpf
+            # by default check if there is an ELF file with the .BTF section at
+            # /boot/vmlinux-$KERNEL.
+            sudo objcopy --input binary --output elf64-little --rename-section .data=.BTF *.btf /boot/vmlinux-$KERNEL
+            rm *.btf
+            echo "vmlinux downloaded at /boot/vmlinux-$KERNEL"
+          else
+            echo "vmlinux not found"
+          fi
+        fi
+
+        make local-gadget-tests
+
     - name: Setup Minikube
       uses: manusa/actions-setup-minikube@v2.4.2
       with:

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.dll
 *.so
 *.dylib
+/local-gadget
 /kubectl-gadget
 /kubectl-gadget-*-*
 /gadget-container/bin

--- a/Makefile
+++ b/Makefile
@@ -102,6 +102,16 @@ controller-tests: kube-apiserver etcd kubectl
 	TEST_ASSET_KUBECTL=$(KUBECTL_BIN) \
 	go test -test.v ./pkg/controllers/... -controller-test
 
+.PHONY: local-gadget-tests
+local-gadget-tests:
+	make -C gadget-container ebpf-objects
+	# Compile and execute in separate commands because Go might not be
+	# available in the root environment
+	go test -c ./pkg/local-gadget-manager \
+		-tags withebpf
+	sudo ./local-gadget-manager.test -test.v -root-test
+	rm -f ./local-gadget-manager.test
+
 .PHONY: integration-tests
 integration-tests: kubectl-gadget
 	KUBECTL_GADGET="$(shell pwd)/kubectl-gadget" \

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,17 @@ LDFLAGS := "-X main.version=$(VERSION) \
 
 .DEFAULT_GOAL := build
 .PHONY: build
-build: manifests generate kubectl-gadget gadget-container
+build: manifests generate local-gadget kubectl-gadget gadget-container
+
+# local-gadget
+.PHONY: local-gadget
+local-gadget:
+	make -C gadget-container ebpf-objects
+	go build \
+		-tags withebpf \
+		-ldflags "-X main.version=$(VERSION)" \
+		-o local-gadget \
+		github.com/kinvolk/inspektor-gadget/cmd/local-gadget
 
 # make does not allow implicit rules (with '%') to be phony so let's use
 # the 'phony_explicit' dependency to make implicit rules inherit the phony

--- a/cmd/local-gadget/main.go
+++ b/cmd/local-gadget/main.go
@@ -1,0 +1,397 @@
+// Copyright 2019-2021 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"strings"
+	"syscall"
+
+	"github.com/chzyer/readline"
+	"github.com/spf13/cobra"
+
+	"github.com/kinvolk/inspektor-gadget/pkg/local-gadget-manager"
+)
+
+// This variable is used by the "version" command and is set during build.
+var version = "undefined"
+
+var localGadgetManager *localgadgetmanager.LocalGadgetManager
+
+func newRootCmd() *cobra.Command {
+	var (
+		optionFollow            bool
+		optionOutputMode        string
+		optionContainerSelector string
+
+		rootCmd = &cobra.Command{
+			Use:   "",
+			Short: "Collection of gadgets for containers",
+		}
+
+		versionCmd = &cobra.Command{
+			Use:   "version",
+			Short: "Show version",
+			Run: func(cmd *cobra.Command, args []string) {
+				fmt.Println(version)
+			},
+		}
+
+		exitCmd = &cobra.Command{
+			Use:   "exit",
+			Short: "Exit",
+			Run: func(cmd *cobra.Command, args []string) {
+				os.Exit(0)
+			},
+		}
+
+		listGadgetsCmd = &cobra.Command{
+			Use:   "list-gadgets",
+			Short: "List all gadgets",
+			Run: func(cmd *cobra.Command, args []string) {
+				for _, n := range localGadgetManager.ListGadgets() {
+					fmt.Println(n)
+				}
+			},
+		}
+
+		listTracesCmd = &cobra.Command{
+			Use:   "list-traces",
+			Short: "List all traces",
+			Run: func(cmd *cobra.Command, args []string) {
+				for _, n := range localGadgetManager.ListTraces() {
+					fmt.Println(n)
+				}
+			},
+		}
+
+		listContainersCmd = &cobra.Command{
+			Use:   "list-containers",
+			Short: "List all containers",
+			Run: func(cmd *cobra.Command, args []string) {
+				for _, n := range localGadgetManager.ListContainers() {
+					fmt.Println(n)
+				}
+			},
+		}
+
+		createCmd = &cobra.Command{
+			Use:   "create gadget-name trace-name",
+			Short: "Create a new trace",
+			Run: func(cmd *cobra.Command, args []string) {
+				if len(args) != 2 {
+					fmt.Println("missing gadget name or trace name")
+					return
+				}
+				gadget, name := args[0], args[1]
+				err := localGadgetManager.AddTracer(gadget, name, optionContainerSelector, optionOutputMode)
+				if err != nil {
+					fmt.Println(err.Error())
+					return
+				}
+				err = localGadgetManager.Operation(name, "start")
+				if err != nil {
+					fmt.Println(err.Error())
+					return
+				}
+				ret, err := localGadgetManager.Show(name)
+				if err != nil {
+					fmt.Println(err.Error())
+					return
+				}
+				fmt.Print(ret)
+			},
+		}
+
+		operationCmd = &cobra.Command{
+			Use:   "operation trace-name [operation-name]",
+			Short: "Execute an operation on a trace",
+			Run: func(cmd *cobra.Command, args []string) {
+				if len(args) != 2 {
+					fmt.Println("missing name or operation")
+					return
+				}
+				name, opname := args[0], args[1]
+				err := localGadgetManager.Operation(name, opname)
+				if err != nil {
+					fmt.Println(err.Error())
+					return
+				}
+				ret, err := localGadgetManager.Show(name)
+				if err != nil {
+					fmt.Println(err.Error())
+					return
+				}
+				fmt.Print(ret)
+			},
+		}
+
+		showCmd = &cobra.Command{
+			Use:   "show trace-name",
+			Short: "Show the status of a trace",
+			Run: func(cmd *cobra.Command, args []string) {
+				if len(args) != 1 {
+					fmt.Println("missing name")
+					return
+				}
+				name := args[0]
+				ret, err := localGadgetManager.Show(name)
+				if err != nil {
+					fmt.Println(err.Error())
+					return
+				}
+				fmt.Print(ret)
+			},
+		}
+
+		streamCmd = &cobra.Command{
+			Use:   "stream trace-name",
+			Short: "Show the stream output of a trace",
+			Run: func(cmd *cobra.Command, args []string) {
+				if len(args) != 1 {
+					fmt.Println("missing name")
+					return
+				}
+				name := args[0]
+				var stop chan struct{}
+				sigs := make(chan os.Signal, 1)
+				if optionFollow {
+					stop = make(chan struct{})
+					signal.Notify(sigs, syscall.SIGINT)
+				}
+				ch, err := localGadgetManager.Stream(name, stop)
+				if err != nil {
+					fmt.Printf("Error: %s\n", err)
+					return
+				}
+			Loop:
+				for {
+					select {
+					case line, ok := <-ch:
+						if !ok {
+							break Loop
+						}
+						fmt.Println(line)
+					case <-sigs:
+						signal.Stop(sigs)
+						stop <- struct{}{}
+					}
+				}
+				return
+			},
+		}
+
+		deleteCmd = &cobra.Command{
+			Use:   "delete trace-name",
+			Short: "Delete a trace",
+			Run: func(cmd *cobra.Command, args []string) {
+				if len(args) != 1 {
+					fmt.Println("missing name")
+					return
+				}
+				name := args[0]
+				err := localGadgetManager.Delete(name)
+				if err != nil {
+					fmt.Println(err.Error())
+				}
+			},
+		}
+
+		dumpCmd = &cobra.Command{
+			Use:   "dump",
+			Short: "Dump internal data",
+			Run: func(cmd *cobra.Command, args []string) {
+				fmt.Println(localGadgetManager.Dump())
+			},
+		}
+
+		completionCmd = &cobra.Command{
+			Use:    "completion",
+			Hidden: true,
+		}
+	)
+
+	cobra.EnableCommandSorting = false
+	rootCmd.AddCommand(
+		completionCmd,
+		listGadgetsCmd,
+		listContainersCmd,
+		listTracesCmd,
+		createCmd,
+		operationCmd,
+		showCmd,
+		streamCmd,
+		deleteCmd,
+		dumpCmd,
+		versionCmd,
+		exitCmd,
+	)
+
+	streamCmd.Flags().BoolVarP(
+		&optionFollow,
+		"follow", "f",
+		false,
+		"output appended data as the stream grows")
+
+	createCmd.Flags().StringVarP(
+		&optionOutputMode,
+		"output-mode", "",
+		"",
+		"output mode")
+
+	createCmd.Flags().StringVarP(
+		&optionContainerSelector,
+		"container-selector", "c",
+		"",
+		"container name")
+
+	return rootCmd
+}
+
+func main() {
+	var err error
+	localGadgetManager, err = localgadgetmanager.NewManager()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	homedir, err := os.UserHomeDir()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	var completer = readline.NewPrefixCompleter(
+		readline.PcItem("list-gadgets"),
+		readline.PcItem("list-containers"),
+		readline.PcItem("list-traces"),
+		readline.PcItem("create",
+			readline.PcItemDynamic(func(string) []string {
+				return localGadgetManager.ListGadgets()
+			},
+				readline.PcItemDynamic(func(string) []string {
+					n := len(localGadgetManager.ListTraces())
+					return []string{fmt.Sprintf("trace%d", n+1)}
+				},
+					readline.PcItem("--container-selector",
+						readline.PcItemDynamic(func(string) []string {
+							return localGadgetManager.ListContainers()
+						}),
+					),
+					readline.PcItem("--output-mode",
+						readline.PcItemDynamic(func(line string) []string {
+							fields := strings.Fields(line)
+							if len(fields) < 2 {
+								return []string{}
+							}
+							// TODO: this might select the wrong field if flags are placed elsewhere
+							gadget := fields[1]
+							outputModesSupported, err := localGadgetManager.GadgetOutputModesSupported(gadget)
+							if err != nil {
+								return nil
+							}
+							return outputModesSupported
+						}),
+					),
+				),
+			),
+		),
+		readline.PcItem("operation",
+			readline.PcItemDynamic(func(string) []string {
+				return localGadgetManager.ListTraces()
+			},
+				readline.PcItemDynamic(func(line string) []string {
+					fields := strings.Fields(line)
+					if len(fields) < 2 {
+						return []string{}
+					}
+					// TODO: this might select the wrong field if flags are placed elsewhere
+					traceName := fields[1]
+					return localGadgetManager.ListOperations(traceName)
+				}),
+			),
+		),
+		readline.PcItem("show",
+			readline.PcItemDynamic(func(string) []string {
+				return localGadgetManager.ListTraces()
+			}),
+		),
+		readline.PcItem("stream",
+			readline.PcItemDynamic(func(string) []string {
+				return localGadgetManager.ListTraces()
+			},
+				readline.PcItem("--follow"),
+			),
+		),
+		readline.PcItem("delete",
+			readline.PcItemDynamic(func(string) []string {
+				return localGadgetManager.ListTraces()
+			}),
+		),
+		readline.PcItem("dump"),
+		readline.PcItem("version"),
+		readline.PcItem("exit"),
+		readline.PcItem("help"),
+	)
+
+	l, err := readline.NewEx(&readline.Config{
+		Prompt:          "\033[31m»\033[0m ",
+		HistoryFile:     filepath.Join(homedir, ".local-gadget.history"),
+		AutoComplete:    completer,
+		InterruptPrompt: "^C",
+		EOFPrompt:       "exit",
+	})
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer l.Close()
+
+	for {
+		input, err := l.Readline()
+		if err == readline.ErrInterrupt {
+			if len(input) == 0 {
+				break
+			}
+			continue
+		} else if err == io.EOF {
+			break
+		}
+
+		input = strings.TrimSpace(input)
+		if input == "" {
+			continue
+		}
+
+		if err = execInput(input); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+		}
+	}
+}
+
+func execInput(input string) error {
+	rootCmd := newRootCmd()
+
+	args := strings.Split(input, " ")
+	rootCmd.SetArgs(args)
+
+	err := rootCmd.Execute()
+	return err
+}

--- a/docs/local-gadget.md
+++ b/docs/local-gadget.md
@@ -1,0 +1,108 @@
+---
+title: local-gadget
+weight: 80
+description: >
+  How to use the local-gadget tool.
+---
+
+Inspektor Gadget can also be used without Kubernetes to trace containers with the local-gadget tool.
+
+## Examples
+
+### biolatency
+
+```
+$ sudo ./local-gadget
+» create biolatency trace1
+» operation trace1 stop
+State: Completed
+Tracing block device I/O... Hit Ctrl-C to end.
+
+     usecs               : count     distribution
+         0 -> 1          : 0        |                                        |
+         2 -> 3          : 0        |                                        |
+         4 -> 7          : 0        |                                        |
+         8 -> 15         : 0        |                                        |
+        16 -> 31         : 1        |                                        |
+        32 -> 63         : 13       |*****                                   |
+        64 -> 127        : 37       |***************                         |
+       128 -> 255        : 27       |***********                             |
+       256 -> 511        : 17       |*******                                 |
+       512 -> 1023       : 14       |*****                                   |
+      1024 -> 2047       : 2        |                                        |
+      2048 -> 4095       : 95       |****************************************|
+      4096 -> 8191       : 6        |**                                      |
+```
+
+### dns
+
+Start the DNS gadget:
+```
+$ sudo ./local-gadget 
+» create dns trace1 --container-selector shell01
+» stream trace1 -f
+{"notice":"tracer attached","node":"local","namespace":"default","pod":"shell01"}
+{"node":"local","namespace":"default","pod":"shell01","name":"wikipedia.org.","pkt_type":"OUTGOING"}
+{"node":"local","namespace":"default","pod":"shell01","name":"wikipedia.org.","pkt_type":"OUTGOING"}
+{"node":"local","namespace":"default","pod":"shell01","name":"wikipedia.org.","pkt_type":"OUTGOING"}
+{"node":"local","namespace":"default","pod":"shell01","name":"wikipedia.org.","pkt_type":"OUTGOING"}
+{"node":"local","namespace":"default","pod":"shell01","name":"www.wikipedia.org.","pkt_type":"OUTGOING"}
+{"node":"local","namespace":"default","pod":"shell01","name":"www.wikipedia.org.","pkt_type":"OUTGOING"}
+{"notice":"tracer detached","node":"local","namespace":"default","pod":"shell01"}
+```
+
+Start a container:
+```
+$ docker run -ti --rm --name shell01 busybox wget wikipedia.org
+```
+
+### seccomp
+
+```
+$ sudo ./local-gadget
+» create seccomp trace1 --container-selector shell01 --output-mode Status
+```
+
+Start a container:
+```
+docker run -ti --rm --name shell01 busybox
+```
+
+Resume from the local-gadget terminal:
+```
+» operation trace1 generate
+State: Started
+{
+  "defaultAction": "SCMP_ACT_ERRNO",
+  "architectures": [
+    "SCMP_ARCH_X86_64",
+    "SCMP_ARCH_X86",
+    "SCMP_ARCH_X32"
+  ],
+  "syscalls": [
+    {
+      "names": [
+        "arch_prctl",
+        "brk",
+        "close",
+        "fcntl",
+        "getcwd",
+        "geteuid",
+        "getpgrp",
+        "getpid",
+        "getppid",
+        "getuid",
+        "ioctl",
+        "open",
+        "poll",
+        "read",
+        "rt_sigaction",
+        "rt_sigreturn",
+        "setpgid",
+        "write"
+      ],
+      "action": "SCMP_ACT_ALLOW"
+    }
+  ]
+}
+```

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ require (
 	github.com/cilium/ebpf v0.6.3-0.20210910140648-4d5607ee1690
 	github.com/containerd/nri v0.1.1-0.20210619071632-28f76457b672
 	github.com/containers/common v0.42.0
-	github.com/docker/docker v20.10.7+incompatible
+	github.com/docker/docker v20.10.8+incompatible
 	github.com/docker/go-units v0.4.0
 	github.com/iovisor/gobpf v0.2.0 // indirect
 	github.com/kinvolk/traceloop v0.0.0-20210623155108-6f4efc6fca46

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/kinvolk/inspektor-gadget
 
 require (
+	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e
 	github.com/cilium/ebpf v0.6.3-0.20210910140648-4d5607ee1690
 	github.com/containerd/nri v0.1.1-0.20210619071632-28f76457b672
 	github.com/containers/common v0.42.0

--- a/go.sum
+++ b/go.sum
@@ -358,8 +358,9 @@ github.com/docker/docker v0.7.3-0.20190327010347-be7ac8be2ae0/go.mod h1:eEKB0N0r
 github.com/docker/docker v1.4.2-0.20190924003213-a8608b5b67c7/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker v1.4.2-0.20191219165747-a9416c67da9f/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker v20.10.3-0.20210216175712-646072ed6524+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
-github.com/docker/docker v20.10.7+incompatible h1:Z6O9Nhsjv+ayUEeI1IojKbYcsGdgYSNqxe1s2MYzUhQ=
 github.com/docker/docker v20.10.7+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v20.10.8+incompatible h1:RVqD337BgQicVCzYrrlhLDWhq6OAD2PJDUg2LsEUvKM=
+github.com/docker/docker v20.10.8+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker-credential-helpers v0.6.3/go.mod h1:WRaJzqw3CTB9bk10avuGsjVBZsD05qeibJ1/TYlvc0Y=
 github.com/docker/docker-credential-helpers v0.6.4/go.mod h1:ofX3UI0Gz1TteYBjtgs07O36Pyasyp66D2uKT7H8W1c=
 github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKohAFqRJQ=

--- a/go.sum
+++ b/go.sum
@@ -186,8 +186,11 @@ github.com/checkpoint-restore/go-criu/v4 v4.0.2/go.mod h1:xUQBLp4RLc5zJtWY++yjOo
 github.com/checkpoint-restore/go-criu/v4 v4.1.0/go.mod h1:xUQBLp4RLc5zJtWY++yjOoMoB5lihDt7fai+75m+rGw=
 github.com/checkpoint-restore/go-criu/v5 v5.0.0/go.mod h1:cfwC0EG7HMUenopBsUf9d89JlCLQIfgVcNsNN0t6T2M=
 github.com/cheggaaa/pb v1.0.27/go.mod h1:pQciLPpbU0oxA0h+VJYYLxO+XeDQb5pZijXscXHm81s=
+github.com/chzyer/logex v1.1.10 h1:Swpa1K6QvQznwJRcfTfQJmTE72DqScAa40E+fbHEXEE=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
+github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e h1:fY5BOSpyZCqRo5OhCuC+XN+r/bBCmeuuJtjz+bCNIf8=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
+github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1 h1:q763qf9huN11kDQavWsoZXJNW3xEE4JJyHa5Q25/sd8=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/cilium/ebpf v0.0.0-20200110133405-4032b1d8aae3/go.mod h1:MA5e5Lr8slmEg9bt0VpxxWqJlO4iwu3FBdHUzV7wQVg=
 github.com/cilium/ebpf v0.0.0-20200507155900-a9f01edf17e3/go.mod h1:XT+cAw5wfvsodedcijoh1l9cf7v1x9FlFB/3VmF/O8s=

--- a/pkg/container-collection/options.go
+++ b/pkg/container-collection/options.go
@@ -91,7 +91,10 @@ func WithDockerEnrichment() ContainerCollectionOption {
 			}
 			if len(containers) == 1 {
 				if len(containers[0].Names) > 0 {
-					container.Podname = strings.TrimPrefix(containers[0].Names[0], "/")
+					container.Name = strings.TrimPrefix(containers[0].Names[0], "/")
+					// Some gadgets require the namespace and pod name to be set
+					container.Namespace = "default"
+					container.Podname = container.Name
 				}
 			} else {
 				log.Errorf("container %s has %d names", container.Id, len(containers))

--- a/pkg/container-collection/options.go
+++ b/pkg/container-collection/options.go
@@ -359,7 +359,11 @@ func WithRuncFanotify() ContainerCollectionOption {
 
 		// Future containers
 		cc.containerEnrichers = append(cc.containerEnrichers, func(container *pb.ContainerDefinition) bool {
-			runcNotifier.AddWatchContainerTermination(container.Id, int(container.Pid))
+			err := runcNotifier.AddWatchContainerTermination(container.Id, int(container.Pid))
+			if err != nil {
+				log.Errorf("runc fanotify enricher: failed to watch container %s: %s", container.Id, err)
+				return false
+			}
 			return true
 		})
 		return nil

--- a/pkg/container-collection/options.go
+++ b/pkg/container-collection/options.go
@@ -61,6 +61,9 @@ func WithDockerEnrichment() ContainerCollectionOption {
 				log.Errorf("failed to inspect container %s: %s", container.ID, err)
 				continue
 			}
+			if !res.State.Running {
+				continue
+			}
 			if res.State.Pid == 0 {
 				log.Errorf("failed to inspect container %s: container pid is 0", container.ID)
 				continue

--- a/pkg/gadget-collection/gadget-collection.go
+++ b/pkg/gadget-collection/gadget-collection.go
@@ -36,3 +36,11 @@ func TraceFactories() map[string]gadgets.TraceFactory {
 		"traceloop":              traceloop.NewFactory(),
 	}
 }
+
+func TraceFactoriesForLocalGadget() map[string]gadgets.TraceFactory {
+	return map[string]gadgets.TraceFactory{
+		"dns":              dns.NewFactory(),
+		"socket-collector": socketcollector.NewFactory(),
+		"seccomp":          seccomp.NewFactory(),
+	}
+}

--- a/pkg/local-gadget-manager/local-gadget-manager.go
+++ b/pkg/local-gadget-manager/local-gadget-manager.go
@@ -1,0 +1,298 @@
+// Copyright 2019-2021 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package localgadgetmanager
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	gadgetv1alpha1 "github.com/kinvolk/inspektor-gadget/pkg/api/v1alpha1"
+	"github.com/kinvolk/inspektor-gadget/pkg/container-collection"
+	"github.com/kinvolk/inspektor-gadget/pkg/gadget-collection"
+	"github.com/kinvolk/inspektor-gadget/pkg/gadgets"
+	pb "github.com/kinvolk/inspektor-gadget/pkg/gadgettracermanager/api"
+	"github.com/kinvolk/inspektor-gadget/pkg/gadgettracermanager/stream"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type LocalGadgetManager struct {
+	containercollection.ContainerCollection
+
+	traceFactories map[string]gadgets.TraceFactory
+
+	// tracers by name
+	tracers map[string]tracer
+}
+
+type tracer struct {
+	gadget        string
+	name          string
+	factory       gadgets.TraceFactory
+	traceResource *gadgetv1alpha1.Trace
+	gadgetStream  *stream.GadgetStream
+}
+
+func (l *LocalGadgetManager) ListGadgets() []string {
+	gadgets := []string{}
+	for name := range l.traceFactories {
+		gadgets = append(gadgets, name)
+	}
+	sort.Strings(gadgets)
+	return gadgets
+}
+
+func (l *LocalGadgetManager) GadgetOutputModesSupported(gadget string) (ret []string, err error) {
+	factory, ok := l.traceFactories[gadget]
+	if !ok {
+		return nil, fmt.Errorf("unknown gadget %q", gadget)
+	}
+	outputModesSupported := factory.OutputModesSupported()
+	for k := range outputModesSupported {
+		ret = append(ret, k)
+	}
+	sort.Strings(ret)
+	return ret, nil
+}
+
+func (l *LocalGadgetManager) ListOperations(name string) []string {
+	operations := []string{}
+
+	tracer, ok := l.tracers[name]
+	if !ok {
+		return operations
+	}
+
+	for opname := range tracer.factory.Operations() {
+		operations = append(operations, opname)
+	}
+
+	sort.Strings(operations)
+	return operations
+}
+
+func (l *LocalGadgetManager) ListTraces() []string {
+	traces := []string{}
+	for name := range l.tracers {
+		traces = append(traces, name)
+	}
+	sort.Strings(traces)
+	return traces
+}
+
+func (l *LocalGadgetManager) ListContainers() []string {
+	containers := []string{}
+	l.ContainerCollection.ContainerRange(func(c *pb.ContainerDefinition) {
+		containers = append(containers, c.Name)
+	})
+	sort.Strings(containers)
+	return containers
+}
+
+func (l *LocalGadgetManager) AddTracer(gadget, name, containerFilter, outputMode string) error {
+	factory, ok := l.traceFactories[gadget]
+	if !ok {
+		return fmt.Errorf("unknown gadget %q", gadget)
+	}
+	_, ok = l.tracers[name]
+	if ok {
+		return fmt.Errorf("trace %q already exists", name)
+	}
+
+	outputModesSupported := factory.OutputModesSupported()
+	if outputMode == "" {
+		if _, ok := outputModesSupported["Stream"]; ok {
+			outputMode = "Stream"
+		} else if _, ok := outputModesSupported["Status"]; ok {
+			outputMode = "Status"
+		} else {
+			for k := range outputModesSupported {
+				outputMode = k
+				break
+			}
+		}
+	}
+	if _, ok := outputModesSupported[outputMode]; !ok {
+		outputModesSupportedStr := ""
+		for k := range outputModesSupported {
+			outputModesSupportedStr += k + ", "
+		}
+		outputModesSupportedStr = strings.TrimSuffix(outputModesSupportedStr, ", ")
+		return fmt.Errorf("unsupported output mode %q for gadget %q (must be one of: %s)", outputMode, gadget, outputModesSupportedStr)
+	}
+
+	traceResource := &gadgetv1alpha1.Trace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "gadget",
+		},
+		Spec: gadgetv1alpha1.TraceSpec{
+			Node:       "local",
+			Gadget:     gadget,
+			RunMode:    "Manual",
+			OutputMode: outputMode,
+		},
+	}
+	if containerFilter != "" {
+		traceResource.Spec.Filter = &gadgetv1alpha1.ContainerFilter{
+			Namespace: "default",
+			Podname:   containerFilter,
+			Labels:    map[string]string{},
+		}
+	}
+
+	l.tracers[name] = tracer{
+		gadget:        gadget,
+		name:          name,
+		factory:       factory,
+		traceResource: traceResource,
+		gadgetStream:  stream.NewGadgetStream(),
+	}
+	return nil
+}
+
+func (l *LocalGadgetManager) Operation(name, opname string) error {
+	tracer, ok := l.tracers[name]
+	if !ok {
+		return fmt.Errorf("cannot find trace %q", name)
+	}
+
+	if opname != "" {
+		gadgetOperation, ok := tracer.factory.Operations()[opname]
+		if !ok {
+			return fmt.Errorf("Unknown operation %q", opname)
+		}
+		tracerNamespacedName := tracer.traceResource.ObjectMeta.Namespace +
+			"/" + tracer.traceResource.ObjectMeta.Name
+		gadgetOperation.Operation(tracerNamespacedName, tracer.traceResource)
+	}
+
+	return nil
+}
+
+func (l *LocalGadgetManager) Show(name string) (ret string, err error) {
+	tracer, ok := l.tracers[name]
+	if !ok {
+		return "", fmt.Errorf("cannot find trace %q", name)
+	}
+	if tracer.traceResource.Status.State != "" {
+		ret += fmt.Sprintf("State: %s\n", tracer.traceResource.Status.State)
+	}
+	if tracer.traceResource.Status.OperationError != "" {
+		ret += fmt.Sprintf("Error: %s\n", tracer.traceResource.Status.OperationError)
+	}
+	if tracer.traceResource.Status.Output != "" {
+		ret += fmt.Sprintln(tracer.traceResource.Status.Output)
+	}
+
+	return ret, nil
+}
+
+func (l *LocalGadgetManager) Delete(name string) error {
+	tracer, ok := l.tracers[name]
+	if !ok {
+		return fmt.Errorf("cannot find trace %q", name)
+	}
+
+	tracer.factory.Delete("gadget/" + name)
+	delete(l.tracers, name)
+	return nil
+}
+
+func (l *LocalGadgetManager) PublishEvent(tracerID string, line string) error {
+	name := strings.TrimPrefix(tracerID, "trace_gadget_")
+	t, ok := l.tracers[name]
+	if !ok {
+		return fmt.Errorf("cannot find trace %q", name)
+	}
+
+	t.gadgetStream.Publish(line)
+	return nil
+}
+
+func (l *LocalGadgetManager) Stream(name string, stop chan struct{}) (chan string, error) {
+	t, ok := l.tracers[name]
+	if !ok {
+		return nil, fmt.Errorf("cannot find trace %q", name)
+	}
+
+	out := make(chan string)
+
+	ch := t.gadgetStream.Subscribe()
+
+	go func() {
+		if stop == nil {
+			for len(ch) > 0 {
+				line := <-ch
+				out <- line.Line
+			}
+			t.gadgetStream.Unsubscribe(ch)
+			close(out)
+		} else {
+			for {
+				select {
+				case <-stop:
+					t.gadgetStream.Unsubscribe(ch)
+					close(out)
+					return
+				case line := <-ch:
+					out <- line.Line
+				}
+			}
+		}
+	}()
+	return out, nil
+}
+
+func (l *LocalGadgetManager) Dump() string {
+	out := "List of containers:\n"
+	l.ContainerCollection.ContainerRange(func(c *pb.ContainerDefinition) {
+		out += fmt.Sprintf("%+v\n", c)
+	})
+	out += "List of tracers:\n"
+	for i, t := range l.tracers {
+		out += fmt.Sprintf("%v -> %q %q\n",
+			i,
+			t.gadget,
+			t.name)
+		out += fmt.Sprintf("    %+v\n", t.traceResource)
+		out += fmt.Sprintf("    %+v\n", t.traceResource.Spec.Filter)
+	}
+	return out
+}
+
+func NewManager() (*LocalGadgetManager, error) {
+	l := &LocalGadgetManager{
+		traceFactories: gadgetcollection.TraceFactoriesForLocalGadget(),
+		tracers:        make(map[string]tracer),
+	}
+	err := l.ContainerCollection.ContainerCollectionInitialize(
+		containercollection.WithPubSub(),
+		containercollection.WithCgroupEnrichment(),
+		containercollection.WithLinuxNamespaceEnrichment(),
+		containercollection.WithDockerEnrichment(),
+		containercollection.WithRuncFanotify(),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, factory := range l.traceFactories {
+		factory.Initialize(l, nil)
+	}
+
+	return l, nil
+}

--- a/pkg/local-gadget-manager/local-gadget-manager_test.go
+++ b/pkg/local-gadget-manager/local-gadget-manager_test.go
@@ -1,0 +1,269 @@
+// Copyright 2021 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package localgadgetmanager
+
+import (
+	"bytes"
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/client"
+)
+
+var rootTest = flag.Bool("root-test", false, "enable tests requiring root")
+
+func TestBasic(t *testing.T) {
+	if !*rootTest {
+		t.Skip("skipping test requiring root.")
+	}
+	localGadgetManager, err := NewManager()
+	if err != nil {
+		t.Fatalf("Failed to start local gadget manager: %s", err)
+	}
+	gadgets := localGadgetManager.ListGadgets()
+	if len(gadgets) == 0 {
+		t.Fatalf("Failed to get any gadgets")
+	}
+}
+
+func runTestContainer(t *testing.T, name, image, command string) {
+	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+	if err != nil {
+		t.Fatalf("Failed to connect to Docker: %s", err)
+	}
+	ctx := context.Background()
+
+	_ = cli.ContainerRemove(ctx, name, types.ContainerRemoveOptions{})
+
+	reader, err := cli.ImagePull(ctx, image, types.ImagePullOptions{})
+	if err != nil {
+		t.Fatalf("Failed to pull image container: %s", err)
+	}
+	io.Copy(ioutil.Discard, reader)
+
+	resp, err := cli.ContainerCreate(ctx, &container.Config{
+		Image: image,
+		Cmd:   []string{"/bin/sh", "-c", command},
+		Tty:   false,
+	}, nil, nil, nil, name)
+	if err != nil {
+		t.Fatalf("Failed to create container: %s", err)
+	}
+	if err := cli.ContainerStart(ctx, resp.ID, types.ContainerStartOptions{}); err != nil {
+		t.Fatalf("Failed to start container: %s", err)
+	}
+
+	statusCh, errCh := cli.ContainerWait(ctx, resp.ID, container.WaitConditionNotRunning)
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("Failed to wait for container: %s", err)
+		}
+	case <-statusCh:
+	}
+
+	out, err := cli.ContainerLogs(ctx, resp.ID, types.ContainerLogsOptions{ShowStdout: true})
+	if err != nil {
+		t.Fatalf("Failed to get container logs: %s", err)
+	}
+	buf := new(bytes.Buffer)
+	buf.ReadFrom(out)
+	t.Logf("Container %s output:\n%s", image, string(buf.Bytes()))
+
+	err = cli.ContainerRemove(ctx, name, types.ContainerRemoveOptions{Force: true})
+	if err != nil {
+		t.Fatalf("Failed to remove container: %s", err)
+	}
+
+	err = cli.Close()
+	if err != nil {
+		t.Fatalf("Failed to close docker client: %s", err)
+	}
+}
+
+func stacks() string {
+	buf := make([]byte, 1024)
+	for {
+		n := runtime.Stack(buf, true)
+		if n < len(buf) {
+			return string(buf[:n])
+		}
+		buf = make([]byte, 2*len(buf))
+	}
+}
+
+func currentFdList(t *testing.T) (ret string) {
+	files, err := ioutil.ReadDir("/proc/self/fd")
+	if err != nil {
+		t.Fatalf("Failed to list fds: %s", err)
+	}
+	for _, file := range files {
+		fd, err := strconv.Atoi(file.Name())
+		if err != nil {
+			continue
+		}
+		dest, err := os.Readlink("/proc/self/fd/" + file.Name())
+		if err != nil {
+			continue
+		}
+		ret += fmt.Sprintf("%d: %s\n", fd, dest)
+	}
+	return
+}
+
+func checkFdList(t *testing.T, initialFdList string, attempts int, sleep time.Duration) {
+	for i := 0; ; i++ {
+		finalFdList := currentFdList(t)
+		if initialFdList == finalFdList {
+			return
+		}
+
+		if i >= (attempts - 1) {
+			t.Fatalf("After %d attempts, fd leaked:\n%s\n%s", attempts, initialFdList, finalFdList)
+		}
+
+		time.Sleep(sleep)
+	}
+}
+
+func TestSeccomp(t *testing.T) {
+	if !*rootTest {
+		t.Skip("skipping test requiring root.")
+	}
+	localGadgetManager, err := NewManager()
+	if err != nil {
+		t.Fatalf("Failed to start local gadget manager: %s", err)
+	}
+
+	initialFdList := currentFdList(t)
+
+	containerName := "test-local-gadget-seccomp001"
+	err = localGadgetManager.AddTracer("seccomp", "my-tracer", containerName, "Stream")
+	if err != nil {
+		t.Fatalf("Failed to create tracer: %s", err)
+	}
+	err = localGadgetManager.Operation("my-tracer", "start")
+	if err != nil {
+		t.Fatalf("Failed to start the tracer: %s", err)
+	}
+
+	runTestContainer(t, containerName, "docker.io/library/alpine", "mkdir /foo ; echo OK")
+
+	ch, err := localGadgetManager.Stream("my-tracer", nil)
+	if err != nil {
+		t.Fatalf("Failed to get stream: %s", err)
+	}
+	results := <-ch
+	if !strings.Contains(results, "- mkdir") {
+		t.Fatalf("Failed to get correct Seccomp Policy: %s", results)
+	}
+
+	err = localGadgetManager.Delete("my-tracer")
+	if err != nil {
+		t.Fatalf("Failed to delete tracer: %s", err)
+	}
+
+	s := stacks()
+	keyword := "seccomp"
+	if strings.Contains(s, keyword) {
+		t.Fatalf("Error: stack contains %q:\n%s", keyword, s)
+	}
+
+	checkFdList(t, initialFdList, 5, 100*time.Millisecond)
+}
+
+func TestDNS(t *testing.T) {
+	if !*rootTest {
+		t.Skip("skipping test requiring root.")
+	}
+	localGadgetManager, err := NewManager()
+	if err != nil {
+		t.Fatalf("Failed to start local gadget manager: %s", err)
+	}
+
+	initialFdList := currentFdList(t)
+
+	containerName := "test-local-gadget-dns001"
+	err = localGadgetManager.AddTracer("dns", "my-tracer", containerName, "Stream")
+	if err != nil {
+		t.Fatalf("Failed to create tracer: %s", err)
+	}
+	err = localGadgetManager.Operation("my-tracer", "start")
+	if err != nil {
+		t.Fatalf("Failed to start the tracer: %s", err)
+	}
+
+	runTestContainer(t, containerName, "docker.io/tutum/dnsutils", "dig microsoft.com")
+
+	ch, err := localGadgetManager.Stream("my-tracer", nil)
+	if err != nil {
+		t.Fatalf("Failed to get stream: %s", err)
+	}
+	results := <-ch + "\n"
+	results += <-ch + "\n"
+	results += <-ch + "\n"
+	t.Logf("Output:\n%s", results)
+
+	expectedResults := `{"notice":"tracer attached","node":"local","namespace":"default","pod":"test-local-gadget-dns001"}
+{"node":"local","namespace":"default","pod":"test-local-gadget-dns001","name":"microsoft.com.","pkt_type":"OUTGOING"}
+{"notice":"tracer detached","node":"local","namespace":"default","pod":"test-local-gadget-dns001"}
+`
+	if results != expectedResults {
+		t.Fatalf("Failed to get correct DNS: %s", results)
+	}
+
+	err = localGadgetManager.Delete("my-tracer")
+	if err != nil {
+		t.Fatalf("Failed to delete tracer: %s", err)
+	}
+
+	s := stacks()
+	keyword := "pkg/gadgets/dns/"
+	if strings.Contains(s, keyword) {
+		t.Fatalf("Error: stack contains %q:\n%s", keyword, s)
+	}
+
+	checkFdList(t, initialFdList, 5, 100*time.Millisecond)
+}
+
+func TestCollector(t *testing.T) {
+	if !*rootTest {
+		t.Skip("skipping test requiring root.")
+	}
+	localGadgetManager, err := NewManager()
+	if err != nil {
+		t.Fatalf("Failed to start local gadget manager: %s", err)
+	}
+
+	err = localGadgetManager.AddTracer("socket-collector", "my-tracer1", "my-container", "Status")
+	if err != nil {
+		t.Fatalf("Failed to create tracer: %s", err)
+	}
+	err = localGadgetManager.Operation("my-tracer1", "start")
+	if err != nil {
+		t.Fatalf("Failed to start the tracer: %s", err)
+	}
+}


### PR DESCRIPTION
# New command: local-gadget

This patch makes the gadgets from Inspektor Gadget available on a Linux
machine without Kubernetes:
- kubectl-gadget: Inspektor Gadget on Kubernetes
- local-gadget: Inspektor Gadget on a single Linux machine

local-gadget can be executed without parameters and it will start a
shell with auto completion. Type "help" to get the list of commands.
Commands are implemented with cobra.

local-gadget uses the runc fanotify package to know when containers
based on runc are started or stopped. Notably it works with docker
containers.

Possible use cases:

- Faster development cycle of gadgets: they no longer need to be
  deployed on Kubernetes and the compilation of a single binary is
  faster than the build of the gadget container.

- Easier to write gadget tests: we can test whether a BPF program is
  accepted by the verifier without deploying to Kubernetes.

- Some gadgets have meaningful use cases on their own on a single Linux
  machine. E.g. generate seccomp profiles with Docker.

## Compilation

```
make local-gadget
```

## Example with biolatency:

```
( echo trace biolatency t1 ; \
  echo operation t1 start ; \
  sleep 5 ; \
  echo operation t1 stop ) | sudo ./local-gadget
```

```
Output: Tracing block device I/O... Hit Ctrl-C to end.

     usecs               : count     distribution
         0 -> 1          : 0        |                                        |
         2 -> 3          : 0        |                                        |
         4 -> 7          : 0        |                                        |
         8 -> 15         : 0        |                                        |
        16 -> 31         : 0        |                                        |
        32 -> 63         : 1        |********************                    |
        64 -> 127        : 0        |                                        |
       128 -> 255        : 0        |                                        |
       256 -> 511        : 0        |                                        |
       512 -> 1023       : 0        |                                        |
      1024 -> 2047       : 2        |****************************************|
      2048 -> 4095       : 1        |********************                    |
```

## Example with seccomp:
```
( echo trace seccomp t1 mycontainer ; \
  echo operation t1 start ; \
  echo operation t1 generate ) | sudo ./local-gadget
```

```
Output: {
  "defaultAction": "SCMP_ACT_ERRNO",
  "architectures": [
    "SCMP_ARCH_X86_64",
    "SCMP_ARCH_X86",
    "SCMP_ARCH_X32"
  ],
  "syscalls": [
    {
      "names": [],
      "action": "SCMP_ACT_ALLOW"
    }
  ]
}
```
## Testing done

Tested on Minikube with the docker driver on 5.12.6-300.fc34.x86_64.

There are a few tests for LocalGadgetManager. The tests require root.

Example of execution:
```
$ sudo unshare --net make local-gadget-tests
go test -test.v ./pkg/local-gadget-manager/... -root-test \
        -tags withebpf
=== RUN   TestBasic
--- PASS: TestBasic (0.00s)
=== RUN   TestSeccomp
State: Started
OperationError:
Output:
State: Stopped
OperationError:
Output:
--- PASS: TestSeccomp (0.19s)
=== RUN   TestCollector
time="2021-08-30T09:04:25+02:00" level=info msg="Gadget socket-collector: Using PID 919055 to retrieve network namespaces of Podname \"my-container\" in Namespace \"local\""
State: Completed
OperationError:
Output: []
State: Completed
OperationError:
Output: [
]

--- PASS: TestCollector (0.13s)
PASS
ok      github.com/kinvolk/inspektor-gadget/pkg/local-gadget-manager    0.334s
```
