### PR TITLE
gadgets: cleanup dead code

### DIFF
--- a/pkg/gadgets/biolatency/gadget.go
+++ b/pkg/gadgets/biolatency/gadget.go
@@ -74,24 +74,6 @@ func (f *TraceFactory) Operations() map[string]gadgets.TraceOperation {
 	}
 }
 
-func (t *Trace) Operation(trace *gadgetv1alpha1.Trace,
-	operation string,
-	params map[string]string) {
-
-	if trace.ObjectMeta.Namespace != gadgets.TRACE_DEFAULT_NAMESPACE {
-		trace.Status.OperationError = fmt.Sprintf("This gadget only accepts operations on traces in the %s namespace", gadgets.TRACE_DEFAULT_NAMESPACE)
-		return
-	}
-	switch operation {
-	case "start":
-		t.Start(trace)
-	case "stop":
-		t.Stop(trace)
-	default:
-		trace.Status.OperationError = fmt.Sprintf("Unknown operation %q", operation)
-	}
-}
-
 func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 	if t.started {
 		trace.Status.OperationError = ""

--- a/pkg/gadgets/dns/gadget.go
+++ b/pkg/gadgets/dns/gadget.go
@@ -91,23 +91,6 @@ func (f *TraceFactory) Operations() map[string]gadgets.TraceOperation {
 		},
 	}
 }
-func (t *Trace) Operation(trace *gadgetv1alpha1.Trace,
-	operation string,
-	params map[string]string) {
-
-	if trace.ObjectMeta.Namespace != gadgets.TRACE_DEFAULT_NAMESPACE {
-		trace.Status.OperationError = fmt.Sprintf("This gadget only accepts operations on traces in the %s namespace", gadgets.TRACE_DEFAULT_NAMESPACE)
-		return
-	}
-	switch operation {
-	case "start":
-		t.Start(trace)
-	case "stop":
-		t.Stop(trace)
-	default:
-		trace.Status.OperationError = fmt.Sprintf("Unknown operation %q", operation)
-	}
-}
 
 type pubSubKey string
 

--- a/pkg/gadgets/networkpolicy/gadget.go
+++ b/pkg/gadgets/networkpolicy/gadget.go
@@ -92,32 +92,6 @@ func (f *TraceFactory) Operations() map[string]gadgets.TraceOperation {
 	}
 }
 
-func (f *Trace) Operation(trace *gadgetv1alpha1.Trace,
-	operation string,
-	params map[string]string) {
-
-	if trace.ObjectMeta.Namespace != gadgets.TRACE_DEFAULT_NAMESPACE {
-		trace.Status.OperationError = fmt.Sprintf("This gadget only accepts operations on traces in the %s namespace", gadgets.TRACE_DEFAULT_NAMESPACE)
-		return
-	}
-	if trace.ObjectMeta.Name != "network-policy-advisor" {
-		trace.Status.OperationError = "This gadget only accepts operations on the trace named network-policy-advisor"
-		return
-	}
-	switch operation {
-	case "start":
-		f.Start(trace)
-	case "update":
-		f.UpdateOutput(trace)
-	case "report":
-		f.Report(trace)
-	case "stop":
-		f.Stop(trace)
-	default:
-		trace.Status.OperationError = fmt.Sprintf("Unknown operation %q", operation)
-	}
-}
-
 func (f *Trace) Start(trace *gadgetv1alpha1.Trace) {
 	if f.started {
 		trace.Status.OperationError = ""

--- a/pkg/gadgets/process-collector/gadget.go
+++ b/pkg/gadgets/process-collector/gadget.go
@@ -15,8 +15,6 @@
 package processcollector
 
 import (
-	"fmt"
-
 	gadgetv1alpha1 "github.com/kinvolk/inspektor-gadget/pkg/api/v1alpha1"
 	"github.com/kinvolk/inspektor-gadget/pkg/gadgets"
 	"github.com/kinvolk/inspektor-gadget/pkg/gadgets/process-collector/tracer"
@@ -48,22 +46,6 @@ func (f *TraceFactory) Operations() map[string]gadgets.TraceOperation {
 				f.LookupOrCreate(name, n).(*Trace).Start(trace)
 			},
 		},
-	}
-}
-
-func (t *Trace) Operation(trace *gadgetv1alpha1.Trace,
-	operation string,
-	params map[string]string) {
-
-	if trace.ObjectMeta.Namespace != gadgets.TRACE_DEFAULT_NAMESPACE {
-		trace.Status.OperationError = fmt.Sprintf("This gadget only accepts operations on traces in the %s namespace", gadgets.TRACE_DEFAULT_NAMESPACE)
-		return
-	}
-	switch operation {
-	case "start":
-		t.Start(trace)
-	default:
-		trace.Status.OperationError = fmt.Sprintf("Unknown operation %q", operation)
 	}
 }
 

--- a/pkg/gadgets/seccomp/gadget.go
+++ b/pkg/gadgets/seccomp/gadget.go
@@ -115,26 +115,6 @@ func (f *TraceFactory) Operations() map[string]gadgets.TraceOperation {
 	}
 }
 
-func (t *Trace) Operation(trace *gadgetv1alpha1.Trace,
-	operation string,
-	params map[string]string) {
-
-	if trace.ObjectMeta.Namespace != gadgets.TRACE_DEFAULT_NAMESPACE {
-		trace.Status.OperationError = fmt.Sprintf("This gadget only accepts operations on traces in the %s namespace", gadgets.TRACE_DEFAULT_NAMESPACE)
-		return
-	}
-	switch operation {
-	case "start":
-		t.Start(trace)
-	case "generate":
-		t.Generate(trace)
-	case "stop":
-		t.Stop(trace)
-	default:
-		trace.Status.OperationError = fmt.Sprintf("Unknown operation %q", operation)
-	}
-}
-
 func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 	if t.started {
 		trace.Status.OperationError = ""


### PR DESCRIPTION
After refactoring Operations() in the TraceFactory interface, this code
is no longer needed.

This is a follow up to https://github.com/kinvolk/inspektor-gadget/pull/256