### PR TITLE
socket-collector: Improve filtering

### DIFF
--- a/cmd/kubectl-gadget/utils/trace.go
+++ b/cmd/kubectl-gadget/utils/trace.go
@@ -229,6 +229,13 @@ RetryLoop:
 		nodeErrors := make(map[string]string)
 		for _, i := range results.Items {
 			if i.Status.State == "Completed" || i.Status.State == "Started" {
+				if i.Status.Output == "" && i.Spec.OutputMode == "Status" {
+					// Ignoring empty outputs allows us to show an error instead of
+					// an empty list when none of the traces generate an output.
+					// This is particularly useful for gadgets like socket-collector
+					// where an empty list could be misunderstood.
+					continue
+				}
 				successNodeCount++
 			} else {
 				if timeout {


### PR DESCRIPTION
# socket-collector: Improve filtering

This commit improves the filtering for the socket-collector gadget introduced by PR #227. It is now possible to filter by namespace (or use -A for all-namespaces) and labels.

## Testing done

Some examples with the output in columns:

```
$ kubectl gadget socket-collector -n default
NODE      NAMESPACE    POD         PROTOCOL    LOCAL               REMOTE              STATUS
mynode    default      my-pod      TCP         10.0.0.187:44928    10.0.0.191:27017    ESTABLISHED
mynode    default      my-pod      TCP         0.0.0.0:8081        0.0.0.0:0           LISTEN
mynode    default      my-pod-2    TCP         127.0.0.1:51962     127.0.0.1:2379      ESTABLISHED
```

```
$ kubectl gadget socket-collector -n demo
NODE      NAMESPACE    POD       PROTOCOL    LOCAL            REMOTE           STATUS
mynode    demo         my-pod    UDP         10.0.0.216:68    10.0.0.107:67    ACTIVE
```

```
$ kubectl gadget socket-collector -A -p my-pod
NODE      NAMESPACE    POD       PROTOCOL    LOCAL               REMOTE              STATUS
mynode    default      my-pod    TCP         10.0.0.187:44928    10.0.0.191:27017    ESTABLISHED
mynode    default      my-pod    TCP         0.0.0.0:8081        0.0.0.0:0           LISTEN
mynode    demo         my-pod    UDP         10.0.0.216:68       10.0.0.107:67       ACTIVE
```

```
$ kubectl gadget socket-collector -n kube-system -l k8s-app=gadget
NODE      NAMESPACE      POD             PROTOCOL    LOCAL               REMOTE             STATUS
mynode    kube-system    gadget-gw7bh    TCP         10.0.0.205:57476    10.0.0.234:4240    ESTABLISHED
mynode    kube-system    gadget-gw7bh    TCP         127.0.0.1:2379      127.0.0.1:51920    ESTABLISHED
mynode    kube-system    gadget-gw7bh    TCP         127.0.0.1:2379      127.0.0.1:52010    ESTABLISHED
```
