### PR TITLE
cmd: set default of tools-mode to auto

### DIFF
--- a/cmd/kubectl-gadget/deploy.go
+++ b/cmd/kubectl-gadget/deploy.go
@@ -71,7 +71,7 @@ func init() {
 	deployCmd.PersistentFlags().StringVarP(
 		&toolsMode,
 		"tools-mode", "",
-		"standard",
+		"auto",
 		"which kind of tools to use (auto, core, standard)")
 
 	rootCmd.AddCommand(deployCmd)


### PR DESCRIPTION
# Set default of tools-mode to auto

Now that we solved the issue with CO-RE based tools (#230), the default value can be set back to "auto".