### PR TITLE
seccomp: Align namespace and naming convention of the generated profiles

### DIFF
--- a/docs/examples/seccomp/confined.yaml
+++ b/docs/examples/seccomp/confined.yaml
@@ -9,7 +9,7 @@ spec:
   securityContext:
     seccompProfile:
       type: Localhost
-      localhostProfile: operator/seccomp-demo/hello-profile.json
+      localhostProfile: operator/gadget/hello-python.json
   containers:
   - name: hello-python
     image: tiangolo/uwsgi-nginx-flask:latest

--- a/docs/guides/seccomp.md
+++ b/docs/guides/seccomp.md
@@ -274,7 +274,14 @@ $ kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/security-pr
 Once installed, the seccomp gadget can generate `seccompprofile` resources
 that can be used directly by our pods.
 
-To do this, we need to use the `--seccomp-profile` option of the command line.
+We need to use the `--output-mode` (or simply `-m`) option to create the
+`SeccompProfile` resource instead of printing the policy in the terminal
+(default behaviour). Consider that using the option `--profile-prefix`,
+we can specify the namespace and the prefix-name of the resource:
+`namespace/prefix-name`. Notice the namespace is not mandatory.
+If the option `--profile-prefix` is not used, the resource will be
+automatically named using the pod name, and it will be created in the
+trace's namespace (`gadget` if kubectl-gadget CLI was used).
 
 ```bash
 # Delete the pod.
@@ -282,7 +289,7 @@ $ kubectl delete -f docs/examples/seccomp/unconfined.yaml
 pod "hello-python" deleted
 
 # Create the pod and start a new trace again
-$ kubectl gadget seccomp-advisor start -n seccomp-demo -m seccomp-profile --seccomp-profile-name seccomp-demo/hello-profile -p hello-python
+$ kubectl gadget seccomp-advisor start -m seccomp-profile -n seccomp-demo -p hello-python
 TAyR9BXes6GU04rG
 $ kubectl apply -f docs/examples/seccomp/unconfined.yaml
 pod/hello-python created
@@ -300,9 +307,9 @@ $ kill %1
 
 # Now stop the gadget to generate the seccomp profile.
 $ kubectl gadget seccomp-advisor stop TAyR9BXes6GU04rG
-$ kubectl get -n seccomp-demo seccompprofile
+$ kubectl get seccompprofile -n gadget
 NAME            STATUS      AGE
-hello-profile   Installed   42s
+hello-python    Installed   9s
 ```
 
 This profile can now be used as the seccomp profile for our pod. To do
@@ -315,7 +322,7 @@ spec:
   securityContext:
     seccompProfile:
       type: Localhost
