### PR TITLE
makefile: Add targets to easily deploy the gadget container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,7 @@ minikube-install: gadget-container kubectl-gadget
 	./kubectl-gadget deploy | kubectl delete -f - || true
 	time kubectl wait --for=delete namespace gadget 2>/dev/null || true
 	time kubectl wait --for=delete daemonset -n kube-system gadget 2>/dev/null || true
-	./kubectl-gadget deploy --traceloop=false --hook-mode=fanotify | \
-		sed 's/imagePullPolicy: Always/imagePullPolicy: Never/g' | \
+	./kubectl-gadget deploy --traceloop=false --hook-mode=fanotify \
+		--image-pull-policy=Never | \
 		sed 's/initialDelaySeconds: 10/initialDelaySeconds: '$(LIVENESS_PROBE_INITIAL_DELAY_SECONDS)'/g' | \
 		kubectl apply -f -

--- a/cmd/kubectl-gadget/deploy.go
+++ b/cmd/kubectl-gadget/deploy.go
@@ -35,6 +35,7 @@ var gadgetimage = "undefined"
 
 var (
 	image             string
+	imagePullPolicy   string
 	traceloop         bool
 	traceloopLoglevel string
 	hookMode          string
@@ -48,6 +49,11 @@ func init() {
 		"image", "",
 		gadgetimage,
 		"container image")
+	deployCmd.PersistentFlags().StringVarP(
+		&imagePullPolicy,
+		"image-pull-policy", "",
+		"Always",
+		"pull policy for the container image")
 	deployCmd.PersistentFlags().BoolVarP(
 		&traceloop,
 		"traceloop", "",
@@ -127,7 +133,7 @@ spec:
       containers:
       - name: gadget
         image: {{.Image}}
-        imagePullPolicy: Always
+        imagePullPolicy: {{.ImagePullPolicy}}
         command: [ "/entrypoint.sh" ]
         lifecycle:
           preStop:
@@ -225,6 +231,7 @@ spec:
 
 type parameters struct {
 	Image             string
+	ImagePullPolicy   string
 	Version           string
 	Traceloop         bool
 	TraceloopLoglevel string
@@ -253,6 +260,7 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 
 	p := parameters{
 		image,
+		imagePullPolicy,
 		version,
 		traceloop,
 		traceloopLoglevel,


### PR DESCRIPTION
# Add targets to easily deploy the gadget container

This PR introduces new targets to make easier the testing of the Inspektor Gadget:

## Case 1 - Kubernetes cluster using directly our local Docker
If we are testing our modified gadget container image in a Kubernetes cluster that is running in the host itself and uses directly the same local Docker we are using for building (e.g, we installed directly in the host kubeadm or minikube with `vm-driver=none`), it means that we can work locally, and we do not need to push the image to a registry.

The following command will compile and deploy our customised image using the parameter `--image-pull-policy=Never` which will force Kubelet to look for the image locally instead of trying to fetch it during the deployment. This will allow us to skip the uploading and downloading phases and will make the developing cycle faster:
  
```
$ make install-local-gadget-container
```

## Case 2 - Minikube running in the host
If we are using a minikube cluster (with `vm-driver=docker`) installed directly in our host, the combination of `docker-save` + `minikube docker-env` + `docker-load` could be a solution to avoid the need of using a registry. The following command will do that for us and will then deploy the image: 

```
$ make minikube-install
```
NOTE: It is not supported for a multi-node cluster.

## Case 3 - Remote Kubernetes cluster (e.g. AKS)
If our Kubernetes cluster is running on a VM on our host or we are using a Kubernetes service provider like AKS, we will need to push our image into a registry to make it accessible to the Kubelet instances running on each node.

The following command will compile, push and deploy our image using the repository defined by `CONTAINER_REPO`:
```
$ export CONTAINER_REPO="docker.io/myrepo/gadget"
$ make install-gadget-container
```
NOTE: kubectl needs to be configured to have access to the remote cluster.

## Case 4 - [Special case] Remote Kubernetes cluster running in the same LAN
Consider that _Case 3_ implies uploading the image (around 800MB) and then downloading it again on each node. The point is that if our cluster is running in the same LAN where we are building, meaning that all the nodes are running in a VM/container in the same host or in other hosts in the same LAN. It means that it is not necessary to use a remote registry like DockerHub or Quay but we can use a local registry that will be accessible by all the nodes. It should be definitely faster.

Once we configure our local registry, we need to define `CONTAINER_REPO` to point to our local registry and then deploy the image:
```
$ export CONTAINER_REPO="<REGISTRY-IP>:<REGISTRY-PORT>/gadget"
$ make install-gadget-container
```
NOTE: Also in this case, kubectl needs to be configured to have access to the remote cluster.