### PR TITLE
kubectl-gadget: Manage filtering by non-exisitent node

### DIFF
--- a/cmd/kubectl-gadget/utils/trace.go
+++ b/cmd/kubectl-gadget/utils/trace.go
@@ -136,10 +136,12 @@ func GenericTraceCommand(
 		contextLogger.Fatalf("Error while getting trace rest client: %s", err)
 	}
 
+	nodeFound := false
 	for _, node := range nodes.Items {
 		if params.Node != "" && node.Name != params.Node {
 			continue
 		}
+		nodeFound = true
 
 		trace := &gadgetv1alpha1.Trace{
 			ObjectMeta: metav1.ObjectMeta{
@@ -177,6 +179,10 @@ func GenericTraceCommand(
 			deleteTraces(nil, traceRestClient, traceID)
 			contextLogger.Fatalf("Error creating trace on node %s: %q", node.Name, err)
 		}
+	}
+
+	if params.Node != "" && !nodeFound {
+		contextLogger.Fatalf("Invalid filter: Node %q does not exist", params.Node)
 	}
 
 	var listTracesOptions = metav1.ListOptions{


### PR DESCRIPTION
# Manage filtering by non-exisitent node

This PR fixes #251.

## Testing done
Before this PR:
```
$ ./kubectl-gadget socket-collector -n default -p my-pod --node non-existent-node
FATA[0000] Error getting traces from all nodes           args="[]" command="kubectl-gadget socket-collector"

$ ./kubectl-gadget process-collector -A --node non-existent-node
FATA[0000] Error getting traces from all nodes           args="[]" command="kubectl-gadget process-collector"

$ ./kubectl-gadget dns -A --node non-existent-node
NODE             NAMESPACE        POD                            TYPE      NAME
FATA[0000] Error getting traces from all nodes           args="[]" command="kubectl-gadget dns"
```
After this PR:
```
$ ./kubectl-gadget socket-collector -n default -p my-pod --node non-existent-node
FATA[0000] Invalid filter: Node "non-existent-node" does not exist  args="[]" command="kubectl-gadget socket-collector"

$ ./kubectl-gadget process-collector -A --node non-existent-node
FATA[0000] Invalid filter: Node "non-existent-node" does not exist  args="[]" command="kubectl-gadget process-collector"

$ ./kubectl-gadget dns -A --node non-existent-node
NODE             NAMESPACE        POD                            TYPE      NAME
FATA[0000] Invalid filter: Node "non-existent-node" does not exist  args="[]" command="kubectl-gadget dns"
```