-      localhostProfile: operator/seccomp-demo/hello-profile.json
+      localhostProfile: operator/gadget/hello-python.json
 ```
 
 We have this change already applied in the `confined.yaml` file. To apply

--- a/pkg/gadgets/seccomp/gadget.go
+++ b/pkg/gadgets/seccomp/gadget.go
@@ -234,8 +234,7 @@ func (t *Trace) containerTerminated(trace *gadgetv1alpha1.Trace, event pubsub.Pu
 
 func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 	if t.started {
-		trace.Status.OperationError = ""
-		trace.Status.Output = ""
+		gadgets.CleanupTraceStatus(trace)
 		trace.Status.State = "Started"
 		return
 	}
@@ -273,10 +272,8 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 	traceSingleton.users++
 	t.started = true
 
-	trace.Status.OperationError = ""
-	trace.Status.Output = ""
+	gadgets.CleanupTraceStatus(trace)
 	trace.Status.State = "Started"
-	return
 }
 
 func (t *Trace) Generate(trace *gadgetv1alpha1.Trace) {
@@ -410,5 +407,4 @@ func (t *Trace) Stop(trace *gadgetv1alpha1.Trace) {
 	t.started = false
 
 	trace.Status.State = "Stopped"
-	return
 }

--- a/pkg/gadgets/seccomp/gadget_test.go
+++ b/pkg/gadgets/seccomp/gadget_test.go
@@ -1,0 +1,217 @@
+// Copyright 2019-2021 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package seccomp
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	seccompprofilev1alpha1 "sigs.k8s.io/security-profiles-operator/api/seccompprofile/v1alpha1"
+)
+
+func TestGetSeccompProfileNextName(t *testing.T) {
+	// Empty profile list
+	profileList := []seccompprofilev1alpha1.SeccompProfile{}
+	podName := "podname"
+	expectedNextName := "podname"
+	nextName := getSeccompProfileNextName(profileList, podName)
+	if nextName != expectedNextName {
+		t.Fatalf("Invalid computation of next name '%s'. Expecting '%s' from an empty profile list",
+			nextName, expectedNextName)
+	}
+
+	// There do not exist profiles with podname or podname-X as name.
+	profileList = []seccompprofilev1alpha1.SeccompProfile{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "another-name",
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "prefix-podname",
+			},
+		},
+	}
+	podName = "podname"
+	expectedNextName = "podname"
+	nextName = getSeccompProfileNextName(profileList, podName)
+	if nextName != expectedNextName {
+		t.Fatalf("Invalid computation of next name '%s'. Expecting '%s' from the given profile list",
+			nextName, expectedNextName)
+	}
+
+	// There exist a profile with the podname but no one with podname-X.
+	profileList = []seccompprofilev1alpha1.SeccompProfile{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "another-name",
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "prefix-podname",
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "podname",
+			},
+		},
+	}
+	podName = "podname"
+	expectedNextName = "podname-2"
+	nextName = getSeccompProfileNextName(profileList, podName)
+	if nextName != expectedNextName {
+		t.Fatalf("Invalid computation of next name '%s'. Expecting '%s' from the given profile list",
+			nextName, expectedNextName)
+	}
+
+	// There exist a profile with the podname and another with podname-X.
+	profileList = []seccompprofilev1alpha1.SeccompProfile{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "another-name",
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "prefix-podname",
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "podname",
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "podname-2",
+			},
+		},
+	}
+	podName = "podname"
+	expectedNextName = "podname-3"
+	nextName = getSeccompProfileNextName(profileList, podName)
+	if nextName != expectedNextName {
+		t.Fatalf("Invalid computation of next name '%s'. Expecting '%s' from the given profile list",
+			nextName, expectedNextName)
+	}
+
+	// There exist at least one profile with podname-X.
+	profileList = []seccompprofilev1alpha1.SeccompProfile{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "another-name",
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "prefix-podname",
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "podname-10",
+			},
+		},
+	}
+	podName = "podname"
+	expectedNextName = "podname-11"
+	nextName = getSeccompProfileNextName(profileList, podName)
+	if nextName != expectedNextName {
+		t.Fatalf("Invalid computation of next name '%s'. Expecting '%s' from the given profile list",
+			nextName, expectedNextName)
+	}
+
+	// There exist multiple profiles with podname-X.
+	profileList = []seccompprofilev1alpha1.SeccompProfile{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "another-name",
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "prefix-podname",
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "podname-2",
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "podname-7",
+			},
+		},
+	}
+	podName = "podname"
+	expectedNextName = "podname-8"
+	nextName = getSeccompProfileNextName(profileList, podName)
+	if nextName != expectedNextName {
+		t.Fatalf("Invalid computation of next name '%s'. Expecting '%s' from the given profile list",
+			nextName, expectedNextName)
+	}
+
+	// Ignoring profiles with sintax podname-X where X is not a number.
+	profileList = []seccompprofilev1alpha1.SeccompProfile{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "another-name",
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "podname-xa4b5",
+			},
+		},
+	}
+	podName = "podname"
+	expectedNextName = "podname"
+	nextName = getSeccompProfileNextName(profileList, podName)
+	if nextName != expectedNextName {
+		t.Fatalf("Invalid computation of next name '%s'. Expecting '%s' from the given profile list",
+			nextName, expectedNextName)
+	}
+
+	// Another case where function must ignore the profiles with
+	// syntax podname-X where X is not a number.
+	profileList = []seccompprofilev1alpha1.SeccompProfile{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "another-name",
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "podname-xa4b5",
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "podname-5",
+			},
+		},
+	}
+	podName = "podname"
+	expectedNextName = "podname-6"
+	nextName = getSeccompProfileNextName(profileList, podName)
+	if nextName != expectedNextName {
+		t.Fatalf("Invalid computation of next name '%s'. Expecting '%s' from the given profile list",
+			nextName, expectedNextName)
+	}
+}

--- a/pkg/gadgets/seccomp/syscalls_none.go
+++ b/pkg/gadgets/seccomp/syscalls_none.go
@@ -25,7 +25,8 @@ func syscallArrToLinuxSeccomp(v []byte) *specs.LinuxSeccomp {
 	panic("Not implemented")
 	return nil
 }
-func syscallArrToSeccompPolicy(namespace, name, generateName string, v []byte) *seccompprofilev1alpha1.SeccompProfile {
+
+func syscallArrToSeccompPolicy(profileName *SeccompProfileNsName, v []byte) *seccompprofilev1alpha1.SeccompProfile {
 	panic("Not implemented")
 	return nil
 }


### PR DESCRIPTION
# Align namespace and naming convention of the generated profiles

This PR aligns the name of the profiles generated on-demand and at pod termination. Now, both generations use the following logic to name the profiles:
```golang
if traceSpecOutput != "" {
    name = Generated using traceSpecOutput as prefix, e.g myprofile-5t6g9
    if traceSpecOutput contains namespace {
        namespace = Retrieved from traceSpecOutput. Syntax: namespace/prefix-name
    } else {
        namespace = Fallback to trace's namespace
    }
} else {
    name = Use podname (or podname-X if needed) as name, e.g mypod, mypod-2, ...
    namespace = Fallback to trace's namespace
}
```

Why do we generate names in some cases and use a counter in others?
- Generated names are used when we are generating profiles for different pods thus it would have no sense to use a counter in this case.
- The counter is used because the user is probably performing multiple experiments on the same pod. With the counter we trying to make the user's life easier by enumerating increasingly the profiles. Using generated names will force the user to check the `creationTimestamp` to verify the order profiles were created.


Fixes #377.

### Possible future improvements
- An annotation specifying that the policy was generated on-demand or at-termination could be useful?
- We need to improve the error handling when policies are generated at pod termination. Currently, the gadget is reporting an `operationWarning` because there is no pod that matches the requested filter. However, it already generated the policy thus the message is not appropriate. This improvement will be done in another PR: https://github.com/kinvolk/inspektor-gadget/pull/422 
- Instead of just saying `Successfully created seccomp profile`, we could use the `global-trace-id` to print the list of all the policies generated (on-demand and at-termination) when the user executes `kubectl gadget seccomp-policy stop <id>`.

## Testing done

### Before this PR:
The on-demand policy uses the `spec.output` field as the name: `seccomp-demo/hello-profile`. On the other hand, the at-termination policy is created in the trace's namespace `gadget` and with the trace's name as prefix `seccomp-mcnw4-pnpdz`.

#### Seccomp Profiles generated on-demand:
```
# Start monitoring
$ ./kubectl-gadget seccomp-advisor start -m seccomp-profile --seccomp-profile-name seccomp-demo/hello-profile -n seccomp-demo -p hello-python
0IND69Fe1icVd2I5

