### PR TITLE
Avoid recompiling gadget-container when only client code changed

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,5 @@
 *
 !go.mod
 !go.sum
-!cmd
 !gadget-container
 !pkg


### PR DESCRIPTION
# Avoid recompiling gadget-container when only client code changed

Remove `cmd` folder (which includes only client source code) from `.dockerignore` file to avoid gadget-container being recompiled if only client code changed.

This PR follows idea of working with Docker layers introduced in PR kinvolk/inspektor-gadget#188. 

## Testing done

1. Modify one file on `cmd` folder
2. Execute `make gadget-container`
3. Check that `gadget-container-deps` are not recompiled.
4. Check generated image passes all tests.