### PR TITLE
docs: Update guides to use `-o json` instead of `--json`

### DIFF
--- a/docs/guides/biotop.md
+++ b/docs/guides/biotop.md
@@ -9,7 +9,7 @@ The gadget doesn't support the following flags:
  * `--containername`
  * `--podname`
  * `--namespace`
- * `--json`
+ * `--output`
 
 ```
 $ kubectl gadget biotop --node ip-10-0-30-247 --all-namespaces

--- a/docs/guides/process-collector.md
+++ b/docs/guides/process-collector.md
@@ -24,6 +24,8 @@ Create a pod on the `demo` namespace using the `nginx` image:
 ```
 $ kubectl -n demo run mypod --image=nginx
 pod/mypod created
+$ kubectl wait -n demo --for=condition=ready pod/mypod
+pod/mypod condition met
 ```
 
 After the pod is running, we can try to get the list of running processes again:
@@ -67,10 +69,10 @@ demo         mypod    mypod        nginx    37935
 demo         mypod    mypod        sleep    41165
 ```
 
-We can also get the information in JSON format, by passing the `--json` flag.
+We can also get the information in JSON format, by passing the `-o json` flag.
 
 ```
-$ kubectl gadget process-collector -n demo --json
+$ kubectl gadget process-collector -n demo -o json
 [
   {
     "tgid": 34270,

--- a/docs/guides/socket-collector.md
+++ b/docs/guides/socket-collector.md
@@ -48,10 +48,10 @@ NODE       NAMESPACE               POD          PROTOCOL    LOCAL           REMO
 my-node    test-socketcollector    nginx-app    TCP         0.0.0.0:8080    0.0.0.0:0    LISTEN
 ```
 
-We can also get the information in JSON format, by passing the --json flag.
+We can also get the information in JSON format, by passing the `-o json` flag.
 Just take into account that IP address and port are displayed separated with this format:
 ```
-$ kubectl gadget socket-collector -n test-socketcollector --json
+$ kubectl gadget socket-collector -n test-socketcollector -o json
 [
   {
     "node": "my-node",


### PR DESCRIPTION
# docs: Update guides to use `-o json` instead of `--json`

After PR https://github.com/kinvolk/inspektor-gadget/pull/333, the user can get the output in JSON format using the `--output json` or `-o json` instead of `--json`. Update the guides accordingly.
