### PR TITLE
utils: trace: Wait for given initial state after creating the trace.

### DIFF
--- a/cmd/kubectl-gadget/biolatency.go
+++ b/cmd/kubectl-gadget/biolatency.go
@@ -25,16 +25,18 @@ import (
 )
 
 const (
-	GADGET_NAME        = "biolatency"
-	GADGET_OUTPUTMODE  = "Status"
-	GADGET_OUTPUTSTATE = "Completed"
+	GADGET_NAME         = "biolatency"
+	GADGET_OUTPUTMODE   = "Status"
+	GADGET_OUTPUTSTATE  = "Completed"
+	GADGET_INITIALSTATE = "Started"
 )
 
 var biolatencyTraceConfig = &utils.TraceConfig{
-	GadgetName:       GADGET_NAME,
-	TraceOutputMode:  GADGET_OUTPUTMODE,
-	TraceOutputState: GADGET_OUTPUTSTATE,
-	CommonFlags:      &params,
+	GadgetName:        GADGET_NAME,
+	TraceOutputMode:   GADGET_OUTPUTMODE,
+	TraceOutputState:  GADGET_OUTPUTSTATE,
+	TraceInitialState: GADGET_INITIALSTATE,
+	CommonFlags:       &params,
 }
 
 var biolatencyCmd = &cobra.Command{


### PR DESCRIPTION
Hi.


In this commit, I added waiting for the trace to be in a given by user initial state once it is created.
The advantage of doing so is that we give a "ready to use" trace to the user and also print trace warnings and errors during its creation rather than waiting for the user to use a `stop` operation.

It fixes #391.


Best regards.