### PR TITLE
seccomp: generate SeccompProfile for terminated pods

### DIFF
--- a/pkg/gadgets/seccomp/gadget.go
+++ b/pkg/gadgets/seccomp/gadget.go
@@ -22,14 +22,17 @@ import (
 	"strings"
 	"sync"
 
+	log "github.com/sirupsen/logrus"
 	apimachineryruntime "k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	seccompprofilev1alpha1 "sigs.k8s.io/security-profiles-operator/api/seccompprofile/v1alpha1"
+	k8syaml "sigs.k8s.io/yaml"
 
 	gadgetv1alpha1 "github.com/kinvolk/inspektor-gadget/pkg/api/v1alpha1"
 	"github.com/kinvolk/inspektor-gadget/pkg/gadgets"
 	seccomptracer "github.com/kinvolk/inspektor-gadget/pkg/gadgets/seccomp/tracer"
+	"github.com/kinvolk/inspektor-gadget/pkg/gadgettracermanager/pubsub"
 )
 
 type Trace struct {
@@ -56,12 +59,50 @@ func NewFactory() gadgets.TraceFactory {
 }
 
 func (f *TraceFactory) Description() string {
-	return `The seccomp gadget traces system calls for each container in order to generate seccomp policies on-demand.`
+	return `The seccomp gadget traces system calls for each container in order to generate
+seccomp policies.
+
+The seccomp policies can be generated in two ways:
+1. on demand with the gadget.kinvolk.io/operation=generate annotation. In this
+   case, the Trace.Spec.Filter should specify the namespace and pod name to the
+   exclusion of other fields because there can be only one SeccompProfile
+   written in the Trace.Status.Output or in the SeccompProfile resource named
+   by Trace.Spec.Output. The on-demand generation supports the outputMode
+   Status and ExternalResource.
+2. automatically when containers matching the Trace.Spec.Filter terminate. In
+   this case, all filters are supported. The at-termination generation supports
+   the outputMode ExternalResource and Stream.
+
+The seccomp policies can be written in the Status field of the Trace custom
+resource, or in SeccompProfiles custom resources managed by the [Kubernetes
+Security Profiles
+Operator](https://github.com/kubernetes-sigs/security-profiles-operator).
+
+SeccompProfiles will have the following annotations:
+
+* seccomp.gadget.kinvolk.io/trace: the namespaced name of the Trace custom
+  resource that generated this SeccompProfile
+* seccomp.gadget.kinvolk.io/node: the node where this SeccompProfile was
+  generated
+* seccomp.gadget.kinvolk.io/pod: the pod namespaced name of the pod that was
+  traced
+* seccomp.gadget.kinvolk.io/container: the container name in the pod that was
+  traced
+* seccomp.gadget.kinvolk.io/container-id: the container ID in the pod that
+  was traced. Typically, 64 hexadecimal characters.
+* seccomp.gadget.kinvolk.io/pid: the process ID of the container in the pod
+  that was traced.
+
+SeccompProfiles will have the same labels as the Trace custom resource that
+generated them. They don't have meaning for the seccomp gadget. They are
+merely copied for convenience.
+`
 }
 
 func (f *TraceFactory) OutputModesSupported() map[string]struct{} {
 	return map[string]struct{}{
 		"Status":           {},
+		"Stream":           {},
 		"ExternalResource": {},
 	}
 }
@@ -99,7 +140,8 @@ func (f *TraceFactory) Operations() map[string]gadgets.TraceOperation {
 			Order: 1,
 		},
 		"generate": {
-			Doc: "Generate a seccomp profile",
+			Doc: `Generate a seccomp profile for the pod specified in Trace.Spec.Filter. The
+namespace and pod name should be specified at the exclusion of other fields.`,
 			Operation: func(name string, trace *gadgetv1alpha1.Trace) {
 				f.LookupOrCreate(name, n).(*Trace).Generate(trace)
 			},
@@ -112,6 +154,68 @@ func (f *TraceFactory) Operations() map[string]gadgets.TraceOperation {
 			},
 			Order: 3,
 		},
+	}
+}
+
+type pubSubKey string
+
+func genPubSubKey(namespace, name string) pubSubKey {
+	return pubSubKey(fmt.Sprintf("gadget/seccomp/%s/%s", namespace, name))
+}
+
+// containerTerminated is a callback called every time a container is
+// terminated on the node. It is used to generate a SeccompProfile when a
+// container terminates.
+func (t *Trace) containerTerminated(trace *gadgetv1alpha1.Trace, event pubsub.PubSubEvent) {
+	if event.Container.Mntns == 0 {
+		log.Errorf("Container has unknown mntns")
+		return
+	}
+
+	// Get the list of syscalls from the BPF hash map
+	b := traceSingleton.tracer.Peek(event.Container.Mntns)
+
+	// The container has terminated. Cleanup the BPF hash map
+	traceSingleton.tracer.Delete(event.Container.Mntns)
+
+	var r *seccompprofilev1alpha1.SeccompProfile
+	generateName := trace.ObjectMeta.Name + "-"
+	r = syscallArrToSeccompPolicy(trace.ObjectMeta.Namespace, "", generateName, b)
+
+	// Copy labels from the trace into the SeccompProfile. This will allow
+	// the CLI to add a label on the trace and gather its output
+	if trace.ObjectMeta.Labels != nil {
+		for key, value := range trace.ObjectMeta.Labels {
+			r.ObjectMeta.Labels[key] = value
+		}
+	}
+	podName := fmt.Sprintf("%s/%s", event.Container.Namespace, event.Container.Podname)
+	traceName := fmt.Sprintf("%s/%s", trace.ObjectMeta.Namespace, trace.ObjectMeta.Name)
+	r.ObjectMeta.Annotations["seccomp.gadget.kinvolk.io/trace"] = traceName
+	r.ObjectMeta.Annotations["seccomp.gadget.kinvolk.io/node"] = trace.Spec.Node
+	r.ObjectMeta.Annotations["seccomp.gadget.kinvolk.io/pod"] = podName
+	r.ObjectMeta.Annotations["seccomp.gadget.kinvolk.io/container"] = event.Container.Name
+	r.ObjectMeta.Annotations["seccomp.gadget.kinvolk.io/container-id"] = event.Container.Id
+	r.ObjectMeta.Annotations["seccomp.gadget.kinvolk.io/pid"] = fmt.Sprint(event.Container.Pid)
+
+	switch trace.Spec.OutputMode {
+	case "ExternalResource":
+		log.Infof("Trace %s: creating SeccompProfile for pod %s", traceName, podName)
+		err := t.client.Create(context.TODO(), r)
+		if err != nil {
+			log.Errorf("Failed to create Seccomp Profile for pod %s: %s", podName, err)
+		}
+	case "Stream":
+		log.Infof("Trace %s: adding SeccompProfile for pod %s in stream", traceName, podName)
+		yamlOutput, err := k8syaml.Marshal(r)
+		if err != nil {
+			log.Errorf("Failed to convert Seccomp Profile to yaml: %s", err)
+			return
+		}
+		t.resolver.PublishEvent(
+			gadgets.TraceName(trace.ObjectMeta.Namespace, trace.ObjectMeta.Name),
+			fmt.Sprintf("%s\n---\n", string(yamlOutput)),
+		)
 	}
 }
 
