### PR TITLE
Remove pinned eBPF objects

### DIFF
--- a/gadget-container/cleanup.sh
+++ b/gadget-container/cleanup.sh
@@ -46,4 +46,9 @@ fi
 
 rm -f /host/opt/nri/bin/nrigadget
 
+# This is a last resource to remove all possible pinned ebpf objects created by
+# Inspektor Gadget & Traceloop
+rm -rf /sys/fs/bpf/gadget/
+rm -rf /sys/fs/bpf/straceback/
+
 echo "Cleanup completed"

--- a/gadget-container/entrypoint.sh
+++ b/gadget-container/entrypoint.sh
@@ -200,16 +200,16 @@ fi
 
 echo "Starting the Gadget Tracer Manager in the background..."
 rm -f /run/gadgettracermanager.socket
-/bin/gadgettracermanager -serve $GADGET_EXTRA_PARAMS -controller &
 
 if [ "$INSPEKTOR_GADGET_OPTION_TRACELOOP" = "true" ] ; then
+  /bin/gadgettracermanager -serve $GADGET_EXTRA_PARAMS -controller &
+
   rm -f /run/traceloop.socket
   if [ "$INSPEKTOR_GADGET_OPTION_TRACELOOP_LOGLEVEL" != "" ] ; then
     exec /bin/traceloop -log "$INSPEKTOR_GADGET_OPTION_TRACELOOP_LOGLEVEL" k8s
   else
     exec /bin/traceloop k8s
   fi
+else
+  exec /bin/gadgettracermanager -serve $GADGET_EXTRA_PARAMS -controller
 fi
-
-echo "Ready."
-sleep infinity

--- a/gadget-container/gadgettracermanager/main.go
+++ b/gadget-container/gadgettracermanager/main.go
@@ -280,5 +280,7 @@ func main() {
 		exitSignal := make(chan os.Signal)
 		signal.Notify(exitSignal, syscall.SIGINT, syscall.SIGTERM)
 		<-exitSignal
+
+		tracerManager.Close()
 	}
 }

--- a/pkg/gadgettracermanager/gadgettracermanager.go
+++ b/pkg/gadgettracermanager/gadgettracermanager.go
@@ -700,6 +700,14 @@ func NewServer(nodeName string) (*GadgetTracerManager, error) {
 	return newServer(nodeName, false, false, true, true)
 }
 
+// Close releases any resource that could be in use by the tracer manager, like
+// ebpf maps.
+func (m *GadgetTracerManager) Close() {
+	if m.containersMap != nil {
+		os.Remove(filepath.Join(gadgets.PIN_PATH, "containers"))
+	}
+}
+
 func increaseRlimit() error {
 	limit := &unix.Rlimit{
 		Cur: unix.RLIM_INFINITY,


### PR DESCRIPTION
Some changes to remove the different pinned eBPF objects when removing the gadget container. For more details please check each commit message. 