### PR TITLE
dns gadget: stop on error on perf ring buffer

### DIFF
--- a/pkg/gadgets/dns/tracer/tracer.go
+++ b/pkg/gadgets/dns/tracer/tracer.go
@@ -215,6 +215,7 @@ func (t *Tracer) listen(rd *perf.Reader, f func(name, pktType string)) {
 				return
 			}
 			log.Errorf("Error while reading from perf event reader: %s", err)
+			return
 		}
 
 		if record.LostSamples != 0 {


### PR DESCRIPTION
The perf file descriptor seems to be closed while we are still reading
on it. This patch does not fully resolved the issue, but at least the
error management should prevent gadget-tracer-manager from crashing.

Symptoms:
```
time="2021-09-14T13:44:20Z" level=error msg="Error while reading from perf event reader: bad file descriptor"
panic: runtime error: index out of range [0] with length 0

goroutine 379 [running]:
github.com/kinvolk/inspektor-gadget/pkg/gadgets/dns/tracer.parseDNSEvent(0x0, 0x0, 0x0, 0x2e, 0xc000886f58, 0x1, 0x1)
	/gadget/pkg/gadgets/dns/tracer/tracer.go:198 +0x24c
github.com/kinvolk/inspektor-gadget/pkg/gadgets/dns/tracer.(*Tracer).listen(0xc00000f440, 0xc00033c820, 0xc0005d1840)
	/gadget/pkg/gadgets/dns/tracer/tracer.go:225 +0x179
created by github.com/kinvolk/inspektor-gadget/pkg/gadgets/dns/tracer.(*Tracer).Attach
	/gadget/pkg/gadgets/dns/tracer/tracer.go:162 +0x64a
```

The patch comes from #249, which is not ready yet, but we can at least fix the crash now.
