### PR TITLE
gadgettracermanager: add command to dump stacks

### DIFF
--- a/pkg/gadgettracermanager/gadgettracermanager.go
+++ b/pkg/gadgettracermanager/gadgettracermanager.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sync"
 	"unsafe"
 
@@ -336,6 +337,11 @@ func (g *GadgetTracerManager) DumpState(_ context.Context, req *pb.DumpStateRequ
 			out += fmt.Sprintf("        - %s/%s [Mntns=%v CgroupId=%v]\n", c.Namespace, c.Podname, c.Mntns, c.CgroupId)
 		})
 	}
+	out += "List of stacks:\n"
+	buf := make([]byte, 1<<20)
+	stacklen := runtime.Stack(buf, true)
+	out += fmt.Sprintf("%s\n", buf[:stacklen])
+
 	return &pb.Dump{State: out}, nil
 }
 


### PR DESCRIPTION
# gadgettracermanager: add command to dump stacks

While debugging some issue on https://github.com/kinvolk/inspektor-gadget/pull/272, I wanted to print all go routine stacks to see if a go routine was stuck.

## How to use

For debugging, the dump command will now print all go routine stacks:
```
gadgettracermanager -dump
```
```
kubectl exec -ti -n kube-system $(kubectl get pod -n kube-system -l k8s-app=gadget -o name) -- gadgettracermanager -dump | less
```

## Testing done

I tested that I can print the stacks.