### PR TITLE
Update traceloop binary

### DIFF
--- a/gadget.Dockerfile
+++ b/gadget.Dockerfile
@@ -23,12 +23,12 @@ RUN cd /gadget/gadget-container && make gadget-container-deps
 # Builder: traceloop
 
 # traceloop built from:
-# https://github.com/kinvolk/traceloop/commit/3a57301aba445720c630ba99b58892da72a31e35
+# https://github.com/kinvolk/traceloop/commit/6f4efc6fca46d92c75f4ec4e6c6e1d829bdeaddf
 # See:
 # - https://github.com/kinvolk/traceloop/actions
 # - https://hub.docker.com/r/kinvolk/traceloop/tags
 
-FROM docker.io/kinvolk/traceloop:202006050210553a5730 as traceloop
+FROM docker.io/kinvolk/traceloop:202109280218336f4efc as traceloop
 
 # Main gadget image
 


### PR DESCRIPTION
It fixes traces not being shown in an AKS cluster

I'm not 100% sure why the old version wasn't working, I think it's something that was fixed by this commit -> https://github.com/kinvolk/traceloop/commit/6f4efc6fca46d92c75f4ec4e6c6e1d829bdeaddf. 

Fixes https://github.com/kinvolk/inspektor-gadget/issues/248. 

Notes to reviewers: Please be sure that you are able to reproduce the issue in https://github.com/kinvolk/inspektor-gadget/issues/248 and that this PR actually fixes it. 