### PR TITLE
Add support for arm64 on linux and darwin

### DIFF
--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -98,9 +98,10 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-single-buildx
 
-    - name: Login to DockerHub
+    - name: Login to Container Registry
       uses: docker/login-action@v1
       with:
+        registry: ${{ secrets.CONTAINER_REGISTRY }}
         username: ${{ secrets.CONTAINER_REGISTRY_USERNAME }}
         password: ${{ secrets.CONTAINER_REGISTRY_PASSWORD }}
 

--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -123,14 +123,13 @@ jobs:
         rm -rf /tmp/.buildx-cache
         mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
-    - name: Build kubectl gadget Plugin
+    - name: Build kubectl gadget plugin for all platforms
       run: |
-        make kubectl-gadget
+        make kubectl-gadget-all
 
         # Prepare assets for release and actions artifacts
-
-        platforms="darwin-amd64 linux-amd64 windows-amd64"
-        for platform in $platforms; do
+        for target in $(make list-kubectl-gadget-targets); do
+          platform=$(echo $target|cut -d- -f3-4)
           mkdir $platform
           cp kubectl-gadget-$platform $platform/kubectl-gadget
           cp LICENSE $platform/
@@ -175,41 +174,13 @@ jobs:
         draft: false
         prerelease: false
 
-    - name: Upload linux-amd64 Release Asset
-      id: upload-release-asset-linux-amd64
-      uses: actions/upload-release-asset@v1.0.1
+    - name: Upload kubectl-gadget Release Assets
+      uses: csexton/release-asset-action@v2
       if: startsWith(github.ref, 'refs/tags/v')
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: inspektor-gadget-linux-amd64.tar.gz
-        asset_name: inspektor-gadget-linux-amd64.tar.gz
-        asset_content_type: application/gzip
-
-    - name: Upload darwin-amd64 Release Asset
-      id: upload-release-asset-darwin-amd64
-      uses: actions/upload-release-asset@v1.0.1
-      if: startsWith(github.ref, 'refs/tags/v')
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: inspektor-gadget-darwin-amd64.tar.gz
-        asset_name: inspektor-gadget-darwin-amd64.tar.gz
-        asset_content_type: application/gzip
-
-    - name: Upload windows-amd64 Release Asset
-      id: upload-release-asset-windows-amd64
-      uses: actions/upload-release-asset@v1.0.1
-      if: startsWith(github.ref, 'refs/tags/v')
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: inspektor-gadget-windows-amd64.tar.gz
-        asset_name: inspektor-gadget-windows-amd64.tar.gz
-        asset_content_type: application/gzip
+        pattern: "inspektor-gadget-*-*.tar.gz"
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        release-url: ${{ steps.create_release.outputs.upload_url }}
 
     - name: Upload Testing Asset
       id: upload-release-asset-testing
@@ -230,4 +201,4 @@ jobs:
 
     - name: Update new version in krew-index
       if: startsWith(github.ref, 'refs/tags/v')
-      uses: rajatjindal/krew-release-bot@v0.0.38
+      uses: rajatjindal/krew-release-bot@v0.0.40

--- a/.gitignore
+++ b/.gitignore
@@ -4,9 +4,7 @@
 *.dll
 *.so
 *.dylib
-/kubectl-gadget-darwin-amd64
-/kubectl-gadget-linux-amd64
-/kubectl-gadget-windows-amd64
+/kubectl-gadget-*-*
 /gadget-container/bin
 
 # Test binary, build with `go test -c`

--- a/.krew.yaml
+++ b/.krew.yaml
@@ -32,12 +32,28 @@ spec:
         arch: amd64
     {{addURIAndSha "https://github.com/kinvolk/inspektor-gadget/releases/download/{{ .TagName }}/inspektor-gadget-linux-amd64.tar.gz" .TagName }}
     bin: kubectl-gadget
+
+  - selector:
+      matchLabels:
+        os: linux
+        arch: arm64
+    {{addURIAndSha "https://github.com/kinvolk/inspektor-gadget/releases/download/{{ .TagName }}/inspektor-gadget-linux-arm64.tar.gz" .TagName }}
+    bin: kubectl-gadget
+
   - selector:
       matchLabels:
         os: darwin
         arch: amd64
     {{addURIAndSha "https://github.com/kinvolk/inspektor-gadget/releases/download/{{ .TagName }}/inspektor-gadget-darwin-amd64.tar.gz" .TagName }}
     bin: kubectl-gadget
