### PR TITLE
New pkg: container-collection

### DIFF
--- a/pkg/container-collection/container-collection.go
+++ b/pkg/container-collection/container-collection.go
@@ -1,0 +1,212 @@
+// Copyright 2019-2021 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package containercollection provides the ContainerCollection struct to keep
+// track of the set of running containers and primitives to query that set with
+// various criteria.
+//
+// It is used by the Gadget Tracer Manager to keep track of containers part of
+// Kubernetes pods and by Local Gadget Manager to keep track of containers on a
+// Linux system.
+package containercollection
+
+import (
+	"sync"
+
+	pb "github.com/kinvolk/inspektor-gadget/pkg/gadgettracermanager/api"
+	"github.com/kinvolk/inspektor-gadget/pkg/gadgettracermanager/pubsub"
+)
+
+// ContainerCollection holds a set of containers. It can be embedded as an
+// anonymous struct to help other structs implement the ContainerResolver
+// interface. For this reason, some methods are namespaced with 'Container' to
+// make this clear.
+type ContainerCollection struct {
+	// Keys:   Container ID
+	// Values: pb.ContainerDefinition
+	containers sync.Map
+
+	// subs contains a list of subscribers of container events
+	pubsub *pubsub.GadgetPubSub
+}
+
+// ContainerCollectionInitialize initializes a ContainerCollection. It is
+// useful when ContainerCollection is embedded as an anonymous struct because
+// we don't use a contructor in that case.
+func (cc *ContainerCollection) ContainerCollectionInitialize() {
+	cc.pubsub = pubsub.NewGadgetPubSub()
+}
+
+// GetContainer looks up a container by the container id and return it if
+// found, or return nil if not found.
+func (cc *ContainerCollection) GetContainer(id string) *pb.ContainerDefinition {
+	v, ok := cc.containers.Load(id)
+	if !ok {
+		return nil
+	}
+	containerDefinition := v.(pb.ContainerDefinition)
+	return &containerDefinition
+}
+
+// RemoveContainer removes a container from the collection.
+func (cc *ContainerCollection) RemoveContainer(id string) {
+	v, loaded := cc.containers.LoadAndDelete(id)
+	if !loaded {
+		return
+	}
+
+	cc.pubsub.Publish(pubsub.EVENT_TYPE_REMOVE_CONTAINER, v.(pb.ContainerDefinition))
+}
+
+// AddContainer adds a container to the collection.
+func (cc *ContainerCollection) AddContainer(container pb.ContainerDefinition) {
+	cc.containers.Store(container.Id, container)
+
+	cc.pubsub.Publish(pubsub.EVENT_TYPE_ADD_CONTAINER, container)
+}
+
+// LookupMntnsByContainer returns the mount namespace inode of the container
+// specified in arguments or zero if not found
+func (cc *ContainerCollection) LookupMntnsByContainer(namespace, pod, container string) (mntns uint64) {
+	cc.containers.Range(func(key, value interface{}) bool {
+		c := value.(pb.ContainerDefinition)
+		if namespace == c.Namespace && pod == c.Podname && container == c.Name {
+			mntns = c.Mntns
+			// container found, stop iterating
+			return false
+		}
+		return true
+	})
+	return
+}
+
+// LookupMntnsByPod returns the mount namespace inodes of all containers
+// belonging to the pod specified in arguments, indexed by the name of the
+// containers or an empty map if not found
+func (cc *ContainerCollection) LookupMntnsByPod(namespace, pod string) map[string]uint64 {
+	ret := make(map[string]uint64)
+	cc.containers.Range(func(key, value interface{}) bool {
+		c := value.(pb.ContainerDefinition)
+		if namespace == c.Namespace && pod == c.Podname {
+			ret[c.Name] = c.Mntns
+		}
+		return true
+	})
+	return ret
+}
+
+// LookupPIDByContainer returns the PID of the container
+// specified in arguments or zero if not found
+func (cc *ContainerCollection) LookupPIDByContainer(namespace, pod, container string) (pid uint32) {
+	cc.containers.Range(func(key, value interface{}) bool {
+		c := value.(pb.ContainerDefinition)
+		if namespace == c.Namespace && pod == c.Podname && container == c.Name {
+			pid = c.Pid
+			// container found, stop iterating
+			return false
+		}
+		return true
+	})
+	return
+}
+
+// LookupPIDByPod returns the PID of all containers belonging to
+// the pod specified in arguments, indexed by the name of the
+// containers or an empty map if not found
+func (cc *ContainerCollection) LookupPIDByPod(namespace, pod string) map[string]uint32 {
+	ret := make(map[string]uint32)
+	cc.containers.Range(func(key, value interface{}) bool {
+		c := value.(pb.ContainerDefinition)
+		if namespace == c.Namespace && pod == c.Podname {
+			ret[c.Name] = c.Pid
+		}
+		return true
+	})
+	return ret
+}
+
+// GetContainersBySelector returns a slice of containers that match
+// the selector or an empty slice if there are not matches
+func (cc *ContainerCollection) GetContainersBySelector(
+	containerSelector *pb.ContainerSelector,
+) []pb.ContainerDefinition {
+	selectedContainers := []pb.ContainerDefinition{}
+	cc.containers.Range(func(key, value interface{}) bool {
+		c := value.(pb.ContainerDefinition)
+		if ContainerSelectorMatches(containerSelector, &c) {
+			selectedContainers = append(selectedContainers, c)
+		}
+		return true
+	})
+	return selectedContainers
+}
+
+// ContainerLen returns how many containers are stored in the collection.
+func (cc *ContainerCollection) ContainerLen() (count int) {
+	cc.containers.Range(func(key, value interface{}) bool {
+		count++
+		return true
+	})
+	return
+}
+
+// ContainerRange iterates over the containers of the collection and calls the
+// callback function for each of them.
+func (cc *ContainerCollection) ContainerRange(f func(pb.ContainerDefinition)) {
+	cc.containers.Range(func(key, value interface{}) bool {
+		c := value.(pb.ContainerDefinition)
+		f(c)
+		return true
+	})
+}
+
+// ContainerRangeWithSelector iterates over the containers of the collection
+// and calls the callback function for each of those that matches the container
+// selector.
+func (cc *ContainerCollection) ContainerRangeWithSelector(
+	containerSelector *pb.ContainerSelector,
+	f func(pb.ContainerDefinition),
+) {
+	cc.containers.Range(func(key, value interface{}) bool {
+		c := value.(pb.ContainerDefinition)
+		if ContainerSelectorMatches(containerSelector, &c) {
+			f(c)
+		}
+		return true
+	})
+}
+
+// Subscribe returns the list of existing containers and registers a callback
+// for notifications about additions and deletions of containers
+func (cc *ContainerCollection) Subscribe(key interface{}, selector pb.ContainerSelector, f pubsub.FuncNotify) []pb.ContainerDefinition {
+	ret := []pb.ContainerDefinition{}
+	cc.pubsub.Subscribe(key, func(event pubsub.PubSubEvent) {
+		if ContainerSelectorMatches(&selector, &event.Container) {
+			f(event)
+		}
+	}, func() {
+		// Fetch the list of containers inside pubsub.Subscribe() to
+		// guarantee that no new container event will be published at
+		// the same time.
+		cc.ContainerRangeWithSelector(&selector, func(c pb.ContainerDefinition) {
+			ret = append(ret, c)
+		})
+	})
+	return ret
+}
+
+// Unsubscribe undoes a previous call to Subscribe
+func (cc *ContainerCollection) Unsubscribe(key interface{}) {
+	cc.pubsub.Unsubscribe(key)
+}

