### PR TITLE
GitHub Action: check for any uncommitted changes

### DIFF
--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -126,6 +126,14 @@ jobs:
 
     - name: Build kubectl gadget plugin for all platforms
       run: |
+        # Prevent releases with -dirty suffix due to forgotten entries in
+        # .gitignore.
+        changes="$(git status --porcelain)"
+        if [ -n "$changes" ] ; then
+          echo "$changes"
+          exit 1
+        fi
+
         make kubectl-gadget-all
 
         # Prepare assets for release and actions artifacts


### PR DESCRIPTION
Check for any uncommitted changes and fail the GitHub Action if any is
found.

This is to avoid mistakes like in the previous release where a version
with the "-dirty" suffix was reported:
```
$ ./kubectl-gadget version
v0.3.0-dirty
```

This was because "bin/" was forgotten from .gitignore. With this patch,
we will no longer forget entries in .gitignore.

Fixes https://github.com/kinvolk/inspektor-gadget/issues/301