### PR TITLE
local-gadget: remove memlock rlimit

### DIFF
--- a/pkg/gadgettracermanager/gadgettracermanager.go
+++ b/pkg/gadgettracermanager/gadgettracermanager.go
@@ -344,8 +344,8 @@ func newServer(conf *Conf) (*GadgetTracerManager, error) {
 	containerEventFuncs := []pubsub.FuncNotify{}
 
 	if !conf.TestOnly {
-		if err := increaseRlimit(); err != nil {
-			return nil, fmt.Errorf("failed to increase memlock limit: %w", err)
+		if _, err := ebpf.RemoveMemlockRlimit(); err != nil {
+			return nil, err
 		}
 
 		if err := os.Mkdir(gadgets.PIN_PATH, 0700); err != nil && !errors.Is(err, unix.EEXIST) {
@@ -468,12 +468,4 @@ func (m *GadgetTracerManager) Close() {
 	if m.containersMap != nil {
 		os.Remove(filepath.Join(gadgets.PIN_PATH, "containers"))
 	}
-}
-
-func increaseRlimit() error {
-	limit := &unix.Rlimit{
-		Cur: unix.RLIM_INFINITY,
-		Max: unix.RLIM_INFINITY,
-	}
-	return unix.Setrlimit(unix.RLIMIT_MEMLOCK, limit)
 }

--- a/pkg/local-gadget-manager/local-gadget-manager.go
+++ b/pkg/local-gadget-manager/local-gadget-manager.go
@@ -26,6 +26,7 @@ import (
 	pb "github.com/kinvolk/inspektor-gadget/pkg/gadgettracermanager/api"
 	"github.com/kinvolk/inspektor-gadget/pkg/gadgettracermanager/stream"
 
+	"github.com/cilium/ebpf"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -275,6 +276,10 @@ func (l *LocalGadgetManager) Dump() string {
 }
 
 func NewManager() (*LocalGadgetManager, error) {
+	if _, err := ebpf.RemoveMemlockRlimit(); err != nil {
+		return nil, err
+	}
+
 	l := &LocalGadgetManager{
 		traceFactories: gadgetcollection.TraceFactoriesForLocalGadget(),
 		tracers:        make(map[string]tracer),


### PR DESCRIPTION
While gadgettracermanager increased the memlock rlimit, local-gadget was
not doing it and this leads to this error:

```
{"err":"failed to create BPF collection: program bpf_prog1: load
program: RLIMIT_MEMLOCK may be too low: operation not
permitted","notice":"failed to attach
tracer","node":"local","namespace":"default","pod":"shell01"}
```

This patch increases the memlock rlimit for local-gadget using the
provided function from cilium/ebpf and use the same code pattern in
gadgettracermanager.

Note that recent kernels don't require the memlock rlimit to be
increased when the process has CAP_IPC_LOCK (Linux >= 5.11). But it has
been found necessary for Linux 5.10.

cc @tormath1 