# Create workload and interact with it

# Generate the profile
$ ./kubectl-gadget seccomp-advisor stop 0IND69Fe1icVd2I5
Successfully created seccomp profile "seccomp-demo/hello-profile"!

# Check the profile
$ kubectl get seccompprofile -A
NAMESPACE       NAME             STATUS       AGE
seccomp-demo    hello-profile    Installed    11s
```

#### Seccomp Profiles generated at pod termination:
```
$ ./kubectl-gadget seccomp-advisor start -m seccomp-profile --seccomp-profile-name seccomp-demo/hello-profile -n seccomp-demo -p hello-python
DT8HSvzpYJvw3tAp

# Create workload and interact with it

# Terminate involved pod
$ kubectl delete pod/hello-python -n seccomp-demo
pod "hello-python" deleted

# Check the profile
$ kubectl get seccompprofile -A
NAMESPACE    NAME                   STATUS       AGE
gadget       seccomp-mcnw4-pnpdz    Installed    10s

# Stop monitoring (To be improved)
$ ./kubectl-gadget seccomp-advisor stop DT8HSvzpYJvw3tAp
Failed to run the gadget on all nodes: Pod seccomp-demo/hello-python not found
Error: Failed to run the gadget on all nodes: None of them succeeded
```

### After this PR:
On-demand and at-termination policies are named using the `spec.output` as namespace and prefix name: `seccomp-demo/hello-profile-XXXX`. If `spec.output` is not specified through option `--profix-prefix-name`, the policy is created in the trace's namespace and with the same pod name.

#### Seccomp Profiles generated on-demand using `--profix-prefix-name`:

```
# Start monitoring
$ ./kubectl-gadget seccomp-advisor start -m seccomp-profile --profile-prefix-name seccomp-demo/hello-profile -n seccomp-demo -p hello-python
TnvvRHRtuHBPcBZV