--- a/pkg/container-collection/interface.go
+++ b/pkg/container-collection/interface.go
@@ -1,0 +1,54 @@
+// Copyright 2019-2021 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package containercollection
+
+import (
+	pb "github.com/kinvolk/inspektor-gadget/pkg/gadgettracermanager/api"
+	"github.com/kinvolk/inspektor-gadget/pkg/gadgettracermanager/pubsub"
+)
+
+// ContainerResolver offers primitives to look up running containers with
+// various criteria, and to subscribe to container creation and termination.
+type ContainerResolver interface {
+	// LookupMntnsByContainer returns the mount namespace inode of the container
+	// specified in arguments or zero if not found
+	LookupMntnsByContainer(namespace, pod, container string) uint64
+
+	// LookupMntnsByPod returns the mount namespace inodes of all containers
+	// belonging to the pod specified in arguments, indexed by the name of the
+	// containers or an empty map if not found
+	LookupMntnsByPod(namespace, pod string) map[string]uint64
+
+	// LookupPIDByContainer returns the PID of the container
+	// specified in arguments or zero if not found
+	LookupPIDByContainer(namespace, pod, container string) uint32
+
+	// LookupPIDByPod returns the PID of all containers belonging to
+	// the pod specified in arguments, indexed by the name of the
+	// containers or an empty map if not found
+	LookupPIDByPod(namespace, pod string) map[string]uint32
+
+	// GetContainersBySelector returns a slice of containers that match
+	// the selector or an empty slice if there are not matches
+	GetContainersBySelector(containerSelector *pb.ContainerSelector) []pb.ContainerDefinition
+
+	// Subscribe returns the list of existing containers and registers a
+	// callback for notifications about additions and deletions of
+	// containers
+	Subscribe(key interface{}, s pb.ContainerSelector, f pubsub.FuncNotify) []pb.ContainerDefinition
+
+	// Unsubscribe undoes a previous call to Subscribe
+	Unsubscribe(key interface{})
+}

