### PR TITLE
Use BTFGen

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,4 @@
 !cmd
 !gadget-container
 !pkg
+!tools

--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -108,6 +108,8 @@ jobs:
       with:
         context: .
         file: gadget.Dockerfile
+        build-args: |
+          ENABLE_BTFGEN=true
         # TODO: how to avoid pushing a container before running integration tests
         push: true
         tags: ${{ secrets.CONTAINER_REPO }}:${{ env.IMAGE_TAG }}

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,8 @@ MINIKUBE ?= minikube
 GOHOSTOS ?= $(shell go env GOHOSTOS)
 GOHOSTARCH ?= $(shell go env GOHOSTARCH)
 
+ENABLE_BTFGEN ?= false
+
 # Adds a '-dirty' suffix to version string if there are uncommitted changes
 changes := $(shell git status --porcelain)
 ifeq ($(changes),)
@@ -110,7 +112,8 @@ install/kubectl-gadget: kubectl-gadget-$(GOHOSTOS)-$(GOHOSTARCH)
 # gadget container
 .PHONY: gadget-container
 gadget-container:
-	docker build -t $(CONTAINER_REPO):$(IMAGE_TAG) -f gadget.Dockerfile .
+	docker build -t $(CONTAINER_REPO):$(IMAGE_TAG) -f gadget.Dockerfile \
+		--build-arg ENABLE_BTFGEN=$(ENABLE_BTFGEN) .
 
 .PHONY: push-gadget-container
 push-gadget-container:
@@ -168,3 +171,7 @@ minikube-install: gadget-container kubectl-gadget
 		--image-pull-policy=Never | \
 		sed 's/initialDelaySeconds: 10/initialDelaySeconds: '$(LIVENESS_PROBE_INITIAL_DELAY_SECONDS)'/g' | \
 		kubectl apply -f -
+
+.PHONY: btfgen
+btfgen:
+	./tools/btfgen.sh

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -38,9 +38,8 @@ kubectl-gadget-linux-amd64` or `make kubectl-gadget-darwin-amd64`.
 You can build and push the container gadget image by running the following commands:
 
 ```
