### PR TITLE
Makefile: minikube-install: wait for uninstall before new installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,6 +115,8 @@ minikube-install: gadget-container kubectl-gadget
 	# because of Finalizers.
 	kubectl delete crd traces.gadget.kinvolk.io || true
 	./kubectl-gadget deploy | kubectl delete -f - || true
+	time kubectl wait --for=delete namespace gadget 2>/dev/null || true
+	time kubectl wait --for=delete daemonset -n kube-system gadget 2>/dev/null || true
 	./kubectl-gadget deploy --traceloop=false --hook-mode=fanotify | \
 		sed 's/imagePullPolicy: Always/imagePullPolicy: Never/g' | \
 		sed 's/initialDelaySeconds: 10/initialDelaySeconds: '$(LIVENESS_PROBE_INITIAL_DELAY_SECONDS)'/g' | \


### PR DESCRIPTION
I have race conditions where the gadget namespace is not fully deleted
after the "kubectl delete -f". So the "kubectl apply" does not need to
create the namespace, but then the deletion terminates soon after.

Similarly, there are sometimes two gadgets pod: one in the terminating
state, and one in the creating state.

Additionally, it seems that "kubectl delete --wait" does not always
work. So I am adding an explicit "kubectl wait".

@ashu8912 