### PR TITLE
GHA: don't update krew on forks

### DIFF
--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -235,5 +235,7 @@ jobs:
         make -C integration push
 
     - name: Update new version in krew-index
-      if: startsWith(github.ref, 'refs/tags/v')
+      if: |
+        startsWith(github.ref, 'refs/tags/v')
+        && github.repository == 'kinvolk/inspektor-gadget'
       uses: rajatjindal/krew-release-bot@v0.0.40


### PR DESCRIPTION
# GHA: don't update krew on forks

When forking the inspektor-gadget repository for testing the release process, we don't want to mistakenly publish a release to krew-index. This patch detects the fork and skip the krew-index update in that case.

## How to use


## Testing done

Tested via:

https://github.com/alban/inspektor-gadget/runs/4224664726?check_suite_focus=true