### PR TITLE
Add support of biotop gadget

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Usage:
 
 Available Commands:
   bindsnoop         Trace IPv4 and IPv6 bind() system calls
+  biotop            Trace block device I/O top
   capabilities      Trace capabilities security checks triggered by applications
   completion        generate the autocompletion script for the specified shell
   deploy            Deploy Inspektor Gadget on the worker nodes
@@ -58,6 +59,7 @@ Available Commands:
 Specific documentation for the gadgets can be found in the following links:
 
 - [bindsnoop](docs/guides/bindsnoop.md)
+- [biotop](docs/guides/biotop.md)
 - [capabilities](docs/guides/capabilities.md)
 - [execsnoop](docs/guides/execsnoop.md)
 - [network-policy](docs/guides/network-policy.md)

--- a/docs/guides/biotop.md
+++ b/docs/guides/biotop.md
@@ -1,0 +1,23 @@
+---
+title: 'The "biotop" gadget'
+weight: 10
+---
+
+The biotop gadget allows us to see block device I/O on node(s).
+
+The gadget doesn't support the following flags:
+ * `--containername`
+ * `--podname`
+ * `--namespace`
+ * `--json`
+
+```
+$ kubectl gadget biotop --node ip-10-0-30-247 --all-namespaces
+
+14:28:17 loadavg: 0.53 0.32 0.34 8/528 43043
+
+PID    COMM             D MAJ MIN DISK       I/O  Kbytes  AVGms
+1860   etcd             W 253 0   vda          3      24   0.38
+```
+
+We can leave the monitoring with Ctrl-C.


### PR DESCRIPTION
# Add support of biotop gadget

This change introduces a new command to execute `biotop` gadget. The gadget doesn't support namespace, containername or podname parameters. It traces disk usage per node.

# How to use it
`kubectl gadget biotop --all-namespaces`

## Testing done

Executed the following commands:
```
Invalid commands:
kubectl gadget biotop # FATA[0000] biotop only works with --all-namespaces
kubectl gadget biotop --namespace default # FATA[0000] biotop only works with --all-namespaces
kubectl gadget biotop --containername container FATA[0000] biotop doesn't support --containername or --podname
kubectl gadget biotop --podname podname FATA[0000] biotop doesn't support --containername or --podname

Valid commands:
kubectl gadget biotop --all-namespaces
kubectl gadget biotop --all-namespaces --node minikube
```
