### PR TITLE
kubectl-gadget/bcc: Manage filtering by non-existent node

### DIFF
--- a/cmd/kubectl-gadget/utils/trace.go
+++ b/cmd/kubectl-gadget/utils/trace.go
@@ -182,9 +182,7 @@ func createTraces(trace *gadgetv1alpha1.Trace) error {
 		return fmt.Errorf("Error setting up trace REST client: %w", err)
 	}
 
-	nodeFound := false
 	traceNode := trace.Spec.Node
-
 	for _, node := range nodes.Items {
 		if traceNode != "" && node.Name != traceNode {
 			continue
@@ -194,7 +192,6 @@ func createTraces(trace *gadgetv1alpha1.Trace) error {
 		if traceNode == "" {
 			trace.Spec.Node = node.Name
 		}
-		nodeFound = true
 
 		err = traceRestClient.
 			Post().
@@ -212,10 +209,6 @@ func createTraces(trace *gadgetv1alpha1.Trace) error {
 
 			return fmt.Errorf("Error creating trace on node %q: %w", node.Name, err)
 		}
-	}
-
-	if traceNode != "" && !nodeFound {
-		return fmt.Errorf("Invalid filter: Node %q does not exist", traceNode)
 	}
 
 	return nil


### PR DESCRIPTION
# Manage filtering by non-existent node

This PR moves into a common place for the BCC (previously not covered) and non-BCC gadgets the node existence verification.

As discussed in the comments, this check will be removed when we will support the addition/deletion of nodes.

### Before this PR
The gadget does not notify any error and remains blocked just doing nothing.
```
$ ./kubectl-gadget opensnoop -A --node non-existent-node
^C
Terminating...
```
### After this PR
The gadget finishes immediately with the following error:
```
$ ./kubectl-gadget opensnoop -A --node non-existent-node
Error: invalid filter: node "non-existent-node" does not exist
```