+
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: arm64
+    {{addURIAndSha "https://github.com/kinvolk/inspektor-gadget/releases/download/{{ .TagName }}/inspektor-gadget-darwin-arm64.tar.gz" .TagName }}
+    bin: kubectl-gadget
+
   - selector:
       matchLabels:
         os: windows

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -72,6 +72,7 @@ to be able to use them:
 
 
 - `CONTAINER_REPO`: The container repository to use. Example: docker.io/kinvolk/gadget
+- `CONTAINER_REGISTRY`: The registry containing the repo above. Leave empty for Docker Hub. Example: ghcr.io, foo.azurecr.io, gcr.io
 - `CONTAINER_REGISTRY_USERNAME` & `CONTAINER_REGISTRY_PASSWORD`: Authentication information for the the repo above.
 
 ### Development environment on minikube for the traceloop gadget

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -27,8 +27,11 @@ use the value of the `CONTAINER_REPO` env variable, it defaults to
 
 ### Building the client executable
 
-You can compile for all supported platforms by running `make kubectl-gadget`
-or build for a specific one with `make kubectl-gadget-linux-amd64` or `make kubectl-gadget-darwin-amd64`.
+You can compile for your platform by running `make kubectl-gadget`.
+
+To cross compile for all supported platforms, you can run `make
+kubectl-gadget-all` or select a specific one with `make
+kubectl-gadget-linux-amd64` or `make kubectl-gadget-darwin-amd64`.
 
 ### Building the gadget container image
 

--- a/integration/Makefile
+++ b/integration/Makefile
@@ -1,4 +1,5 @@
-IMAGE_TAG=$(shell ../tools/image-tag branch)
+CONTAINER_REPO ?= docker.io/kinvolk/gadget
+IMAGE_TAG ?= $(shell ./tools/image-tag branch)
 
 TESTS_DOCKER_ARGS ?= "-e KUBECONFIG=/opt/kubeconfig/config -v $(HOME)/.kube:/opt/kubeconfig"
 
@@ -6,12 +7,12 @@ TESTS_DOCKER_ARGS ?= "-e KUBECONFIG=/opt/kubeconfig/config -v $(HOME)/.kube:/opt
 build:
 	mkdir -p bin
 	cp ../kubectl-gadget-linux-amd64 bin/kubectl-gadget
-	docker build -t docker.io/kinvolk/gadgettest:$(IMAGE_TAG) -f Dockerfile .
+	docker build -t $(CONTAINER_REPO)test:$(IMAGE_TAG) -f Dockerfile .
 	rm -f bin/kubectl-gadget
 
 .PHONY: push
 push:
-	docker push docker.io/kinvolk/gadgettest:$(IMAGE_TAG)
+	docker push $(CONTAINER_REPO)test:$(IMAGE_TAG)
 
 .PHONY: test
 test:
@@ -20,12 +21,12 @@ test:
 		docker run -i \
 			--net=host \
 			$(TESTS_DOCKER_ARGS) \
-			docker.io/kinvolk/gadgettest:$(IMAGE_TAG) ; \
+			$(CONTAINER_REPO)test:$(IMAGE_TAG) ; \
 	else \
 		echo "Running tests with KUBECONFIG = $(KUBECONFIG)" ; \
 		docker run -i \
 			--net=host \
 			-e KUBECONFIG=/opt/kubeconfig/$(shell basename "$(KUBECONFIG)") \
 			-v $(shell dirname "$(KUBECONFIG)"):/opt/kubeconfig \
-			docker.io/kinvolk/gadgettest:$(IMAGE_TAG) ; \
+			$(CONTAINER_REPO)test:$(IMAGE_TAG) ; \
 	fi

--- a/tests.mk
+++ b/tests.mk
@@ -1,6 +1,4 @@
 TEST_ASSETS=$(PWD)/bin
-OS_NAME := $(shell uname -s | tr A-Z a-z)
-ARCH ?= amd64
 
 # download etcd
 etcd:
@@ -13,12 +11,12 @@ ifeq (, $(wildcard $(TEST_ASSETS)/etcd))
 	GITHUB_URL=https://github.com/etcd-io/etcd/releases/download ;\
 	DOWNLOAD_URL=$${GITHUB_URL} ;\
 	ETCD_VER=v3.5.0 ;\
