### PR TITLE
Network Policy Advisor: move advisor in separate package

### DIFF
--- a/cmd/kubectl-gadget/networkpolicyadvisor.go
+++ b/cmd/kubectl-gadget/networkpolicyadvisor.go
@@ -33,7 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 
 	"github.com/kinvolk/inspektor-gadget/cmd/kubectl-gadget/utils"
-	"github.com/kinvolk/inspektor-gadget/pkg/gadgets/networkpolicy"
+	"github.com/kinvolk/inspektor-gadget/pkg/gadgets/networkpolicy/advisor"
 	"github.com/kinvolk/inspektor-gadget/pkg/gadgets/networkpolicy/types"
 	"github.com/kinvolk/inspektor-gadget/pkg/k8sutil"
 )
@@ -191,13 +191,13 @@ func runNetworkPolicyReport(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("Parameter --input missing")
 	}
 
-	advisor := networkpolicy.NewAdvisor()
-	err := advisor.LoadFile(inputFileName)
+	adv := advisor.NewAdvisor()
+	err := adv.LoadFile(inputFileName)
 	if err != nil {
 		return err
 	}
 
-	advisor.GeneratePolicies()
+	adv.GeneratePolicies()
 
 	w, closure, err := newWriter(outputFileName)
 	if err != nil {
@@ -205,7 +205,7 @@ func runNetworkPolicyReport(cmd *cobra.Command, args []string) error {
 	}
 	defer closure()
 
-	_, err = w.Write([]byte(advisor.FormatPolicies()))
+	_, err = w.Write([]byte(adv.FormatPolicies()))
 	if err != nil {
 		contextLogger.Fatalf("Error writing file %q: %s", outputFileName, err)
 	}

--- a/pkg/gadgets/networkpolicy/advisor/advisor.go
+++ b/pkg/gadgets/networkpolicy/advisor/advisor.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package networkpolicy
+package advisor
 
 import (
 	"bufio"

--- a/pkg/gadgets/networkpolicy/advisor/advisor_test.go
+++ b/pkg/gadgets/networkpolicy/advisor/advisor_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package networkpolicy
+package advisor
 
 import (
 	"io/ioutil"

--- a/pkg/gadgets/networkpolicy/gadget.go
+++ b/pkg/gadgets/networkpolicy/gadget.go
@@ -26,6 +26,7 @@ import (
 
 	gadgetv1alpha1 "github.com/kinvolk/inspektor-gadget/pkg/api/v1alpha1"
 	"github.com/kinvolk/inspektor-gadget/pkg/gadgets"
+	"github.com/kinvolk/inspektor-gadget/pkg/gadgets/networkpolicy/advisor"
 )
 
 type Trace struct {
@@ -141,15 +142,15 @@ func (f *Trace) UpdateOutput(trace *gadgetv1alpha1.Trace) {
 }
 
 func (f *Trace) Report(trace *gadgetv1alpha1.Trace) {
-	advisor := NewAdvisor()
-	err := advisor.LoadBuffer([]byte(trace.Status.Output))
+	adv := advisor.NewAdvisor()
+	err := adv.LoadBuffer([]byte(trace.Status.Output))
 	if err != nil {
 		trace.Status.OperationError = fmt.Sprintf("Cannot parse report: %s", err)
 		return
 	}
 
-	advisor.GeneratePolicies()
-	output := advisor.FormatPolicies()
+	adv.GeneratePolicies()
+	output := adv.FormatPolicies()
 
 	trace.Status.OperationError = ""
 	trace.Status.Output = output


### PR DESCRIPTION
This is to avoid linking too many packages in the kubectl-gadget CLI tool.

Internal imports before this patch:
```
cmd/kubectl-gadget
    cmd/kubectl-gadget/utils
        pkg/api/v1alpha1
        pkg/factory
        pkg/k8sutil
        pkg/types
    pkg/gadgets/dns/types
    pkg/gadgets/networkpolicy
        pkg/gadgets
            pkg/container-collection
                pkg/gadgettracermanager/api
                pkg/gadgettracermanager/containerutils
                pkg/gadgettracermanager/pubsub
                pkg/runcfanotify
        pkg/gadgets/networkpolicy/types
    pkg/gadgets/socket-collector/types
    pkg/resources
```
Internal imports after this patch:
```
cmd/kubectl-gadget
    cmd/kubectl-gadget/utils
        pkg/api/v1alpha1
        pkg/factory
        pkg/k8sutil
        pkg/types
    pkg/gadgets/dns/types
    pkg/gadgets/networkpolicy/advisor
        pkg/gadgets/networkpolicy/types
    pkg/gadgets/socket-collector/types
    pkg/resources
```