-$ cd gadget-container
-$ make build
-$ make push
+$ make gadget-container
+$ make push-gadget-container
 ```
 
 The BPF code is built using a Docker container, so you don't have to worry
@@ -58,6 +57,8 @@ argument when deploying to the Kuberentes cluster.
 described in [BCC](#Updating-BCC-from-upstream) section.
 - See the [minikube](#Development-environment-on-minikube)
 section for a faster development cycle.
+- You can generate the required BTF information for some well known
+  kernel versions by setting `ENABLE_BTFGEN=true`
 
 ## Workflows
 

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -12,9 +12,11 @@ node, as well as whether or not the kernel has
 [BTF](https://www.kernel.org/doc/html/latest/bpf/btf.html) enabled (via
 `CONFIG_DEBUG_INFO_BTF=y`).
 
-For some well known kernel versions, the lack of BTF is remediated by
-downloading the symbols from
-[btfhub](https://github.com/aquasecurity/btfhub/).
+The required BTF information for some well known kernel versions is
+generated with [BTFGen](https://github.com/kinvolk/btfgen) and shipped
+within the gadget container image. If there are not shipped types for
+the running kernel then they are downloaded from
+[BTFhub](https://github.com/aquasecurity/btfhub/).
 
 ## Required Kernel Versions
 

--- a/gadget-container/entrypoint.sh
+++ b/gadget-container/entrypoint.sh
@@ -142,25 +142,33 @@ echo "Gadget Tracer Manager hook mode: ${GADGET_TRACER_MANAGER_HOOK_MODE}"
 KERNEL=$(uname -r)
 ARCH=$(uname -m)
 if test -f /sys/kernel/btf/vmlinux; then
-  echo "BTF is available at /sys/kernel/btf/vmlinux"
+  echo "Kernel provided BTF is available at /sys/kernel/btf/vmlinux"
 else
-  echo "BTF is not available: Trying BTFHub"
   source /host/etc/os-release
 
-  URL="https://github.com/aquasecurity/btfhub-archive/raw/main/$ID/$VERSION_ID/$ARCH/$KERNEL.btf.tar.xz"
-
-  echo "Trying to download vmlinux from $URL"
-
-  if [[ $(wget -S --spider "$URL" 2>&1 | grep 'HTTP/1.1 200 OK') ]]; then
-    wget -q -O /tmp/vmlinux.btf.tar.xz "$URL"
-    tar -xf /tmp/vmlinux.btf.tar.xz
-    # Use objcopy to put the btf info in an ELF file as libbpf and cilium/ebpf
-    # by default check if there is an ELF file with the .BTF section at
-    # /boot/vmlinux-$KERNEL.
-    objcopy --input binary --output elf64-little --rename-section .data=.BTF *.btf /boot/vmlinux-$KERNEL
-    echo "vmlinux downloaded at /boot/vmlinux-$KERNEL"
+  echo "Kernel provided BTF is not available: Trying shipped BTF files"
+  SOURCE_BTF=/btfs/$ID/$VERSION_ID/$ARCH/$KERNEL.btf
+  if [ -f $SOURCE_BTF ]; then
+    objcopy --input binary --output elf64-little --rename-section .data=.BTF $SOURCE_BTF /boot/vmlinux-$KERNEL
+    echo "shipped BTF available. Installed at /boot/vmlinux-$KERNEL"
   else
-    echo "vmlinux not found"
+    echo "shipped BTF not available. Trying to download from BTFHub"
+
+    URL="https://github.com/aquasecurity/btfhub-archive/raw/main/$ID/$VERSION_ID/$ARCH/$KERNEL.btf.tar.xz"
+
+    echo "Trying to download vmlinux from $URL"
+
+    if [[ $(wget -S --spider "$URL" 2>&1 | grep 'HTTP/1.1 200 OK') ]]; then
+      wget -q -O /tmp/vmlinux.btf.tar.xz "$URL"
+      tar -xf /tmp/vmlinux.btf.tar.xz
+      # Use objcopy to put the btf info in an ELF file as libbpf and cilium/ebpf
+      # by default check if there is an ELF file with the .BTF section at
+      # /boot/vmlinux-$KERNEL.
+      objcopy --input binary --output elf64-little --rename-section .data=.BTF *.btf /boot/vmlinux-$KERNEL
+      echo "BTF downloaded at /boot/vmlinux-$KERNEL"
+    else
+      echo "BTF not found"
+    fi
   fi
 fi
 

--- a/tools/btfgen.sh
+++ b/tools/btfgen.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+set -e
+set -x
+
+LIBBPFTOOLS="${LIBBPFTOOLS:-$(pwd)/../bcc/libbpf-tools/.output/}"
+BTFHUB="${BTFHUB:-$(pwd)/../btfhub/}"
+INSPEKTOR_GADGET=${INSPEKTOR_GADGET:-$(pwd)}
+ARCH=x86_64
+OUTPUT=/tmp/btfs
+
+if [ ! -d "${LIBBPFTOOLS}" ]; then
+    echo "error: libbpftools folder not found"
+    exit 1
+fi
+
+if [ ! -d "${BTFHUB}" ]; then
+    echo "error: btfhub folder not found"
+    exit 1
+fi
+
+if [ ! -d "${INSPEKTOR_GADGET}" ]; then
+    echo "error: Inspektor Gadget not found"
+    exit 1
+fi
+
+${BTFHUB}/tools/btfgen.sh -a ${ARCH}                                    \
+    -o ${LIBBPFTOOLS}/bindsnoop.bpf.o                                   \
+    -o ${LIBBPFTOOLS}/execsnoop.bpf.o                                   \
+    -o ${LIBBPFTOOLS}/mountsnoop.bpf.o                                  \
+    -o ${LIBBPFTOOLS}/opensnoop.bpf.o                                   \
+    -o ${LIBBPFTOOLS}/tcpconnect.bpf.o                                  \
+    -o ${INSPEKTOR_GADGET}/pkg/gadgets/seccomp/tracer/bpf/seccomp.o     \
+    #
+
+mkdir -p ${OUTPUT}
+cp -r ${BTFHUB}/custom-archive/* ${OUTPUT}

--- a/tools/getbtfhub.sh
+++ b/tools/getbtfhub.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -e
+
+git clone --depth 1 https://github.com/aquasecurity/btfhub /tmp/btfhub
+git clone --depth 1 https://github.com/aquasecurity/btfhub-archive/ /tmp/btfhub-archive/
+
+mv /tmp/btfhub-archive/* /tmp/btfhub/archive/


### PR DESCRIPTION
BTFGen[0] allows to generate small BTF files with only the information
needed by a set of eBPF objects. This commit makes use of that tool
together with BTFHub[1] to create a set of BTF files needed by Inspektor
Gadget. These files are around 800KB and are included in the gadget
container. At container startup time, the entrypoint script checks if
there's a file for the running kernel, if yes it's installed on the
system.

[0]: https://github.com/kinvolk/btfgen
[1]: https://github.com/aquasecurity/btfhub

TODO:
- [x] Integrate with the CI to include this in the released container image  
- [x] Merge https://github.com/kinvolk/bcc/pull/15