-	wget $${DOWNLOAD_URL}/$${ETCD_VER}/etcd-$${ETCD_VER}-$(OS_NAME)-$(ARCH).tar.gz ;\
+	wget $${DOWNLOAD_URL}/$${ETCD_VER}/etcd-$${ETCD_VER}-$(GOHOSTOS)-$(GOHOSTARCH).tar.gz ;\
 	SHA256SUM=864baa0437f8368e0713d44b83afe21dce1fb4ee7dae4ca0f9dd5f0df22d01c4 ;\
-	sha256sum etcd-$${ETCD_VER}-$(OS_NAME)-$(ARCH).tar.gz | grep -q $$SHA256SUM ;\
+	sha256sum etcd-$${ETCD_VER}-$(GOHOSTOS)-$(GOHOSTARCH).tar.gz | grep -q $$SHA256SUM ;\
 	mkdir -p $(TEST_ASSETS) ;\
-	tar zxvf etcd-$${ETCD_VER}-$(OS_NAME)-$(ARCH).tar.gz ;\
-	mv etcd-$${ETCD_VER}-$(OS_NAME)-$(ARCH)/etcd $(TEST_ASSETS)/ ;\
+	tar zxvf etcd-$${ETCD_VER}-$(GOHOSTOS)-$(GOHOSTARCH).tar.gz ;\
+	mv etcd-$${ETCD_VER}-$(GOHOSTOS)-$(GOHOSTARCH)/etcd $(TEST_ASSETS)/ ;\
 	rm -rf $$INSTALL_TMP_DIR ;\
 	}
 ETCD_BIN=$(TEST_ASSETS)/etcd
@@ -34,7 +32,7 @@ ifeq (, $(wildcard $(TEST_ASSETS)/kube-apiserver))
 	INSTALL_TMP_DIR=$$(mktemp -d) ;\
 	cd $$INSTALL_TMP_DIR ;\
 	VER=v1.21.2 ;\
-	DOWNLOAD_URL=https://dl.k8s.io/$$VER/bin/$(OS_NAME)/$(ARCH)/kube-apiserver ;\
+	DOWNLOAD_URL=https://dl.k8s.io/$$VER/bin/$(GOHOSTOS)/$(GOHOSTARCH)/kube-apiserver ;\
 	wget $${DOWNLOAD_URL} ;\
 	SHA256SUM=04de7369c4e80eaaf8da440dcf62e050e908d786ac8b3248585dbe659c06d769 ;\
 	sha256sum kube-apiserver | grep -q $$SHA256SUM ;\
@@ -56,7 +54,7 @@ ifeq (, $(wildcard $(TEST_ASSETS)/kubectl))
 	INSTALL_TMP_DIR=$$(mktemp -d) ;\
 	cd $$INSTALL_TMP_DIR ;\
 	VER=v1.21.2 ;\
-	DOWNLOAD_URL=https://dl.k8s.io/$$VER/bin/$(OS_NAME)/$(ARCH)/kubectl ;\
+	DOWNLOAD_URL=https://dl.k8s.io/$$VER/bin/$(GOHOSTOS)/$(GOHOSTARCH)/kubectl ;\
 	wget $${DOWNLOAD_URL} ;\
 	SHA256SUM=55b982527d76934c2f119e70bf0d69831d3af4985f72bb87cd4924b1c7d528da ;\
 	sha256sum kubectl | grep -q $$SHA256SUM ;\


### PR DESCRIPTION
# Add support for arm64 on linux and darwin

In order to support the two new platforms, this patch avoids hardcoding
amd64 in different places.

Some changes in the Makefile:

* kubectl-gadget-all: build for all platforms
* kubectl-gadget: build for the host platform only

Other targets are updated to avoid hard coding the platform.

Fixes https://github.com/kinvolk/inspektor-gadget/issues/241

## How to use

In order to validate this PR, reviewers should:
- fork this repository
- set up GitHub Secrets in the forked repository (see [Github Actions](https://github.com/kinvolk/inspektor-gadget/blob/main/docs/CONTRIBUTING.md#github-actions))
- push a git tag on the forked repository
- and check that krew manifest is correct
- download the generated kubectl-gadget and check that it works on the arm64 harware

## Testing done

I don't have the hardware, so this is not tested.