### PR TITLE
Improve collector descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ Available Commands:
   help              Help about any command
   network-policy    Generate network policies based on recorded network activity
   opensnoop         Trace open() system calls
-  process-collector Collect processes
+  process-collector Gather information about running processes
   profile           Profile CPU usage by sampling stack traces
-  socket-collector  Collect sockets
+  socket-collector  Gather information about network sockets
   tcpconnect        Trace TCP connect() system calls
   tcptop            Show the TCP traffic in a pod
   tcptracer         Trace tcp connect, accept and close

--- a/cmd/kubectl-gadget/collector.go
+++ b/cmd/kubectl-gadget/collector.go
@@ -32,13 +32,13 @@ import (
 
 var processCollectorCmd = &cobra.Command{
 	Use:   "process-collector",
-	Short: "Collect processes",
+	Short: "Gather information about running processes",
 	Run:   processCollectorCmdRun,
 }
 
 var socketCollectorCmd = &cobra.Command{
 	Use:   "socket-collector",
-	Short: "Collect sockets",
+	Short: "Gather information about network sockets",
 	Run:   socketCollectorCmdRun,
 }
 

--- a/docs/gadgets/process-collector.md
+++ b/docs/gadgets/process-collector.md
@@ -3,7 +3,7 @@
 title: Gadget process-collector
 ---
 
-The process-collector gadget collects processes
+The process-collector gadget gathers information about running processes
 
 ### Example CR
 
@@ -29,7 +29,7 @@ spec:
 
 #### start
 
-Collect a snapshot of the list of processes
+Create a snapshot of the currently running processes. Once taken, the snapshot is not updated automatically. However one can call the start operation again at any time to update the snapshot.
 
 ```
 $ kubectl annotate -n gadget trace/process-collector \

--- a/docs/gadgets/socket-collector.md
+++ b/docs/gadgets/socket-collector.md
@@ -3,7 +3,7 @@
 title: Gadget socket-collector
 ---
 
-The socket-collector gadget collects tcp and udp sockets.
+The socket-collector gadget gathers information about TCP and UDP sockets.
 
 ### Example CR
 
@@ -28,7 +28,7 @@ spec:
 
 #### start
 
-Collect a snapshot of the list of sockets
+Create a snapshot of the currently open TCP and UDP sockets. Once taken, the snapshot is not updated automatically. However one can call the start operation again at any time to update the snapshot.
 
 ```
 $ kubectl annotate -n gadget trace/socket-collector \

--- a/pkg/gadgets/process-collector/gadget.go
+++ b/pkg/gadgets/process-collector/gadget.go
@@ -32,7 +32,7 @@ func NewFactory() gadgets.TraceFactory {
 }
 
 func (f *TraceFactory) Description() string {
-	return `The process-collector gadget collects processes`
+	return `The process-collector gadget gathers information about running processes`
 }
 
 func (f *TraceFactory) Operations() map[string]gadgets.TraceOperation {
@@ -41,7 +41,9 @@ func (f *TraceFactory) Operations() map[string]gadgets.TraceOperation {
 	}
 	return map[string]gadgets.TraceOperation{
 		"start": {
-			Doc: "Collect a snapshot of the list of processes",
+			Doc: "Create a snapshot of the currently running processes. " +
+				"Once taken, the snapshot is not updated automatically. " +
+				"However one can call the start operation again at any time to update the snapshot.",
 			Operation: func(name string, trace *gadgetv1alpha1.Trace) {
 				f.LookupOrCreate(name, n).(*Trace).Start(trace)
 			},

--- a/pkg/gadgets/socket-collector/gadget.go
+++ b/pkg/gadgets/socket-collector/gadget.go
@@ -39,7 +39,7 @@ func NewFactory() gadgets.TraceFactory {
 }
 
 func (f *TraceFactory) Description() string {
-	return `The socket-collector gadget collects tcp and udp sockets.`
+	return `The socket-collector gadget gathers information about TCP and UDP sockets.`
 }
 
 func (f *TraceFactory) Operations() map[string]gadgets.TraceOperation {
@@ -51,7 +51,9 @@ func (f *TraceFactory) Operations() map[string]gadgets.TraceOperation {
 
 	return map[string]gadgets.TraceOperation{
 		"start": {
-			Doc: "Collect a snapshot of the list of sockets",
+			Doc: "Create a snapshot of the currently open TCP and UDP sockets. " +
+				"Once taken, the snapshot is not updated automatically. " +
+				"However one can call the start operation again at any time to update the snapshot.",
 			Operation: func(name string, trace *gadgetv1alpha1.Trace) {
 				f.LookupOrCreate(name, n).(*Trace).Start(trace)
 			},


### PR DESCRIPTION
"Collect processes" and "Collect sockets" doesn't really help clarify what these gadgets do. Reword this to "Gather information" about either running processes or network sockets, so that we actually provide some additional info in the short description.