### PR TITLE
Update traceloop

### DIFF
--- a/gadget.Dockerfile
+++ b/gadget.Dockerfile
@@ -23,12 +23,12 @@ RUN cd /gadget/gadget-container && make gadget-container-deps
 # Builder: traceloop
 
 # traceloop built from:
-# https://github.com/kinvolk/traceloop/commit/6f4efc6fca46d92c75f4ec4e6c6e1d829bdeaddf
+# https://github.com/kinvolk/traceloop/commit/ae83444f37531606f3148006d2c80bd649d2e392
 # See:
 # - https://github.com/kinvolk/traceloop/actions
 # - https://hub.docker.com/r/kinvolk/traceloop/tags
 
-FROM docker.io/kinvolk/traceloop:202109280218336f4efc as traceloop
+FROM docker.io/kinvolk/traceloop:20211105143601ae8344 as traceloop
 
 # Main gadget image
 


### PR DESCRIPTION
    Update traceloop
    
    Traceloop is failing with the
    "cannot create perfring map mmap error: operation not permitted" error.
    This error is triggered from [0].
    
    By using strace I can find the following:
    
    ```
    $ strace -f -e trace=mmap traceloop k8s
    ...
    
    [pid 14593] mmap(NULL, 266240, PROT_READ, MAP_SHARED, 1162, 0) = -1 EPERM (Operation not permitted)
    ```
    
    It happens because traceloop was missing a call to increase rlimit. This
    commit updates the traceloop version to fix that issue.


ref https://github.com/kinvolk/inspektor-gadget/pull/348/
