### PR TITLE
cmd: Add IPC_LOCK capability to gadget container

### DIFF
--- a/cmd/kubectl-gadget/deploy.go
+++ b/cmd/kubectl-gadget/deploy.go
@@ -253,6 +253,10 @@ spec:
 
               # Needed by setrlimit in gadgettracermanager.
               - SYS_RESOURCE
+
+              # Needed for gadgets that don't dumb the memory rlimit.
+              # (Currently only applies to BCC python-based gadgets)
+              - IPC_LOCK
         volumeMounts:
         - name: host
           mountPath: /host


### PR DESCRIPTION
IPC_LOCK allows to bypass RLIMIT_MEMLOCK. Some gadgets (BCC python-based)
are not bumping their rlimit lock and hence they are failing.

Related to https://github.com/kinvolk/inspektor-gadget/pull/381.

How to reproduce:

```
# deploy IG with traceloop enabled
$ ./kubectl-gadget deploy | kubectl apply -f -

# try to use any BCC tool (be sure you're using the python based ones)
$ ./kubectl-gadget execsnoop
NODE             NAMESPACE        POD              CONTAINER        PCOMM            PID    PPID   RET ARGS
mmap: Operation not permitted
... 
```

Tested in 5.11.0-38-generic. 