### PR TITLE
cmd: Add user stack to capabilities when using --print-stack.

### DIFF
--- a/cmd/kubectl-gadget/bcck8s.go
+++ b/cmd/kubectl-gadget/bcck8s.go
@@ -244,7 +244,7 @@ func bccCmd(subCommand, bccScript string) func(*cobra.Command, []string) {
 		switch subCommand {
 		case "capabilities":
 			if stackFlag {
-				gadgetParams += " -K"
+				gadgetParams += " -K -U"
 			}
 			if uniqueFlag {
 				gadgetParams += " --unique"


### PR DESCRIPTION
Hi.


`--print-stack` description is the following:
```
Print kernel and userspace call stack of cap_capable()
```
But in reality it only printed kernel stack.
With this commit, I added user stack to be printed.


Best regards.