### PR TITLE
Updates .gitignore after latest changes on Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.dll
 *.so
 *.dylib
+/kubectl-gadget
 /kubectl-gadget-*-*
 /gadget-container/bin
 


### PR DESCRIPTION
# Updates .gitignore after latest changes on Makefile

After latest changes on Makefile introduced in PR #255, when 'make kubectl-gadget' is executed, the kubectl-gadget-$(GOHOSTOS)-$(GOHOSTARCH) is renamed as kubectl-gadget. Therefore, this commit updates the .gitignore file accordantly.