@@ -132,6 +236,26 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 			trace.Status.OperationError = fmt.Sprintf("Failed to start seccomp tracer: %s", err)
 			return
 		}
+
+		// 'trace' is owned by the controller and could be modified
+		// outside of the gadget control. Make a copy for the callback.
+		traceCopy := trace.DeepCopy()
+
+		// Subscribes to container termination events in order to
+		// generate a SeccompProfile when a container terminates. We
+		// don't need the list of existing containers, so the return
+		// value is ignored.
+		_ = t.resolver.Subscribe(
+			genPubSubKey(trace.ObjectMeta.Namespace, trace.ObjectMeta.Name),
+			*gadgets.ContainerSelectorFromContainerFilter(trace.Spec.Filter),
+			func(event pubsub.PubSubEvent) {
+				// Ignore container creation events.
+				if event.Type != pubsub.EVENT_TYPE_REMOVE_CONTAINER {
+					return
+				}
+				t.containerTerminated(traceCopy, event)
+			},
+		)
 	}
 	traceSingleton.users++
 	t.started = true
@@ -208,6 +332,7 @@ func (t *Trace) Generate(trace *gadgetv1alpha1.Trace) {
 		}
 	}
 
+	// Get the list of syscalls from the BPF hash map
 	b := traceSingleton.tracer.Peek(mntns)
 
 	switch trace.Spec.OutputMode {
@@ -225,9 +350,9 @@ func (t *Trace) Generate(trace *gadgetv1alpha1.Trace) {
 		parts := strings.SplitN(trace.Spec.Output, "/", 2)
 		var r *seccompprofilev1alpha1.SeccompProfile
 		if len(parts) == 2 {
-			r = syscallArrToSeccompPolicy(parts[0], parts[1], b)
+			r = syscallArrToSeccompPolicy(parts[0], parts[1], "", b)
 		} else {
-			r = syscallArrToSeccompPolicy(trace.ObjectMeta.Namespace, trace.Spec.Output, b)
+			r = syscallArrToSeccompPolicy(trace.ObjectMeta.Namespace, trace.Spec.Output, "", b)
 		}
 		err := t.client.Create(context.TODO(), r)
 		if err != nil {
@@ -252,6 +377,7 @@ func (t *Trace) Stop(trace *gadgetv1alpha1.Trace) {
 	defer traceSingleton.mu.Unlock()
 	traceSingleton.users--
 	if traceSingleton.users == 0 {
+		t.resolver.Unsubscribe(genPubSubKey(trace.ObjectMeta.Namespace, trace.ObjectMeta.Name))
 		traceSingleton.tracer.Close()
 		traceSingleton.tracer = nil
 	}

--- a/pkg/gadgets/seccomp/syscalls.go
+++ b/pkg/gadgets/seccomp/syscalls.go
@@ -86,7 +86,7 @@ func syscallArrToLinuxSeccomp(v []byte) *specs.LinuxSeccomp {
 	return s
 }
 
-func syscallArrToSeccompPolicy(namespace, name string, v []byte) *seccompprofilev1alpha1.SeccompProfile {
+func syscallArrToSeccompPolicy(namespace, name, generateName string, v []byte) *seccompprofilev1alpha1.SeccompProfile {
 	syscalls := []*seccompprofilev1alpha1.Syscall{
 		{
 			Names:  syscallArrToNameList(v),
@@ -97,8 +97,11 @@ func syscallArrToSeccompPolicy(namespace, name string, v []byte) *seccompprofile
 
 	ret := seccompprofilev1alpha1.SeccompProfile{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: namespace,
-			Name:      name,
+			Namespace:    namespace,
+			Name:         name,
+			GenerateName: generateName,
+			Annotations:  map[string]string{},
+			Labels:       map[string]string{},
 		},
 		Spec: seccompprofilev1alpha1.SeccompProfileSpec{
 			BaseProfileName: "",

--- a/pkg/gadgets/seccomp/syscalls_none.go
+++ b/pkg/gadgets/seccomp/syscalls_none.go
@@ -25,7 +25,7 @@ func syscallArrToLinuxSeccomp(v []byte) *specs.LinuxSeccomp {
 	panic("Not implemented")
 	return nil
 }
-func syscallArrToSeccompPolicy(namespace, name string, v []byte) *seccompprofilev1alpha1.SeccompProfile {
+func syscallArrToSeccompPolicy(namespace, name, generateName string, v []byte) *seccompprofilev1alpha1.SeccompProfile {
 	panic("Not implemented")
 	return nil
 }

--- a/pkg/gadgets/seccomp/tracer/tracer.go
+++ b/pkg/gadgets/seccomp/tracer/tracer.go
@@ -97,6 +97,10 @@ func (t *Tracer) Peek(mntns uint64) []byte {
 	return b[:C.SYSCALLS_COUNT]
 }
 
+func (t *Tracer) Delete(mntns uint64) {
+	t.seccompMap.Delete(mntns)
+}
+
 func (t *Tracer) Close() {
 	t.progLink.Close()
 	t.collection.Close()

--- a/pkg/resources/samples/trace-seccomp.yaml
+++ b/pkg/resources/samples/trace-seccomp.yaml
@@ -6,9 +6,19 @@ metadata:
 spec:
   node: minikube
   gadget: seccomp
+
+  # # Example of filter for manual generation with the
+  # # gadget.kinvolk.io/operation=generate annotation. This needs a namespace and
+  # # podname at the exclusion of other fields.
+  # filter:
+  #   namespace: default
+  #   podname: mypod
+
+  # Another example of filter for automatic generation when containers
+  # terminate. All fields are supported.
   filter:
-    namespace: kube-system
-    podname: etcd-minikube
+    namespace: default
+
   runMode: Manual
   outputMode: ExternalResource
   output: gadget/myseccomp


### PR DESCRIPTION
# seccomp: generate SeccompProfile for terminated pods

This patch updates the seccomp gadget to subscribe to container termination events (using `pkg/gadgettracermanager/pubsub`) and to save a Seccomp Profile with a unique name when it happens.

This allows to capture syscalls on short-lived pods. See discussion in https://github.com/kinvolk/inspektor-gadget/issues/265

The new Seccomp Profile resource will have:
* some annotations to identify where it is coming from.
* the labels copied from the Trace custom resource. This will be useful for implementing the kubectl-gadget CLI, to be able to delete all Seccomp Profiles coming from the same Trace resource.

## How to use

See commands below.

## Testing done

Tested with the following commands:

```
$ kubectl apply -f ./pkg/resources/samples/trace-seccomp.yaml
$ kubectl annotate -n gadget trace/seccomp gadget.kinvolk.io/operation=start
$ kubectl run -ti --rm --image=busybox --restart=Never shell-mknod -- mknod /tmp/foo c 1 5
$ kubectl run -ti --rm --image=busybox --restart=Never shell-unshare -- unshare --pid --fork echo OK
$ kubectl run -ti --rm --image=busybox --restart=Never shell-mkdir -- mkdir /foo
```

Then I can see the following Seccomp Profiles with the mknod, unshare and mkdir system calls:

```
$ kubectl get SeccompProfiles -n gadget
NAME            STATUS      AGE
seccomp-2rxkg   Installed   4m14s
seccomp-68zmq   Installed   3m54s
seccomp-ftprf   Installed   59s
```