### PR TITLE
Implement pod informer fallback

### DIFF
--- a/cmd/kubectl-gadget/deploy.go
+++ b/cmd/kubectl-gadget/deploy.go
@@ -34,13 +34,14 @@ var deployCmd = &cobra.Command{
 var gadgetimage = "undefined"
 
 var (
-	image             string
-	imagePullPolicy   string
-	traceloop         bool
-	traceloopLoglevel string
-	hookMode          string
-	livenessProbe     bool
-	toolsMode         string
+	image               string
+	imagePullPolicy     string
+	traceloop           bool
+	traceloopLoglevel   string
+	hookMode            string
+	livenessProbe       bool
+	toolsMode           string
+	fallbackPodInformer bool
 )
 
 func init() {
@@ -79,7 +80,11 @@ func init() {
 		"tools-mode", "",
 		"standard",
 		"which kind of tools to use (auto, core, standard)")
-
+	deployCmd.PersistentFlags().BoolVarP(
+		&fallbackPodInformer,
+		"fallback-podinformer", "",
+		true,
+		"Use pod informer as a fallback for the main hook")
 	rootCmd.AddCommand(deployCmd)
 }
 
@@ -188,6 +193,8 @@ spec:
             value: "{{.HookMode}}"
           - name: INSPEKTOR_GADGET_OPTION_TOOLS_MODE
             value: "{{.ToolsMode}}"
+          - name: INSPEKTOR_GADGET_OPTION_FALLBACK_POD_INFORMER
+            value: "{{.FallbackPodInformer}}"
         securityContext:
           capabilities:
             add:
@@ -291,14 +298,15 @@ spec:
 `
 
 type parameters struct {
-	Image             string
-	ImagePullPolicy   string
-	Version           string
-	Traceloop         bool
-	TraceloopLoglevel string
-	HookMode          string
-	LivenessProbe     bool
-	ToolsMode         string
+	Image               string
+	ImagePullPolicy     string
+	Version             string
+	Traceloop           bool
+	TraceloopLoglevel   string
+	HookMode            string
+	LivenessProbe       bool
+	ToolsMode           string
+	FallbackPodInformer bool
 }
 
 func runDeploy(cmd *cobra.Command, args []string) error {
@@ -328,6 +336,7 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 		hookMode,
 		livenessProbe,
 		toolsMode,
+		fallbackPodInformer,
 	}
 
 	fmt.Printf("%s\n---\n", resources.TracesCustomResource)

--- a/gadget-container/entrypoint.sh
+++ b/gadget-container/entrypoint.sh
@@ -210,5 +210,6 @@ if [ "$INSPEKTOR_GADGET_OPTION_TRACELOOP" = "true" ] ; then
     exec /bin/traceloop k8s
   fi
 else
-  exec /bin/gadgettracermanager -serve -hook-mode=$GADGET_TRACER_MANAGER_HOOK_MODE -controller
+  exec /bin/gadgettracermanager -serve -hook-mode=$GADGET_TRACER_MANAGER_HOOK_MODE \
+    -controller -fallback-podinformer=$INSPEKTOR_GADGET_OPTION_FALLBACK_POD_INFORMER
 fi

--- a/gadget-container/gadgettracermanager/main.go
+++ b/gadget-container/gadgettracermanager/main.go
@@ -251,7 +251,10 @@ func main() {
 
 		var tracerManager *gadgettracermanager.GadgetTracerManager
 
-		tracerManager, err = gadgettracermanager.NewServer(node, hookMode)
+		tracerManager, err = gadgettracermanager.NewServer(&gadgettracermanager.Conf{
+			NodeName: node,
+			HookMode: hookMode,
+		})
 
 		if err != nil {
 			log.Fatalf("failed to create server %v", err)

--- a/gadget-container/gadgettracermanager/main.go
+++ b/gadget-container/gadgettracermanager/main.go
@@ -39,22 +39,23 @@ import (
 )
 
 var (
-	controller    bool
-	serve         bool
-	dump          bool
-	liveness      bool
-	hookMode      string
-	socketfile    string
-	method        string
-	label         string
-	tracerid      string
-	containerId   string
-	cgroupPath    string
-	cgroupId      uint64
-	namespace     string
-	podname       string
-	containername string
-	containerPid  uint
+	controller          bool
+	serve               bool
+	dump                bool
+	liveness            bool
+	fallbackPodInformer bool
+	hookMode            string
+	socketfile          string
+	method              string
+	label               string
+	tracerid            string
+	containerId         string
+	cgroupPath          string
+	cgroupId            uint64
+	namespace           string
+	podname             string
+	containername       string
+	containerPid        uint
 )
 
 const (
@@ -81,6 +82,7 @@ func init() {
 
 	flag.BoolVar(&dump, "dump", false, "Dump state for debugging")
 	flag.BoolVar(&liveness, "liveness", false, "Execute as client and perform liveness probe")
+	flag.BoolVar(&fallbackPodInformer, "fallback-podinformer", true, "Use pod informer as a fallback for main hook")
 }
 
 func main() {
@@ -252,8 +254,9 @@ func main() {
 		var tracerManager *gadgettracermanager.GadgetTracerManager
 
 		tracerManager, err = gadgettracermanager.NewServer(&gadgettracermanager.Conf{
-			NodeName: node,
-			HookMode: hookMode,
+			NodeName:            node,
+			HookMode:            hookMode,
+			FallbackPodInformer: fallbackPodInformer,
 		})
 
 		if err != nil {

--- a/pkg/container-collection/container-collection.go
+++ b/pkg/container-collection/container-collection.go
@@ -129,7 +129,10 @@ func (cc *ContainerCollection) AddContainer(container *pb.ContainerDefinition) {
 		}
 	}
 
-	cc.containers.Store(container.Id, container)
+	_, loaded := cc.containers.LoadOrStore(container.Id, container)
+	if loaded {
+		return
+	}
 	if cc.pubsub != nil {
 		cc.pubsub.Publish(pubsub.EVENT_TYPE_ADD_CONTAINER, *container)
 	}

--- a/pkg/gadgettracermanager/gadgettracermanager.go
+++ b/pkg/gadgettracermanager/gadgettracermanager.go
@@ -438,6 +438,11 @@ func newServer(conf *Conf) (*GadgetTracerManager, error) {
 		return nil, fmt.Errorf("invalid hook mode: %s", conf.HookMode)
 	}
 
+	if conf.FallbackPodInformer && conf.HookMode != "podinformer" {
+		log.Infof("GadgetTracerManager: enabling fallback podinformer")
+		opts = append(opts, containercollection.WithFallbackPodInformer(g.nodeName))
+	}
+
 	err := g.ContainerCollectionInitialize(opts...)
 	if err != nil {
 		return nil, err
@@ -447,9 +452,10 @@ func newServer(conf *Conf) (*GadgetTracerManager, error) {
 }
 
 type Conf struct {
-	NodeName string
-	HookMode string
-	TestOnly bool
+	NodeName            string
+	HookMode            string
+	FallbackPodInformer bool
+	TestOnly            bool
 }
 
 func NewServer(conf *Conf) (*GadgetTracerManager, error) {

--- a/pkg/gadgettracermanager/gadgettracermanager_test.go
+++ b/pkg/gadgettracermanager/gadgettracermanager_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestTracer(t *testing.T) {
-	g, err := newServer("fake-node", "none", true)
+	g, err := newServer(&Conf{NodeName: "fake-node", HookMode: "none", TestOnly: true})
 	if err != nil {
 		t.Fatalf("Failed to create new server: %v", err)
 	}
@@ -99,7 +99,7 @@ func TestTracer(t *testing.T) {
 }
 
 func TestContainer(t *testing.T) {
-	g, err := newServer("fake-node", "none", true)
+	g, err := newServer(&Conf{NodeName: "fake-node", HookMode: "none", TestOnly: true})
 	if err != nil {
 		t.Fatalf("Failed to create new server: %v", err)
 	}

--- a/pkg/gadgettracermanager/k8s/k8s.go
+++ b/pkg/gadgettracermanager/k8s/k8s.go
@@ -138,8 +138,13 @@ func (k *K8sClient) PodToContainers(pod *v1.Pod) []pb.ContainerDefinition {
 			continue
 		}
 
+		idParts := strings.SplitN(s.ContainerID, "//", 2)
+		if len(idParts) != 2 {
+			continue
+		}
+
 		containerDef := pb.ContainerDefinition{
-			Id:        s.ContainerID,
+			Id:        idParts[1],
 			Namespace: pod.GetNamespace(),
 			Podname:   pod.GetName(),
 			Name:      s.Name,


### PR DESCRIPTION
    This commit implements a mechanism that uses a pod informer as backup
    for other hooks. If a container is detected by the pod informer and it
    hasn't been added to the container list then it print a warning message
    to notify the main hook is having issues.

Fixes https://github.com/kinvolk/inspektor-gadget/issues/336

TODO: 
- [x] Check if other hooks (crio, nri) are adding the container runtime prefix to the container ID. If so then remove it 
- [x] Should we expose a way to disable the pod informer completely? 