### PR TITLE
biolatency: Avoid starting gadget if filter was specified

### DIFF
--- a/docs/gadgets/biolatency.md
+++ b/docs/gadgets/biolatency.md
@@ -18,10 +18,6 @@ metadata:
 spec:
   node: minikube
   gadget: biolatency
-  filter:
-    namespace: default
-    labels:
-      role: demo
   runMode: Manual
   outputMode: Status
 ```

--- a/pkg/gadgets/biolatency/gadget.go
+++ b/pkg/gadgets/biolatency/gadget.go
@@ -75,6 +75,11 @@ func (f *TraceFactory) Operations() map[string]gadgets.TraceOperation {
 }
 
 func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
+	if trace.Spec.Filter != nil {
+		trace.Status.OperationError = "Invalid filter: Filtering is not supported"
+		return
+	}
+
 	if t.started {
 		trace.Status.OperationError = ""
 		trace.Status.Output = ""

--- a/pkg/resources/samples/trace-biolatency.yaml
+++ b/pkg/resources/samples/trace-biolatency.yaml
@@ -6,9 +6,5 @@ metadata:
 spec:
   node: minikube
   gadget: biolatency
-  filter:
-    namespace: default
-    labels:
-      role: demo
   runMode: Manual
   outputMode: Status


### PR DESCRIPTION
# Avoid starting gadget if filter was specified

Biolatency gadget currently only supports running at node level. Therefore, do not start the gadget if a filter is specified to prevent
user from thinking it was applied.

## Testing done

Before this PR:
```
# Create CR with a filter 
$ cat <<EOF | kubectl apply -f -
apiVersion: gadget.kinvolk.io/v1alpha1
kind: Trace
metadata:
  name: biolatency
  namespace: gadget
spec:
  node: my-node
  gadget: biolatency
  filter:
    namespace: non-existent-namespace
  runMode: Manual
  outputMode: Status
EOF

$ kubectl annotate -n gadget trace/biolatency gadget.kinvolk.io/operation=start
trace.gadget.kinvolk.io/biolatency annotated

# Any error is reported and gadget is started normally
$ kubectl get -n gadget trace/biolatency -o jsonpath='{.status.operationError}'
$ kubectl get -n gadget trace biolatency -o jsonpath='{.status.state}'
Completed

# Wait for output
$ sleep 10

$ kubectl annotate -n gadget trace/biolatency gadget.kinvolk.io/operation=stop
trace.gadget.kinvolk.io/biolatency annotated

# Any error is reported
$ kubectl get -n gadget trace/biolatency -o jsonpath='{.status.operationError}'

# Gadget generated the output without considering the filter
$ kubectl get -n gadget trace biolatency -o jsonpath='{.status.state}'
Completed
$ kubectl get -n gadget trace biolatency -o jsonpath='{.status.output}'
Tracing block device I/O... Hit Ctrl-C to end.

     usecs               : count     distribution
         0 -> 1          : 0        |                                        |
         2 -> 3          : 0        |                                        |
         4 -> 7          : 0        |                                        |
         8 -> 15         : 0        |                                        |
        16 -> 31         : 22       |***********                             |
        32 -> 63         : 45       |***********************                 |
        64 -> 127        : 62       |*******************************         |
       128 -> 255        : 78       |****************************************|
       256 -> 511        : 20       |**********                              |
       512 -> 1023       : 12       |******                                  |
      1024 -> 2047       : 0        |                                        |
      2048 -> 4095       : 0        |                                        |
      4096 -> 8191       : 0        |                                        |
      8192 -> 16383      : 1        |                                        |

$ kubectl delete trace -n gadget biolatency
```
After this PR:
```
# Create CR with a filter
$ cat <<EOF | kubectl apply -f -
apiVersion: gadget.kinvolk.io/v1alpha1
kind: Trace
metadata:
  name: biolatency
  namespace: gadget
spec:
  node: my-node
  gadget: biolatency
  filter:
    namespace: non-existent-namespace
  runMode: Manual
  outputMode: Status
EOF

$ kubectl annotate -n gadget trace/biolatency gadget.kinvolk.io/operation=start

# Now, gadget does not even start and immediatly reports the error
$ kubectl get -n gadget trace/biolatency -o jsonpath='{.status.operationError}'
Invalid filter: Filtering is not supported

$ kubectl get -n gadget trace biolatency -o jsonpath='{.status.state}'
$ kubectl get -n gadget trace biolatency -o jsonpath='{.status.output}'

$ kubectl delete trace -n gadget biolatency
```