### PR TITLE
Add cli for seccomp.

### DIFF
--- a/cmd/kubectl-gadget/seccompadvisor.go
+++ b/cmd/kubectl-gadget/seccompadvisor.go
@@ -1,0 +1,141 @@
+// Copyright 2019-2021 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/kinvolk/inspektor-gadget/cmd/kubectl-gadget/utils"
+	gadgetv1alpha1 "github.com/kinvolk/inspektor-gadget/pkg/api/v1alpha1"
+)
+
+var seccompAdvisorCmd = &cobra.Command{
+	Use:   "seccomp-advisor",
+	Short: "Generate seccomp policies based on recorded syscalls activity",
+}
+
+var seccompAdvisorStartCmd = &cobra.Command{
+	Use:          "start",
+	Short:        "Start to monitor the system calls",
+	RunE:         runSeccompAdvisorStart,
+	SilenceUsage: true,
+}
+
+var seccompAdvisorStopCmd = &cobra.Command{
+	Use:          "stop",
+	Short:        "Stop monitoring and report the policies",
+	RunE:         runSeccompAdvisorStop,
+	SilenceUsage: true,
+}
+
+var seccompAdvisorListCmd = &cobra.Command{
+	Use:          "list",
+	Short:        "List existing seccomp traces",
+	RunE:         runSeccompAdvisorList,
+	SilenceUsage: true,
+}
+
+func init() {
+	// Add generic information.
+	rootCmd.AddCommand(seccompAdvisorCmd)
+	utils.AddCommonFlags(seccompAdvisorCmd, &params)
+
+	seccompAdvisorCmd.AddCommand(seccompAdvisorStartCmd)
+	seccompAdvisorCmd.AddCommand(seccompAdvisorStopCmd)
+	seccompAdvisorCmd.AddCommand(seccompAdvisorListCmd)
+}
+
+// runSeccompAdvisorStart starts monitoring of syscalls for the given
+// parameters.
+func runSeccompAdvisorStart(cmd *cobra.Command, args []string) error {
+	if params.Podname == "" {
+		return errors.New("Usage: kubectl gadget seccompadvisor start -p podname")
+	}
+
+	config := &utils.TraceConfig{
+		GadgetName:        "seccomp",
+		Operation:         "start",
+		TraceOutputMode:   "Status",
+		TraceInitialState: "Started",
+		CommonFlags:       &params,
+	}
+
+	traceID, err := utils.CreateTrace(config)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("%s\n", traceID)
+
+	return nil
+}
+
+// runSeccompAdvisorStop reports an already running trace which ID was given
+// as parameter.
+func runSeccompAdvisorStop(cmd *cobra.Command, args []string) error {
+	if len(args) == 0 {
+		return errors.New("Usage: kubectl gadget seccomp-advisor stop global-trace-id\n")
+	}
+
+	callback := func(results []gadgetv1alpha1.Trace) error {
+		for _, i := range results {
+			if i.Status.Output != "" {
+				fmt.Printf("%v\n", i.Status.Output)
+			}
+		}
+
+		return nil
+	}
+
+	traceID := args[0]
+
+	// Maybe there is no trace with the given ID.
+	// But it is better to try to delete something which does not exist than
+	// leaking a resource.
+	defer utils.DeleteTrace(traceID)
+
+	err := utils.SetTraceOperation(traceID, "generate")
+	if err != nil {
+		return err
+	}
+
+	// We stop the trace so its Status.State become Stopped.
+	// Indeed, generate operation does not change value of Status.State.
+	err = utils.SetTraceOperation(traceID, "stop")
+	if err != nil {
+		return err
+	}
+
+	err = utils.PrintTraceOutputFromStatus(traceID, "Stopped", callback)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// runSeccompAdvisorList lists already running traces which config was given as
+// parameter.
+func runSeccompAdvisorList(cmd *cobra.Command, args []string) error {
+	config := &utils.TraceConfig{
+		GadgetName:  "seccomp",
+		CommonFlags: &params,
+	}
+
+	return utils.PrintAllTraces(config)
+}

--- a/cmd/kubectl-gadget/utils/trace.go
+++ b/cmd/kubectl-gadget/utils/trace.go
@@ -70,6 +70,11 @@ type TraceConfig struct {
 	// But other gadgets, like dns, can contain output only in Started state.
 	TraceOutputState string
 
+	// TraceOutput is either the name of the file when TraceOutputMode is File or
+	// the name of the external resource when TraceOutputMode is ExternalResource.
+	// Otherwise, its value is ignored.
+	TraceOutput string
+
 	// TraceInitialState is the state in which the trace should be after its
 	// creation.
 	// This field is only used by "multi-rounds gadgets" like biolatency.
@@ -307,6 +312,8 @@ func CreateTrace(config *TraceConfig) (string, error) {
 				"podName":       config.CommonFlags.Podname,
 				"containerName": config.CommonFlags.Containername,
 				"outputMode":    config.TraceOutputMode,
+				// We will not add config.TraceOutput as label because it can contain
+				// "/" which is forbidden in labels.
 			},
 		},
 		Spec: gadgetv1alpha1.TraceSpec{
@@ -315,6 +322,7 @@ func CreateTrace(config *TraceConfig) (string, error) {
 			Filter:     filter,
 			RunMode:    "Manual",
 			OutputMode: config.TraceOutputMode,
+			Output:     config.TraceOutput,
 		},
 	}
 

--- a/docs/examples/seccomp/trace-external.yaml
+++ b/docs/examples/seccomp/trace-external.yaml
@@ -4,7 +4,7 @@ metadata:
   name: seccomp
   namespace: gadget
 spec:
-  node: demo-node
+  node: minikube
   gadget: seccomp
   filter:
     namespace: seccomp-demo

--- a/docs/guides/seccomp.md
+++ b/docs/guides/seccomp.md
@@ -6,11 +6,8 @@ weight: 10
 The Seccomp Policy Advisor gadget records syscalls that are issued in a
 specified pod, and then uses this information to generate the corresponding
 seccomp policy. It can integrate with the [Kubernetes Security Profile
-Operator](https://github.com/kubernetes-sigs/security-profiles-operator), 
+Operator](https://github.com/kubernetes-sigs/security-profiles-operator),
 directly generating the necessary `seccompprofile` resource.
-
-Currently, the Seccomp Policy Advisor can only be used by generating a
-Trace CRD that states the pods to trace.
 
 ### Basic usage
 
@@ -19,7 +16,7 @@ and nginx. The deployment is split in two pieces, the `basic.yaml` file
 that has the infrastructure, and the `unconfined.yaml` file that has the
 pod definition, with no seccomp profile applied.
 
-```
+```bash
 $ kubectl apply -f docs/examples/seccomp/basic.yaml
 namespace/seccomp-demo created
 configmap/app-script created
@@ -28,8 +25,77 @@ $ kubectl apply -f docs/examples/seccomp/unconfined.yaml
 pod/hello-python created
 ```
 
-And trace it with the corresponding `trace-status.yaml` sample CRD, that
-looks like this:
+It is now time to monitor system calls made by our pod:
+
+```bash
+$ kubectl gadget seccomp-advisor start -n seccomp-demo -p hello-python
+jMzhur2dQjZJxDCI
+```
+
+After that, we need to interact with the workload, to get it to generate
+system calls. In our example, it's a simple webservice, and we can interact
+with it by forwarding the service port and then querying the service
+
+```bash
+$ kubectl port-forward service/hello-python-service -n seccomp-demo 8080:6000 &
+[1] 23574
+Forwarding from 127.0.0.1:8080 -> 80
+Forwarding from [::1]:8080 -> 80
+
+$ curl localhost:8080
+Handling connection for 8080
+Hello World!
+
+$ kill %1
+[1]+  Terminated              kubectl port-forward service/hello-python-service -n seccomp-demo 8080:6000
+```
+
+Once we have captured the syscalls, we can ask the gadget to generate the
+corresponding profile:
+
+```bash
+$ kubectl gadget seccomp-advisor stop jMzhur2dQjZJxDCI
+{
+  "defaultAction": "SCMP_ACT_ERRNO",
+  "architectures": [
+    "SCMP_ARCH_X86_64",
+    "SCMP_ARCH_X86",
+    "SCMP_ARCH_X32"
+  ],
+  "syscalls": [
+    {
+      "names": [
+        "accept4",
+        "close",
+        "connect",
+        "epoll_ctl",
+        "epoll_wait",
+        "fstat",
+        "getsockname",
+        "getsockopt",
+        "ioctl",
+        "poll",
+        "read",
+        "recvfrom",
+        "setsockopt",
+        "socket",
+        "stat",
+        "wait4",
+        "write",
+        "writev"
+      ],
+      "action": "SCMP_ACT_ALLOW"
+    }
+  ]
+}
+```
+
+### Using `kubectl annotate`
+
+You can also interact with this gadget by using `kubectl annotate`.
+To keep our example, you will need to use `trace-status.yaml` which content is
+the following:
+
 ```
 apiVersion: gadget.kinvolk.io/v1alpha1
 kind: Trace
@@ -46,25 +112,23 @@ spec:
   outputMode: Status
 ```
 
-The Trace resource defines which pods we want to trace and what type of
-trace we want to run. **Note that you need to set the correct node name in
-the spec of this resource**.
+The `namespace` and `node` under the `filter` label correspond to the `-n` and
+`-p` arguments we used previously.
+**Note that you need to set the correct node name in the spec of this
+resource**.
 
-To create a trace, we need to first apply the resource, and then use the
-operation field to start tracing:
+Once you edited the trace, you can now create it and start it:
 
-```
+```bash
 $ kubectl apply -f docs/examples/seccomp/trace-status.yaml
 trace.gadget.kinvolk.io/seccomp created
 $ kubectl annotate -n gadget trace/seccomp gadget.kinvolk.io/operation=start
 trace.gadget.kinvolk.io/seccomp annotated
 ```
 
-After that, we need to interact with the workload, to get it to generate
-system calls. In our example, it's a simple webservice, and we can interact
-with it by forwarding the service port and then querying the service
+After that, you can interact with the workload like we did previously:
 
-```
+```bash
 $ kubectl port-forward service/hello-python-service -n seccomp-demo 8080:6000 &
 [1] 23574
 Forwarding from 127.0.0.1:8080 -> 80
@@ -78,19 +142,18 @@ $ kill %1
 [1]+  Terminated              kubectl port-forward service/hello-python-service -n seccomp-demo 8080:6000
 ```
 
-Once we have captured the syscalls, we can ask the gadget to generate the
-corresponding profile, by setting the operation to `generate`.
+Now, we can use `kubectl annotate` to generate the trace:
 
-```
+```bash
 $ kubectl annotate -n gadget trace/seccomp gadget.kinvolk.io/operation=generate
 trace.gadget.kinvolk.io/seccomp annotated
 ```
 
-As the `outputMode` was set to `Status`, the generated policy will be
-stored in our CR's status. We can look at it and check out the list of
-syscalls that our `curl` call triggered.
+As the `outputMode` was set to `Status`, the generated policy will be stored in
+our CR's status. We can look at it and check out the list of syscalls that our
+`curl` call triggered.
 
-```
+```bash
 $ kubectl get -n gadget trace/seccomp -o custom-columns=Status:.status
 Status
 map[output:{
@@ -128,6 +191,15 @@ map[output:{
 } state:Started]
 ```
 
+We can stop the current trace using the `stop` operation, and delete the
+current pod, so that we can start a fresh new trace.
+
+```bash
+$ kubectl annotate -n gadget trace/seccomp gadget.kinvolk.io/operation=stop
+trace.gadget.kinvolk.io/seccomp annotated
+$ kubectl delete -f docs/examples/seccomp/trace-status.yaml
+```
+
 ### Capturing all syscalls needed to bring up the pod
 
 That sample policy contains only the syscalls executed for that one single
@@ -136,28 +208,25 @@ also include all the calls needed to bring the pod up.  To do that, we need
 to start the trace before the pod is up, then bring up the pod and generate
 traffic.
 
-We can stop the current trace using the `stop` operation, and delete the
-current pod, so that we can start a fresh new trace.
+We can delete the current pod, so that we can start a fresh new trace.
 
-```
-$ kubectl annotate -n gadget trace/seccomp gadget.kinvolk.io/operation=stop
-trace.gadget.kinvolk.io/seccomp annotated
+```bash
 $ kubectl delete -f docs/examples/seccomp/unconfined.yaml
 pod "hello-python" deleted
 ```
 
-Now we can `start` a new trace, and then create the pod again.
+Now we can create a new trace, and then create the pod again.
 
-```
-$ kubectl annotate -n gadget trace/seccomp gadget.kinvolk.io/operation=start
-trace.gadget.kinvolk.io/seccomp annotated
+```bash
+$ kubectl gadget seccomp-advisor start -n seccomp-demo -p hello-python
+TAyR9BXes6GU04rG
 $ kubectl apply -f docs/examples/seccomp/unconfined.yaml
 pod/hello-python created
 ```
 
 Once the pod is up, we can once again generate some traffic, like before.
 
-```
+```bash
 $ kubectl port-forward service/hello-python-service -n seccomp-demo 8080:6000 &
 [1] 28318
 Forwarding from 127.0.0.1:8080 -> 80
@@ -171,14 +240,17 @@ $ kill %1
 [1]+  Terminated              kubectl port-forward service/hello-python-service -n seccomp-demo 8080:6000
 ```
 
-And now generate the policy again.
-```
-$ kubectl annotate -n gadget trace/seccomp gadget.kinvolk.io/operation=generate
-trace.gadget.kinvolk.io/seccomp annotated
+And now generate the policy again:
+
+```bash
+$ kubectl gadget seccomp-advisor stop TAyR9BXes6GU04rG
+{
+	...
+}
 ```
 
-This time, the Status field will contain a lot more syscalls, as a lot of
-operations need to take place to bring up the pod. 
+This time, the output field will contain a lot more syscalls, as a lot of
+operations need to take place to bring up the pod.
 
 ### Integration with Kubernetes Security Profiles Operator
 
@@ -187,52 +259,31 @@ our pod. But instead of copying it manually, we can also use the
 integration with the [Kubernetes Security Profiles
 Operator](https://github.com/kubernetes-sigs/security-profiles-operator).
 
-When this operator is
-[installed](https://github.com/kubernetes-sigs/security-profiles-operator/blob/master/installation-usage.md#install-operator)
-in the cluster, the seccomp gadget can generate `seccompprofile` resources
+To install the operator, use the following commands:
+
+<!--
+In our code, we include seccompprofile/v1alpha1, thus we apply from v0.3.0 to
+ensure operator.yaml applies on our code.
+-->
+```bash
+$ kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.6.0/cert-manager.yaml
+$ kubectl --namespace cert-manager wait --for condition=ready pod -l app.kubernetes.io/instance=cert-manager
+$ kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/security-profiles-operator/v0.3.0/deploy/operator.yaml
+```
+
+Once installed, the seccomp gadget can generate `seccompprofile` resources
 that can be used directly by our pods.
 
-To do this, we need to change the `outputMode` field to `ExternalResource` and
-the `output` field to the namespace and name of the desired resource. You
-can edit the trace file and re-apply it. Our example directory already
-includes a modified version of the trace in `trace-external.yaml`:
+To do this, we need to use the `--seccomp-profile` option of the command line.
 
-```
-apiVersion: gadget.kinvolk.io/v1alpha1
-kind: Trace
-metadata:
-  name: seccomp
-  namespace: gadget
-spec:
-  node: demo-node
-  gadget: seccomp
-  filter:
-    namespace: seccomp-demo
-    podname: hello-python
-  runMode: Manual
-  outputMode: ExternalResource
-  output: seccomp-demo/hello-profile
-```
-
-**Remember that you need to set the right node name**.
-
-We can apply this modified file, which will change the existing resource.
-We'll need to capture the syscalls once again, from the start and then call
-`generate` again to get the profile generated:
-
-```
-$ kubectl apply -f docs/examples/seccomp/trace-external.yaml
-trace.gadget.kinvolk.io/seccomp configured
-
-# Delete the pod and stop the previous trace
+```bash
+# Delete the pod.
 $ kubectl delete -f docs/examples/seccomp/unconfined.yaml
 pod "hello-python" deleted
-$ kubectl annotate -n gadget trace/seccomp gadget.kinvolk.io/operation=stop
-trace.gadget.kinvolk.io/seccomp annotated
 
-# Start a new trace and create the pod again
-$ kubectl annotate -n gadget trace/seccomp gadget.kinvolk.io/operation=start
-trace.gadget.kinvolk.io/seccomp annotated
+# Create the pod and start a new trace again
+$ kubectl gadget seccomp-advisor start -n seccomp-demo -m seccomp-profile --seccomp-profile-name seccomp-demo/hello-profile -p hello-python
+TAyR9BXes6GU04rG
 $ kubectl apply -f docs/examples/seccomp/unconfined.yaml
 pod/hello-python created
 
@@ -247,12 +298,11 @@ Hello World!
 $ kill %1
 [1]+  Terminated              kubectl port-forward service/hello-python-service -n seccomp-demo 8080:6000
 
-# Now generate the policy as an external resource
-$ kubectl annotate -n gadget trace/seccomp gadget.kinvolk.io/operation=generate
-trace.gadget.kinvolk.io/seccomp annotated
+# Now stop the gadget to generate the seccomp profile.
+$ kubectl gadget seccomp-advisor stop TAyR9BXes6GU04rG
 $ kubectl get -n seccomp-demo seccompprofile
 NAME            STATUS      AGE
-hello-profile   Installed   9s
+hello-profile   Installed   42s
 ```
 
 This profile can now be used as the seccomp profile for our pod. To do
@@ -272,7 +322,7 @@ We have this change already applied in the `confined.yaml` file. To apply
 this change, we need to delete the current pod and create a new one with
 the new configuration:
 
-```
+```bash
 $ kubectl delete -f docs/examples/seccomp/unconfined.yaml
 pod "hello-python" deleted
 $ kubectl apply -f docs/examples/seccomp/confined.yaml
@@ -282,7 +332,7 @@ pod/hello-python created
 Our workload is now running with the seccomp profile. We can verify that
 it's running correctly by querying it once again like before:
 
-```
+```bash
 $ kubectl port-forward service/hello-python-service -n seccomp-demo 8080:6000 &
 [1] 41643
 $ Forwarding from 127.0.0.1:8080 -> 80
@@ -297,7 +347,7 @@ The request is allowed (as expected), but processes that require additional
 syscalls will be blocked. For example, if we try to execute a shell in our
 pod:
 
-```
+```bash
 $ kubectl exec -it -n seccomp-demo hello-python -- /bin/bash
 OCI runtime exec failed: exec failed: container_linux.go:380: starting
 container process caused: exec: "/bin/bash": stat /bin/bash: operation not
@@ -312,13 +362,11 @@ the captured calls.
 ### Cleanup
 
 Once we're done with the demo, we can delete all the resources that we've
-used by deleting the `seccomp-demo` namespace and the trace resource.
+used by deleting the `seccomp-demo` namespace:
 
-```
-$ kubectl delete ns seccomp-demo 
+```bash
+$ kubectl delete ns seccomp-demo
 namespace "seccomp-demo" deleted
-$ kubectl delete -f docs/examples/seccomp/trace-external.yaml
-trace.gadget.kinvolk.io "seccomp" deleted
 ```
 
 ### Troubleshooting

--- a/pkg/gadgets/seccomp/gadget.go
+++ b/pkg/gadgets/seccomp/gadget.go
@@ -315,7 +315,7 @@ func (t *Trace) Generate(trace *gadgetv1alpha1.Trace) {
 			trace.Spec.Filter.ContainerName,
 		)
 		if mntns == 0 {
-			trace.Status.OperationError = fmt.Sprintf("Container %s/%s/%s not found on this node",
+			trace.Status.OperationWarning = fmt.Sprintf("Container %s/%s/%s not found",
 				trace.Spec.Filter.Namespace,
 				trace.Spec.Filter.Podname,
 				trace.Spec.Filter.ContainerName,
@@ -329,7 +329,7 @@ func (t *Trace) Generate(trace *gadgetv1alpha1.Trace) {
 			trace.Spec.Filter.Podname,
 		)
 		if len(mntnsMap) == 0 {
-			trace.Status.OperationError = fmt.Sprintf("Pod %s/%s not found on this node",
+			trace.Status.OperationWarning = fmt.Sprintf("Pod %s/%s not found",
 				trace.Spec.Filter.Namespace,
 				trace.Spec.Filter.Podname,
 			)

--- a/pkg/gadgets/seccomp/gadget.go
+++ b/pkg/gadgets/seccomp/gadget.go
@@ -414,7 +414,6 @@ func (t *Trace) Stop(trace *gadgetv1alpha1.Trace) {
 
 	t.started = false
 
-	trace.Status.OperationError = ""
 	trace.Status.State = "Stopped"
 	return
 }


### PR DESCRIPTION
Hi.

In this PR, I added a CLI for the seccomp gadget:
1. `start`: Run the trace and start monitoring syscalls
2. `stop`: Output the previously captured syscalls on standard output.
3. `list`: List the existing seccomp trace (_i.e._, the ones created with `monitor` which were not `report`ed for the moment).
<details>
  <summary>Here is an example of how to use it</summary>
   
  ```bash
francis@machine:~/Codes/kinvolk/inspektor-gadget$ kubectl apply -f docs/examples/seccomp/basic.yamlnamespace/seccomp-demo created
configmap/app-script created
service/hello-python-service created
francis@machine:~/Codes/kinvolk/inspektor-gadget$ kubectl apply -f docs/examples/seccomp/unconfined.yaml
pod/hello-python created
francis@machine:~/Codes/kinvolk/inspektor-gadget$ ./kubectl-gadget seccomp-advisor monitor -n seccomp-demo -p hello-python
Succesfully created trace with ID: "sTL0lkzNctFSQqpb"!
You will need to use this ID to report trace.
In case you forgot it, you can list existing traces with 'list' subcommand
francis@machine:~/Codes/kinvolk/inspektor-gadget$ kubectl port-forward service/hello-python-service -n seccomp-demo 8081:6000 &
[1] 202845
francis@machine:~/Codes/kinvolk/inspektor-gadget$ Forwarding from 127.0.0.1:8081 -> 80
Forwarding from [::1]:8081 -> 80
curl localhost:8081
Handling connection for 8081
Hello World!
francis@machine:~/Codes/kinvolk/inspektor-gadget$ kill %1
[1]  + terminated  kubectl port-forward service/hello-python-service -n seccomp-demo 8081:6000
{
  "defaultAction": "SCMP_ACT_ERRNO",
  "architectures": [
    "SCMP_ARCH_X86_64",
    "SCMP_ARCH_X86",
    "SCMP_ARCH_X32"
  ],
  "syscalls": [
    {
      "names": [
        "accept4",
        "access",
        "arch_prctl",
        "bind",
        "brk",
        "chmod",
        "chown",
        "clock_gettime",
        "clone",
        "close",
        "connect",
        "dup",
        "dup2",
        "epoll_create",
        "epoll_create1",
        "epoll_ctl",
        "epoll_wait",
        "eventfd2",
        "execve",
        "exit_group",
        "fcntl",
        "fstat",
        "futex",
        "getcwd",
        "getdents64",
        "getegid",
        "geteuid",
        "getgid",
        "getpid",
        "getppid",
        "getrandom",
        "getsockname",
        "getsockopt",
        "gettid",
        "gettimeofday",
        "getuid",
        "io_setup",
        "ioctl",
        "link",
        "listen",
        "lseek",
        "lstat",
        "mkdir",
        "mmap",
        "mprotect",
        "munmap",
        "openat",
        "pipe",
        "pipe2",
        "poll",
        "prctl",
        "pread64",
        "prlimit64",
        "pwrite64",
        "read",
        "readlink",
        "recvfrom",
        "rename",
        "rt_sigaction",
        "rt_sigprocmask",
        "rt_sigreturn",
        "rt_sigsuspend",
        "set_robust_list",
        "set_tid_address",
        "setgid",
        "setgroups",
        "setpgid",
        "setsockopt",
        "setuid",
        "socket",
        "socketpair",
        "stat",
        "sysinfo",
        "uname",
        "unlink",
        "wait4",
        "write",
        "writev"
      ],
      "action": "SCMP_ACT_ALLOW"
    }
  ]
}
```
</details>


Fixes #263 