### PR TITLE
makefile: Ensure CLI is compiled before launching the integration-tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,8 +86,8 @@ controller-tests: kube-apiserver etcd kubectl
 	go test -test.v ./pkg/controllers/... -controller-test
 
 .PHONY: integration-tests
-integration-tests:
-	KUBECTL_GADGET="$(shell pwd)/kubectl-gadget-$(GOHOSTOS)-$(GOHOSTARCH)" \
+integration-tests: kubectl-gadget
+	KUBECTL_GADGET="$(shell pwd)/kubectl-gadget" \
 		go test ./integration/... \
 			-integration \
 			-image $(CONTAINER_REPO):$(IMAGE_TAG)


### PR DESCRIPTION
# Ensure CLI is compiled before launching the integration-tests

If `kubectl-gadget-$(GOHOSTOS)-$(GOHOSTARCH)` does not exist, then `make integration-tests` will fail. Therefore, it needs to be added as dependency.

This PR also starts using `kubectl-gadget` instead of `kubectl-gadget-$(GOHOSTOS)-$(GOHOSTARCH)` to prevent user from keeping both binaries.

## Testing done
Tests were done without having compiled the CLI.

Before this PR:
```
$ make integration-tests
KUBECTL_GADGET="/kinvolk/src/inspektor-gadget/kubectl-gadget-linux-amd64" \
        go test ./integration/... \
                -integration \
                -image blanquicet/gadget:latest
--- FAIL: TestTraceloop (0.13s)
    --- FAIL: TestTraceloop/Deploy_Inspektor_Gadget (0.08s)
        traceloop_test.go:115: Command: $KUBECTL_GADGET deploy $GADGET_IMAGE_FLAG | kubectl apply -f -
        traceloop_test.go:119: Command returned:
            /bin/sh: 1: /kinvolk/src/inspektor-gadget/kubectl-gadget-linux-amd64: not found
            error: no objects passed to apply

        traceloop_test.go:122: exit status 1
    --- FAIL: TestTraceloop/traceloop_list (0.00s)
        traceloop_test.go:115: Command: $KUBECTL_GADGET traceloop list -A
        traceloop_test.go:119: Command returned:
            /bin/sh: 1: /kinvolk/src/inspektor-gadget/kubectl-gadget-linux-amd64: not found

        traceloop_test.go:122: exit status 127
    --- FAIL: TestTraceloop/Cleanup_test_namespace (0.03s)
        traceloop_test.go:115: Command: kubectl delete ns test-traceloop
        traceloop_test.go:119: Command returned:
            Error from server (NotFound): namespaces "test-traceloop" not found

        traceloop_test.go:122: exit status 1
    --- FAIL: TestTraceloop/Cleanup_gadget_deployment (0.02s)
        traceloop_test.go:115: Command: $KUBECTL_GADGET deploy $GADGET_IMAGE_FLAG | kubectl delete -f -
        traceloop_test.go:119: Command returned:
            /bin/sh: 1: /kinvolk/src/inspektor-gadget/kubectl-gadget-linux-amd64: not found
            No resources found

        traceloop_test.go:129: regexp didn't match: "gadget" deleted
            /bin/sh: 1: /kinvolk/src/inspektor-gadget/kubectl-gadget-linux-amd64: not found
            No resources found

FAIL
FAIL    github.com/kinvolk/inspektor-gadget/integration 0.135s
FAIL
make: *** [Makefile:90: integration-tests] Error 1
```

After this PR:
```
$ make integration-tests
export GO111MODULE=on CGO_ENABLED=0 && \
export GOOS=linux GOARCH=amd64 && \
go build -ldflags "-X main.version=`git describe --tags --always` -X main.gadgetimage=blanquicet/gadget:latest -extldflags '-static'" \
        -o kubectl-gadget-${GOOS}-${GOARCH} \
        github.com/kinvolk/inspektor-gadget/cmd/kubectl-gadget
mv kubectl-gadget-linux-amd64 kubectl-gadget
KUBECTL_GADGET="/kinvolk/src/inspektor-gadget/kubectl-gadget" \
        go test ./integration/... \
                -integration \
                -image blanquicet/gadget:latest
ok      github.com/kinvolk/inspektor-gadget/integration 80.026s
```