### PR TITLE
Modify utils.trace API and convert some gadgets to it.

### DIFF
--- a/cmd/kubectl-gadget/dns.go
+++ b/cmd/kubectl-gadget/dns.go
@@ -17,6 +17,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
 
@@ -62,7 +63,20 @@ var dnsCmd = &cobra.Command{
 			)
 		}
 
-		utils.GenericTraceCommand("dns", &params, args, "Stream", nil, transform)
+		config := &utils.TraceConfig{
+			GadgetName:       "dns",
+			Operation:        "start",
+			TraceOutputMode:  "Stream",
+			TraceOutputState: "Started",
+			CommonFlags:      &params,
+		}
+
+		err := utils.RunTraceAndPrintStream(config, transform)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "%s\n", err)
+
+			os.Exit(1)
+		}
 	},
 }
 

--- a/cmd/kubectl-gadget/utils/trace.go
+++ b/cmd/kubectl-gadget/utils/trace.go
@@ -16,6 +16,8 @@ package utils
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"math/rand"
 	"os"
@@ -23,6 +25,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"syscall"
+	"text/tabwriter"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -31,6 +34,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
+	types "k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	restclient "k8s.io/client-go/rest"
@@ -41,8 +45,34 @@ import (
 
 const (
 	GADGET_OPERATION = "gadget.kinvolk.io/operation"
-	traceTimeout     = 2 * time.Second
+	// We name it "global" as if one trace is created on several nodes, then each
+	// copy of the trace on each node will share the same id.
+	GLOBAL_TRACE_ID = "global-trace-id"
+	traceTimeout    = 2 * time.Second
 )
+
+// TraceConfig is used to contain information used to manage a trace.
+type TraceConfig struct {
+	// GadgetName is gadget name, e.g. socket-collector.
+	GadgetName string
+	// Operation is the gadget operation to apply to this trace, e.g. start to
+	// start the tracing.
+	Operation string
+	// TraceOutputMode is the trace output mode, the correct values are:
+	// * "Status": The trace prints information when its status changes.
+	// * "Stream": The trace prints information as events arrive.
+	// * "File": The trace prints information into a file.
+	// * "ExternalResource": The trace prints information an external resource,
+	// e.g. a seccomp profile.
+	TraceOutputMode string
+	// TraceOutputState is the state in which the trace can output information.
+	// For example, trace for *-collector gadget contains output while in
+	// Completed state.
+	// But other gadgets, like dns, can contain output only in Started state.
+	TraceOutputState string
+	// CommonFlags is used to hold parameters given on the command line interface.
+	CommonFlags *CommonFlags
+}
 
 func init() {
 	// The Trace REST client needs to know the Trace CRD
@@ -94,7 +124,7 @@ func printTraceFeedback(f func(format string, args ...interface{}), m map[string
 
 func deleteTraces(contextLogger *log.Entry, traceRestClient *restclient.RESTClient, traceID string) {
 	var listTracesOptions = metav1.ListOptions{
-		LabelSelector: fmt.Sprintf("trace-template-hash=%s", traceID),
+		LabelSelector: fmt.Sprintf("%s=%s", GLOBAL_TRACE_ID, traceID),
 		FieldSelector: fields.Everything().String(),
 	}
 	err := traceRestClient.
@@ -107,6 +137,366 @@ func deleteTraces(contextLogger *log.Entry, traceRestClient *restclient.RESTClie
 	if contextLogger != nil && err != nil {
 		contextLogger.Warningf("Error deleting traces: %q", err)
 	}
+}
+
+// getRestClient returns the RESTClient associated with kubeRestConfig() for
+// APIPath /apis and GroupVersion &gadgetv1alpha1.GroupVersion.
+func getRestClient() (*restclient.RESTClient, error) {
+	restConfig, err := kubeRestConfig()
+	if err != nil {
+		return nil, fmt.Errorf("Error while getting rest config: %w", err)
+	}
+
+	traceConfig := *restConfig
+	traceConfig.ContentConfig.GroupVersion = &gadgetv1alpha1.GroupVersion
+	traceConfig.APIPath = "/apis"
+	traceConfig.NegotiatedSerializer = serializer.NewCodecFactory(scheme.Scheme)
+	traceConfig.UserAgent = restclient.DefaultKubernetesUserAgent()
+
+	traceRestClient, err := restclient.UnversionedRESTClientFor(&traceConfig)
+	if err != nil {
+		return nil, fmt.Errorf("Error setting up trace REST client: %w", err)
+	}
+
+	return traceRestClient, nil
+}
+
+// createTraces creates a trace using Kubernetes REST API.
+// Note that, this function will create the trace on all existing node if
+// trace.Spec.Node is empty.
+func createTraces(trace *gadgetv1alpha1.Trace) error {
+	client, err := k8sutil.NewClientsetFromConfigFlags(KubernetesConfigFlags)
+	if err != nil {
+		return fmt.Errorf("Error setting up Kubernetes client: %w", err)
+	}
+
+	nodes, err := client.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		return fmt.Errorf("Error listing nodes: %w", err)
+	}
+
+	traceRestClient, err := getRestClient()
+	if err != nil {
+		return fmt.Errorf("Error setting up trace REST client: %w", err)
+	}
+
+	nodeFound := false
+	traceNode := trace.Spec.Node
+
+	for _, node := range nodes.Items {
+		if traceNode != "" && node.Name != traceNode {
+			continue
+		}
+		// If no particular node was given, we need to apply this trace on all
+		// available nodes.
+		if traceNode == "" {
+			trace.Spec.Node = node.Name
+		}
+		nodeFound = true
+
+		err = traceRestClient.
+			Post().
+			Namespace(trace.ObjectMeta.Namespace).
+			Resource("traces").
+			Body(trace).
+			Do(context.TODO()).
+			Error()
+		if err != nil {
+			traceID, present := trace.ObjectMeta.Labels[GLOBAL_TRACE_ID]
+			if present {
+				// Clean before exiting!
+				deleteTraces(nil, traceRestClient, traceID)
+			}
+
+			return fmt.Errorf("Error creating trace on node %q: %w", node.Name, err)
+		}
+	}
+
+	// It is possible we change this value in the above loop, restore it to its
+	// previous value.
+	trace.Spec.Node = traceNode
+
+	if traceNode != "" && !nodeFound {
+		return fmt.Errorf("Invalid filter: Node %q does not exist", traceNode)
+	}
+
+	return nil
+}
+
+// updateTraceOperation updates operation for an already existing trace using
+// Kubernetes REST API.
+func updateTraceOperation(trace *gadgetv1alpha1.Trace, operation string) error {
+	traceRestClient, err := getRestClient()
+	if err != nil {
+		return err
+	}
+
+	// This trace will be used as JSON merge patch to update GADGET_OPERATION,
+	// see:
+	// https://datatracker.ietf.org/doc/html/rfc6902
+	// https://datatracker.ietf.org/doc/html/rfc7386
+	type Annotations map[string]string
+	type ObjectMeta struct {
+		Annotations Annotations `json:"annotations"`
+	}
+	type JSONMergePatch struct {
+		ObjectMeta ObjectMeta `json:"metadata"`
+	}
+	patch := JSONMergePatch{
+		ObjectMeta: ObjectMeta{
+			Annotations{
+				GADGET_OPERATION: operation,
+			},
+		},
+	}
+
+	patchBytes, err := json.Marshal(patch)
+	if err != nil {
+		return fmt.Errorf("Error marshalling the operation annotations: %w", err)
+	}
+
+	return traceRestClient.
+		Patch(types.MergePatchType).
+		Namespace(trace.ObjectMeta.Namespace).
+		Resource("traces").
+		Name(trace.ObjectMeta.Name).
+		Body(patchBytes).
+		Do(context.TODO()).
+		Error()
+}
+
+// CreateTrace initializes a trace object with its field according to the given
+// parameter.
+// The trace is then posted to the RESTClient which returns an error if
+// something wrong occurred.
+// A unique trace identifier is returned, this identifier will be used as other
+// function parameter.
+// A trace obtained with this function must be deleted calling DeleteTrace.
+func CreateTrace(config *TraceConfig) (string, error) {
+	traceID := randomTraceID()
+
+	labelsSelector := map[string]string{}
+	if config.CommonFlags.Label != "" {
+		pairs := strings.Split(config.CommonFlags.Label, ",")
+		for _, pair := range pairs {
+			kv := strings.Split(pair, "=")
+			if len(kv) != 2 {
+				return "", errors.New("Labels should be a comma-separated list of key-value pairs (key=value[,key=value,...])")
+			}
+			labelsSelector[kv[0]] = kv[1]
+		}
+	}
+
+	namespace := ""
+	if !config.CommonFlags.AllNamespaces {
+		namespace = GetNamespace()
+	}
+
+	trace := &gadgetv1alpha1.Trace{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: config.GadgetName + "-",
+			Namespace:    "gadget",
+			Annotations: map[string]string{
+				GADGET_OPERATION: config.Operation,
+			},
+			Labels: map[string]string{
+				GLOBAL_TRACE_ID: traceID,
+				// Add all this information here to be able to find the trace thanks
+				// to them when calling getTraceListFromParameters().
+				"gadgetName":    config.GadgetName,
+				"nodeName":      config.CommonFlags.Node,
+				"namespace":     namespace,
+				"podName":       config.CommonFlags.Podname,
+				"containerName": config.CommonFlags.Containername,
+				"outputMode":    config.TraceOutputMode,
+			},
+		},
+		Spec: gadgetv1alpha1.TraceSpec{
+			Node:   config.CommonFlags.Node,
+			Gadget: config.GadgetName,
+			Filter: &gadgetv1alpha1.ContainerFilter{
+				Namespace:     namespace,
+				Podname:       config.CommonFlags.Podname,
+				ContainerName: config.CommonFlags.Containername,
+				Labels:        labelsSelector,
+			},
+			RunMode:    "Manual",
+			OutputMode: config.TraceOutputMode,
+		},
+	}
+
+	err := createTraces(trace)
+	if err != nil {
+		return "", err
+	}
+
+	return traceID, nil
+}
+
+// getTraceListFromOptions returns a list of traces corresponding to the given
+// options.
+func getTraceListFromOptions(listTracesOptions metav1.ListOptions) (gadgetv1alpha1.TraceList, error) {
+	traceRestClient, err := getRestClient()
+	if err != nil {
+		return gadgetv1alpha1.TraceList{}, err
+	}
+
+	var traces gadgetv1alpha1.TraceList
+
+	err = traceRestClient.
+		Get().
+		Namespace("gadget").
+		Resource("traces").
+		VersionedParams(&listTracesOptions, scheme.ParameterCodec).
+		Do(context.TODO()).
+		Into(&traces)
+	if err != nil {
+		return traces, err
+	}
+
+	return traces, nil
+}
+
+// getTraceListFromID returns an array of pointers to gadgetv1alpha1.Trace
+// corresponding to the given traceID.
+// If no trace corresponds to this ID, error is set.
+func getTraceListFromID(traceID string) (gadgetv1alpha1.TraceList, error) {
+	var listTracesOptions = metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("%s=%s", GLOBAL_TRACE_ID, traceID),
+		FieldSelector: fields.Everything().String(),
+	}
+
+	traces, err := getTraceListFromOptions(listTracesOptions)
+	if err != nil {
+		return traces, fmt.Errorf("Error getting traces from traceID %q: %w", traceID, err)
+	}
+
+	if len(traces.Items) == 0 {
+		return traces, fmt.Errorf("No traces found for traceID %q!", traceID)
+	}
+
+	return traces, nil
+}
+
+// SetTraceOperation sets the operation of an existing trace.
+// If trace does not exist an error is returned.
+func SetTraceOperation(traceID string, operation string) error {
+	traces, err := getTraceListFromID(traceID)
+	if err != nil {
+		return err
+	}
+
+	for _, trace := range traces.Items {
+		localError := updateTraceOperation(&trace, operation)
+		if localError != nil {
+			err = fmt.Errorf("%w\nError updating trace operation for %s: %v", err, traceID, localError)
+		}
+	}
+
+	return err
+}
+
+// waitForOutput loops over all trace whom ID is given as parameter waiting
+// until they are in the expected state.
+// After this function and if correct state was given as parameter, the trace
+// output should contain the needed information.
+func waitForOutput(traceID string, expectedState string) (gadgetv1alpha1.TraceList, error) {
+	start := time.Now()
+
+RetryLoop:
+	for {
+		successNodeCount := 0
+		timeout := time.Since(start) > traceTimeout
+		nodeErrors := make(map[string]string)
+		nodeWarnings := make(map[string]string)
+
+		traces, err := getTraceListFromID(traceID)
+		if err != nil {
+			return gadgetv1alpha1.TraceList{}, err
+		}
+
+		for _, i := range traces.Items {
+			if i.Status.OperationError != "" {
+				nodeErrors[i.Spec.Node] = i.Status.OperationError
+			} else if i.Status.OperationWarning != "" {
+				nodeWarnings[i.Spec.Node] = i.Status.OperationWarning
+				// TODO(francis) This code will not work if the trace is already in the
+				// expected state, for example if we decide to generate it twice.
+				// We need to add a cookie (and check it) to be sure the trace is ready.
+			} else if i.Status.State == expectedState {
+				successNodeCount++
+			} else {
+				// Consider Trace as timed out if it neither moved the state forward
+				// nor notified of an error or warning within the time window.
+				if timeout {
+					nodeErrors[i.Spec.Node] = fmt.Sprintf("No results received from trace within %v", traceTimeout)
+					continue
+				}
+
+				time.Sleep(100 * time.Millisecond)
+				continue RetryLoop
+			}
+		}
+
+		printTraceFeedbackFunction := func(format string, args ...interface{}) { fmt.Fprintf(os.Stderr, format+"\n", args...) }
+
+		// Print errors even if some nodes succeeded.
+		defer printTraceFeedback(printTraceFeedbackFunction, nodeErrors)
+
+		// Don't print warnings if at least one node succeeded. This avoids showing
+		// warnings together with the actual output generated by other nodes.
+		if successNodeCount == 0 {
+			printTraceFeedback(printTraceFeedbackFunction, nodeWarnings)
+
+			return gadgetv1alpha1.TraceList{}, errors.New("Failed to run the gadget on all nodes: None of them succeeded")
+		}
+
+		return traces, nil
+	}
+}
+
+// PrintTraceOutputFromStream is used to print trace output using generic
+// printing function.
+// This function is must be used by trace which has TraceOutputMode set to
+// Stream.
+func PrintTraceOutputFromStream(traceID string, expectedState string, params *CommonFlags, transformLine func(string) string) error {
+	traces, err := waitForOutput(traceID, expectedState)
+	if err != nil {
+		return err
+	}
+
+	client, err := k8sutil.NewClientsetFromConfigFlags(KubernetesConfigFlags)
+	if err != nil {
+		return fmt.Errorf("Error setting up Kubernetes client: %w", err)
+	}
+
+	return genericStreamsDisplay(params, &traces, transformLine)
+}
+
+// PrintTraceOutputFromStatus is used to print trace output using function
+// pointer provided by caller.
+// It will parse trace.Spec.Output and print it calling the function pointer.
+func PrintTraceOutputFromStatus(traceID string, expectedState string, customResultsDisplay func(results *gadgetv1alpha1.TraceList)) error {
+	traces, err := waitForOutput(traceID, expectedState)
+	if err != nil {
+		return err
+	}
+
+	customResultsDisplay(&traces)
+
+	return nil
+}
+
+// DeleteTrace deletes the traces for the given trace ID using RESTClient.
+func DeleteTrace(traceID string) error {
+	traceRestClient, err := getRestClient()
+	if err != nil {
+		return err
+	}
+
+	deleteTraces(nil, traceRestClient, traceID)
+
+	return nil
 }
 
 func GenericTraceCommand(
@@ -314,13 +704,163 @@ RetryLoop:
 	deleteTraces(contextLogger, traceRestClient, traceID)
 }
 
+// labelsFromFilter creates a string containing labels value from the given
+// labelFilter.
+func labelsFromFilter(filter map[string]string) string {
+	labels := ""
+	separator := ""
+
+	// Loop on all fields of labelFilter.
+	for labelName, labelValue := range filter {
+		// If this field has no value, just skip it.
+		if labelValue == "" {
+			continue
+		}
+
+		// Concatenate the label to existing one.
+		labels = fmt.Sprintf("%s%s%s=%v", labels, separator, labelName, labelValue)
+		separator = ","
+	}
+
+	return labels
+}
+
+// getTraceListFromParameters returns traces associated with the given config.
+func getTraceListFromParameters(config *TraceConfig) ([]gadgetv1alpha1.Trace, error) {
+	namespace := ""
+	if !config.CommonFlags.AllNamespaces {
+		namespace = GetNamespace()
+	}
+
+	filter := map[string]string{
+		"gadgetName":    config.GadgetName,
+		"nodeName":      config.CommonFlags.Node,
+		"namespace":     namespace,
+		"podName":       config.CommonFlags.Podname,
+		"containerName": config.CommonFlags.Containername,
+		"outputMode":    config.TraceOutputMode,
+	}
+
+	var listTracesOptions = metav1.ListOptions{
+		LabelSelector: labelsFromFilter(filter),
+	}
+
+	traces, err := getTraceListFromOptions(listTracesOptions)
+	if err != nil {
+		return []gadgetv1alpha1.Trace{}, err
+	}
+
+	return traces.Items, nil
+}
+
+// PrintAllTraces prints all traces corresponding to the given config.CommonFlags.
+func PrintAllTraces(config *TraceConfig) error {
+	traces, err := getTraceListFromParameters(config)
+	if err != nil {
+		return err
+	}
+
+	type printingInformation struct {
+		namespace     string
+		nodeName      string
+		podname       string
+		containerName string
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 4, ' ', 0)
+
+	fmt.Fprintln(w, "NAMESPACE\tNODE(S)\tPOD\tCONTAINER\tTRACEID")
+
+	printingMap := map[string]*printingInformation{}
+
+	for _, trace := range traces {
+		id, present := trace.ObjectMeta.Labels[GLOBAL_TRACE_ID]
+		if !present {
+			continue
+		}
+
+		node := trace.Spec.Node
+
+		_, present = printingMap[id]
+		if present {
+			if node == "" {
+				continue
+			}
+
+			// If an entry with this traceID already exists, we just update the node
+			// name by concatenating it to the string.
+			printingMap[id].nodeName = printingMap[id].nodeName + "," + node
+		} else {
+			// Otherwise, we simply create a new entry.
+			filter := trace.Spec.Filter
+
+			printingMap[id] = &printingInformation{
+				namespace:     filter.Namespace,
+				nodeName:      node,
+				podname:       filter.Podname,
+				containerName: filter.ContainerName,
+			}
+		}
+	}
+
+	for id, info := range printingMap {
+		fmt.Fprintf(w, "%v\t%v\t%v\t%v\t%v\n", info.namespace, info.nodeName, info.podname, info.containerName, id)
+	}
+
+	w.Flush()
+
+	return nil
+}
+
+// RunTraceAndPrintStream creates a trace, prints its output and deletes
+// it.
+// It equals calling separately CreateTrace(), then PrintTraceOutputFromStream()
+// and DeleteTrace().
+// This function is thought to be used with "one-run" gadget, i.e. gadget
+// which runs a trace when it is created.
+func RunTraceAndPrintStream(config *TraceConfig, transformLine func(string) string) error {
+	if config.TraceOutputMode != "Stream" {
+		return errors.New("TraceOutputMode must be Stream. Otherwise, call RunTraceAndPrintStatusOutput!")
+	}
+
+	traceID, err := CreateTrace(config)
+	if err != nil {
+		return fmt.Errorf("error creating trace: %w", err)
+	}
+
+	defer DeleteTrace(traceID)
+
+	return PrintTraceOutputFromStream(traceID, config.TraceOutputState, config.CommonFlags, transformLine)
+}
+
+// RunTraceAndPrintStatusOutput creates a trace, prints its output and deletes
+// it.
+// It equals calling separately CreateTrace(), then PrintTraceOutputFromStatus()
+// and DeleteTrace().
+// This function is thought to be used with "one-run" gadget, i.e. gadget
+// which runs a trace when it is created.
+func RunTraceAndPrintStatusOutput(config *TraceConfig, customResultsDisplay func(results *gadgetv1alpha1.TraceList)) error {
+	if config.TraceOutputMode == "Stream" {
+		return errors.New("TraceOutputMode must not be Stream. Otherwise, call RunTraceAndPrintStream!")
+	}
+
+	traceID, err := CreateTrace(config)
+	if err != nil {
+		return fmt.Errorf("error creating trace: %w", err)
+	}
+
+	defer DeleteTrace(traceID)
+
+	return PrintTraceOutputFromStatus(traceID, config.TraceOutputState, customResultsDisplay)
+}
+
 func genericStreamsDisplay(
 	contextLogger *log.Entry,
 	client *kubernetes.Clientset,
 	params *CommonFlags,
 	results *gadgetv1alpha1.TraceList,
 	transformLine func(string) string,
-) {
+) error {
 	sigs := make(chan os.Signal, 1)
 	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
 	completion := make(chan string)
@@ -373,11 +913,11 @@ func genericStreamsDisplay(
 			if params.OutputMode != OutputModeJson {
 				fmt.Println("\nTerminating...")
 			}
-			return
+			return nil
 		case msg := <-completion:
 			fmt.Printf("%s", msg)
 			if atomic.AddInt32(&streamCount, -1) == 0 {
-				return
+				return nil
 			}
 		}
 	}


### PR DESCRIPTION
Hi.


Jose and I are working on adding CLI to `biolatency` and `seccomp` gadget.
To do so, we need to modify the `utils.trace` API.

For the moment, I added several functions to this API:
1. `CreateTrace()` which creates a trace according to the given parameter.
2. `SetTraceOperation()` which updates the operation of an existing trace.
3. `PrintTraceOutput()` which prints the output of a trace.
4. `DeleteTrace()` which deletes a trace created by CreateTrace().

I also updated the following gadgets to this new API:
1. `process-collector`
2. `socket-collector`
3. `dns`

Code was tested and seems fine:
```bash
francis@machine:~/Codes/kinvolk/inspektor-gadget$ kubectl create ns demo                                        francis/utils-trace-new-api % u=
namespace/demo created
francis@machine:~/Codes/kinvolk/inspektor-gadget$ kubectl run --restart=Never -n demo --image=nginx nginx-app --port=80                
pod/nginx-app created
francis@machine:~/Codes/kinvolk/inspektor-gadget$ kubectl wait --timeout=-1s -n test-socketcollector --for=condition=ready pod/nginx-app ; kubectl get pod -n test-socketcollector
pod/nginx-app condition met
NAME        READY   STATUS    RESTARTS   AGE
nginx-app   1/1     Running   0          62m
francis@machine:~/Codes/kinvolk/inspektor-gadget$ ./kubectl-gadget socket-collector -n demo                     francis/utils-trace-new-api % u=
NODE        NAMESPACE    POD          PROTOCOL    LOCAL         REMOTE       STATUS
minikube    demo         nginx-app    TCP         0.0.0.0:80    0.0.0.0:0    LISTEN
francis@machine:~/Codes/kinvolk/inspektor-gadget$ ./kubectl-gadget process-collector -n demo                    francis/utils-trace-new-api % u=
NAMESPACE    POD          CONTAINER    COMM     PID       
demo         nginx-app    nginx-app    nginx    100307    
demo         nginx-app    nginx-app    nginx    100364    
demo         nginx-app    nginx-app    nginx    100365 
francis@machine:~/Codes/kinvolk/inspektor-gadget$ ./kubectl-gadget dns -n demo
# Jump to other terminal.
francis@machine:~/Codes/kinvolk/inspektor-gadget$ kubectl -n demo run mypod -it --image=praqma/network-multitool -- /bin/sh 
If you don't see a command prompt, try pressing enter.
/ # nslookup microsoft.com
# Go back to first terminal.
POD                            TYPE      NAME
mypod                          OUTGOING  microsoft.com.demo.svc.cluster.local.
mypod                          OUTGOING  microsoft.com.svc.cluster.local.
mypod                          OUTGOING  microsoft.com.cluster.local.
mypod                          OUTGOING  microsoft.com.
mypod                          OUTGOING  microsoft.com.
```

I was almost able to test it in a two nodes environment:
```
$ kubectl get node
NAME                                STATUS   ROLES   AGE   VERSION
aks-agentpool-17075730-vmss000001   Ready    agent   56m   v1.20.9
aks-agentpool-17075730-vmss000002   Ready    agent   56m   v1.20.9
$ ./kubectl-gadget process-collector -n kube-system
Failed to run the gadget on all nodes: [failed to create BPF collection: program dump_task: task iterator not supported]Failed to run the gadget on all nodes: None of them succeeded
$ kubectl get trace -A
No resources found
# Traces seems to be deleted
```
With the above problem and to be sure everything was OK regarding trace, I decided to comment out trace deletion in `RunTraceAndPrint`, then I run again the above commands:
```
$ ./kubectl-gadget process-collector -n kube-system
Failed to run the gadget on all nodes: [failed to create BPF collection: program dump_task: task iterator not supported]Failed to run the gadget on all nodes: None of them succeeded
$ kubectl get trace -A
NAMESPACE   NAME                      AGE
gadget      process-collector-kqhz4   5s
gadget      process-collector-stpqt   5s
```
This time, traces are present, so my modifications are "multinodes proof".


Best regards.