### PR TITLE
collectors: Change operation from Start to Collect

### DIFF
--- a/cmd/kubectl-gadget/collector.go
+++ b/cmd/kubectl-gadget/collector.go
@@ -167,7 +167,7 @@ func processCollectorCmdRun(cmd *cobra.Command, args []string) {
 
 	config := &utils.TraceConfig{
 		GadgetName:       "process-collector",
-		Operation:        "start",
+		Operation:        "collect",
 		TraceOutputMode:  "Status",
 		TraceOutputState: "Completed",
 		CommonFlags:      &params,
@@ -261,7 +261,7 @@ func socketCollectorCmdRun(cmd *cobra.Command, args []string) {
 
 	config := &utils.TraceConfig{
 		GadgetName:       "socket-collector",
-		Operation:        "start",
+		Operation:        "collect",
 		TraceOutputMode:  "Status",
 		TraceOutputState: "Completed",
 		CommonFlags:      &params,

--- a/cmd/local-gadget/main.go
+++ b/cmd/local-gadget/main.go
@@ -26,7 +26,7 @@ import (
 	"github.com/chzyer/readline"
 	"github.com/spf13/cobra"
 
-	"github.com/kinvolk/inspektor-gadget/pkg/local-gadget-manager"
+	localgadgetmanager "github.com/kinvolk/inspektor-gadget/pkg/local-gadget-manager"
 )
 
 // This variable is used by the "version" command and is set during build.
@@ -105,7 +105,14 @@ func newRootCmd() *cobra.Command {
 					fmt.Println(err.Error())
 					return
 				}
-				err = localGadgetManager.Operation(name, "start")
+
+				operations := localGadgetManager.ListOperations(name)
+				if len(operations) == 1 {
+					err = localGadgetManager.Operation(name, operations[0])
+				} else {
+					err = localGadgetManager.Operation(name, "start")
+				}
+
 				if err != nil {
 					fmt.Println(err.Error())
 					return

--- a/docs/gadgets/process-collector.md
+++ b/docs/gadgets/process-collector.md
@@ -27,13 +27,13 @@ spec:
 ### Operations
 
 
-#### start
+#### collect
 
-Create a snapshot of the currently running processes. Once taken, the snapshot is not updated automatically. However one can call the start operation again at any time to update the snapshot.
+Create a snapshot of the currently running processes. Once taken, the snapshot is not updated automatically. However one can call the collect operation again at any time to update the snapshot.
 
 ```
 $ kubectl annotate -n gadget trace/process-collector \
-    gadget.kinvolk.io/operation=start
+    gadget.kinvolk.io/operation=collect
 ```
 
 ### Output Modes

--- a/docs/gadgets/socket-collector.md
+++ b/docs/gadgets/socket-collector.md
@@ -26,13 +26,13 @@ spec:
 ### Operations
 
 
-#### start
+#### collect
 
-Create a snapshot of the currently open TCP and UDP sockets. Once taken, the snapshot is not updated automatically. However one can call the start operation again at any time to update the snapshot.
+Create a snapshot of the currently open TCP and UDP sockets. Once taken, the snapshot is not updated automatically. However one can call the collect operation again at any time to update the snapshot.
 
 ```
 $ kubectl annotate -n gadget trace/socket-collector \
-    gadget.kinvolk.io/operation=start
+    gadget.kinvolk.io/operation=collect
 ```
 
 ### Output Modes

--- a/pkg/gadgets/process-collector/gadget.go
+++ b/pkg/gadgets/process-collector/gadget.go
@@ -50,18 +50,18 @@ func (f *TraceFactory) Operations() map[string]gadgets.TraceOperation {
 	}
 
 	return map[string]gadgets.TraceOperation{
-		"start": {
+		"collect": {
 			Doc: "Create a snapshot of the currently running processes. " +
 				"Once taken, the snapshot is not updated automatically. " +
-				"However one can call the start operation again at any time to update the snapshot.",
+				"However one can call the collect operation again at any time to update the snapshot.",
 			Operation: func(name string, trace *gadgetv1alpha1.Trace) {
-				f.LookupOrCreate(name, n).(*Trace).Start(trace)
+				f.LookupOrCreate(name, n).(*Trace).Collect(trace)
 			},
 		},
 	}
 }
 
-func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
+func (t *Trace) Collect(trace *gadgetv1alpha1.Trace) {
 	selector := gadgets.ContainerSelectorFromContainerFilter(trace.Spec.Filter)
 	if len(t.resolver.GetContainersBySelector(selector)) == 0 {
 		gadgets.CleanupTraceStatus(trace)

--- a/pkg/gadgets/socket-collector/gadget.go
+++ b/pkg/gadgets/socket-collector/gadget.go
@@ -56,18 +56,18 @@ func (f *TraceFactory) Operations() map[string]gadgets.TraceOperation {
 	}
 
 	return map[string]gadgets.TraceOperation{
-		"start": {
+		"collect": {
 			Doc: "Create a snapshot of the currently open TCP and UDP sockets. " +
 				"Once taken, the snapshot is not updated automatically. " +
-				"However one can call the start operation again at any time to update the snapshot.",
+				"However one can call the collect operation again at any time to update the snapshot.",
 			Operation: func(name string, trace *gadgetv1alpha1.Trace) {
-				f.LookupOrCreate(name, n).(*Trace).Start(trace)
+				f.LookupOrCreate(name, n).(*Trace).Collect(trace)
 			},
 		},
 	}
 }
 
-func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
+func (t *Trace) Collect(trace *gadgetv1alpha1.Trace) {
 	if trace.Spec.Filter != nil && trace.Spec.Filter.ContainerName != "" {
 		log.Warningf("Gadget %s: Container name filter is not applicable in this gadget, ignoring it!",
 			trace.Spec.Gadget)

--- a/pkg/local-gadget-manager/local-gadget-manager_test.go
+++ b/pkg/local-gadget-manager/local-gadget-manager_test.go
@@ -262,8 +262,8 @@ func TestCollector(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create tracer: %s", err)
 	}
-	err = localGadgetManager.Operation("my-tracer1", "start")
+	err = localGadgetManager.Operation("my-tracer1", "collect")
 	if err != nil {
-		t.Fatalf("Failed to start the tracer: %s", err)
+		t.Fatalf("Failed to run the tracer: %s", err)
 	}
 }


### PR DESCRIPTION
# collectors: Change operation from Start to Collect

`Start` is not an appropriate operation name for the gadgets that generate a snapshot because they are not actually being started but just executed. In fact, after the `Start` operation they do not go in `Started` but `Completed` so they do not even need to be stopped.

For these reasons, the operation name was changed from `Start` to `Collect`.

https://github.com/kinvolk/inspektor-gadget/pull/357 unblocked this implementation and made it quite straightforward.

## How to use

Nothing changes from the user's point of view.

## Testing done

- I tested the socket-collector with the local-gadget.
- I re-run the socket and process collector guides to ensure they were still working correctly.