### PR TITLE
docs: Update links to docs folder

### DIFF
--- a/.krew.yaml
+++ b/.krew.yaml
@@ -17,7 +17,7 @@ spec:
     fetch the log data from ring buffers and display it. What BPF programs are
     and how Inspektor Gadget uses them is briefly explained in the architecture
     document:
-    https://github.com/kinvolk/inspektor-gadget/blob/main/Documentation/architecture.md
+    https://github.com/kinvolk/inspektor-gadget/blob/main/docs/architecture.md
   caveats: |
     Inspektor Gadget needs to be deployed to each node:
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -79,7 +79,7 @@ to be able to use them:
 
 It's possible to make changes to Inspektor Gadget and test them on minikube locally without pushing container images to any registry.
 
-* Follow the specific [installation instructions](Documentation/install.md#minikube) for minikube.
+* Follow the specific [installation instructions](install.md#minikube) for minikube.
 * Make sure the git repositories `traceloop` and `inspektor-gadget` are cloned in sibling directories
 * Minikube with the Docker driver does not work for traceloop. You can use another driver, for example:
 ```


### PR DESCRIPTION
# Update links to docs folder

`Documentation` folder is now named `docs`.