# Create workload and interact with it

# Generate the profile
$ ./kubectl-gadget seccomp-advisor stop TnvvRHRtuHBPcBZV
Successfully created seccomp profile

# Check the profile
$ kubectl get seccompprofile -A
NAMESPACE       NAME                   STATUS       AGE
seccomp-demo    hello-profile-rjxfb    Installed    73s
```

#### Seccomp Profiles generated on-demand _without_ using `--profix-prefix-name`:
```
# Start monitoring
$ ./kubectl-gadget seccomp-advisor start -m seccomp-profile -n seccomp-demo -p hello-python
1vQVu5FpnGpGCfpQ

# Create workload and interact with it

# Generate the profile
$ ./kubectl-gadget seccomp-advisor stop 1vQVu5FpnGpGCfpQ
Successfully created seccomp profile

# Check the profile
$ kubectl get seccompprofile -A
NAMESPACE    NAME             STATUS       AGE
gadget       hello-python    Installed    3s
```

#### Seccomp Profiles generated at pod termination using `--profix-prefix-name`:

```
$ ./kubectl-gadget seccomp-advisor start -m seccomp-profile --profile-prefix-name seccomp-demo/hello-profile -n seccomp-demo -p hello-python
D6f5HTV6BXwFGPMa

# Create workload and interact with it

# Terminate involved pod
$ kubectl delete pod/hello-python -n seccomp-demo
pod "hello-python" deleted

# Check the profile
$ kubectl get seccompprofile -A
NAMESPACE       NAME                   STATUS       AGE
seccomp-demo    hello-profile-vkzpm    Installed    11s

# Stop monitoring (To be improved)
$ ./kubectl-gadget seccomp-advisor stop D6f5HTV6BXwFGPMa
Failed to run the gadget on all nodes: Pod seccomp-demo/hello-python not found
Error: Failed to run the gadget on all nodes: None of them succeeded
```

#### Seccomp Profiles generated at pod termination _without_ using `--profix-prefix-name`:

```
$ ./kubectl-gadget seccomp-advisor start -m seccomp-profile --profile-prefix-name seccomp-demo/hello-profile -n seccomp-demo -p hello-python
eO3d02KjLe7r0bXb

# Create workload and interact with it

# Terminate involved pod
$ kubectl delete pod/hello-python -n seccomp-demo
pod "hello-python" deleted

# Check the profile
$ kubectl get seccompprofile -A
NAMESPACE    NAME             STATUS       AGE
gadget       hello-python    Installed    11s

# Stop monitoring (To be improved)
$ ./kubectl-gadget seccomp-advisor stop eO3d02KjLe7r0bXb
Failed to run the gadget on all nodes: Pod seccomp-demo/hello-python not found
Error: Failed to run the gadget on all nodes: None of them succeeded
```