--- a/pkg/container-collection/match.go
+++ b/pkg/container-collection/match.go
@@ -1,0 +1,47 @@
+// Copyright 2019-2021 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package containercollection
+
+import (
+	pb "github.com/kinvolk/inspektor-gadget/pkg/gadgettracermanager/api"
+)
+
+// ContainerSelectorMatches tells if a container matches the criteria in a
+// container selector.
+func ContainerSelectorMatches(s *pb.ContainerSelector, c *pb.ContainerDefinition) bool {
+	if s.Namespace != "" && s.Namespace != c.Namespace {
+		return false
+	}
+	if s.Podname != "" && s.Podname != c.Podname {
+		return false
+	}
+	if s.Name != "" && s.Name != c.Name {
+		return false
+	}
+	for _, l := range s.Labels {
+		found := false
+		for _, cl := range c.Labels {
+			if cl.Key == l.Key && cl.Value == l.Value {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+
+	return true
+}

--- a/pkg/container-collection/match_test.go
+++ b/pkg/container-collection/match_test.go
@@ -1,0 +1,107 @@
+// Copyright 2019-2021 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package containercollection
+
+import (
+	"testing"
+
+	pb "github.com/kinvolk/inspektor-gadget/pkg/gadgettracermanager/api"
+)
+
+func TestSelector(t *testing.T) {
+	table := []struct {
+		description string
+		match       bool
+		selector    *pb.ContainerSelector
+		container   *pb.ContainerDefinition
+	}{
+		{
+			description: "Selector without filter",
+			match:       true,
+			selector:    &pb.ContainerSelector{},
+			container: &pb.ContainerDefinition{
+				Namespace: "this-namespace",
+				Podname:   "this-pod",
+				Name:      "this-container",
+			},
+		},
+		{
+			description: "Selector with all filters",
+			match:       true,
+			selector: &pb.ContainerSelector{
+				Namespace: "this-namespace",
+				Podname:   "this-pod",
+				Name:      "this-container",
+				Labels: []*pb.Label{
+					{Key: "key1", Value: "value1"},
+					{Key: "key2", Value: "value2"},
+				},
+			},
+			container: &pb.ContainerDefinition{
+				Namespace: "this-namespace",
+				Podname:   "this-pod",
+				Name:      "this-container",
+				Labels: []*pb.Label{
+					{Key: "unrelated-label", Value: "here"},
+					{Key: "key1", Value: "value1"},
+					{Key: "key2", Value: "value2"},
+				},
+			},
+		},
+		{
+			description: "Podname does not match",
+			match:       false,
+			selector: &pb.ContainerSelector{
+				Namespace: "this-namespace",
+				Podname:   "this-pod",
+			},
+			container: &pb.ContainerDefinition{
+				Namespace: "this-namespace",
+				Podname:   "a-misnamed-pod",
+				Name:      "this-container",
+			},
+		},
+		{
+			description: "One label doesn't match",
+			match:       false,
+			selector: &pb.ContainerSelector{
+				Namespace: "this-namespace",
+				Podname:   "this-pod",
+				Name:      "this-container",
+				Labels: []*pb.Label{
+					{Key: "key1", Value: "value1"},
+					{Key: "key2", Value: "value2"},
+				},
+			},
+			container: &pb.ContainerDefinition{
+				Namespace: "this-namespace",
+				Podname:   "this-pod",
+				Name:      "this-container",
+				Labels: []*pb.Label{
+					{Key: "key1", Value: "value1"},
+					{Key: "key2", Value: "something-else"},
+				},
+			},
+		},
+	}
+
+	for i, entry := range table {
+		result := ContainerSelectorMatches(entry.selector, entry.container)
+		if entry.match != result {
+			t.Fatalf("Failed test %q (index %d): result %v expected %v",
+				entry.description, i, result, entry.match)
+		}
+	}
+}

--- a/pkg/gadgets/interface.go
+++ b/pkg/gadgets/interface.go
@@ -18,8 +18,7 @@ import (
 	"sync"
 
 	gadgetv1alpha1 "github.com/kinvolk/inspektor-gadget/pkg/api/v1alpha1"
-	pb "github.com/kinvolk/inspektor-gadget/pkg/gadgettracermanager/api"
-	"github.com/kinvolk/inspektor-gadget/pkg/gadgettracermanager/pubsub"
+	"github.com/kinvolk/inspektor-gadget/pkg/container-collection"
 
 	log "github.com/sirupsen/logrus"
 	apimachineryruntime "k8s.io/apimachinery/pkg/runtime"
@@ -87,35 +86,7 @@ type TraceOperation struct {
 }
 
 type Resolver interface {
-	// LookupMntnsByContainer returns the mount namespace inode of the container
-	// specified in arguments or zero if not found
-	LookupMntnsByContainer(namespace, pod, container string) uint64
-
-	// LookupMntnsByPod returns the mount namespace inodes of all containers
-	// belonging to the pod specified in arguments, indexed by the name of the
-	// containers or an empty map if not found
-	LookupMntnsByPod(namespace, pod string) map[string]uint64
-
-	// LookupPIDByContainer returns the PID of the container
-	// specified in arguments or zero if not found
-	LookupPIDByContainer(namespace, pod, container string) uint32
-
-	// LookupPIDByPod returns the PID of all containers belonging to
-	// the pod specified in arguments, indexed by the name of the
-	// containers or an empty map if not found
-	LookupPIDByPod(namespace, pod string) map[string]uint32
-
-	// GetContainersBySelector returns a slice of containers that match
-	// the selector or an empty slice if there are not matches
-	GetContainersBySelector(containerSelector *pb.ContainerSelector) []pb.ContainerDefinition
-
-	// Subscribe returns the list of existing containers and registers a
-	// callback for notifications about additions and deletions of
-	// containers
-	Subscribe(key interface{}, s pb.ContainerSelector, f pubsub.FuncNotify) []pb.ContainerDefinition
-
-	// Unsubscribe undoes a previous call to Subscribe
-	Unsubscribe(key interface{})
+	containercollection.ContainerResolver
 
 	PublishEvent(tracerID string, line string) error
 }

--- a/pkg/gadgettracermanager/pubsub/pubsub.go
+++ b/pkg/gadgettracermanager/pubsub/pubsub.go
@@ -51,11 +51,19 @@ func NewGadgetPubSub() *GadgetPubSub {
 	}
 }
 
-func (g *GadgetPubSub) Subscribe(key interface{}, f FuncNotify) {
+// Subscribe registers the callback to be called for every container event
+// published with Publish(). Optionally, the caller can pass an initializer()
+// function that is guaranteed to be called before any new container events are
+// published.
+func (g *GadgetPubSub) Subscribe(key interface{}, callback FuncNotify, initializer func()) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
 
-	g.subs[key] = f
+	g.subs[key] = callback
+
+	if initializer != nil {
+		initializer()
+	}
 }
 
 func (g *GadgetPubSub) Unsubscribe(key interface{}) {

--- a/pkg/gadgettracermanager/pubsub/pubsub_test.go
+++ b/pkg/gadgettracermanager/pubsub/pubsub_test.go
@@ -36,7 +36,7 @@ func TestPubSub(t *testing.T) {
 		done <- struct{}{}
 	}
 
-	p.Subscribe(key, callback)
+	p.Subscribe(key, callback, nil)
 
 	p.Publish(EVENT_TYPE_REMOVE_CONTAINER, pb.ContainerDefinition{Id: "container1"})
 	_, ok := <-done


### PR DESCRIPTION
# New pkg: container-collection

Abstracting the set of containers in gadget-tracer-manager, so it can be reused in local-gadget (https://github.com/kinvolk/inspektor-gadget/pull/245).

This includes the helper function ContainerSelectorMatches. Some unit tests were moved accordingly.

## How to use

No changes, this is just refactoring code.

## Testing done

`make test` and `make local-gadget-tests` in the local-gadget branch.