### PR TITLE
seccomp: Record runc syscalls only after the profile are installed

### DIFF
--- a/docs/examples/seccomp/confined.yaml
+++ b/docs/examples/seccomp/confined.yaml
@@ -19,8 +19,6 @@ spec:
     volumeMounts:
     - name: app-script
       mountPath: /app/
-    securityContext:
-      allowPrivilegeEscalation: false
   volumes:
   - name: app-script
     configMap:

--- a/docs/examples/seccomp/unconfined.yaml
+++ b/docs/examples/seccomp/unconfined.yaml
@@ -18,8 +18,6 @@ spec:
     volumeMounts:
     - name: app-script
       mountPath: /app/
-    securityContext:
-      allowPrivilegeEscalation: false
   volumes:
   - name: app-script
     configMap:

--- a/docs/guides/seccomp.md
+++ b/docs/guides/seccomp.md
@@ -315,7 +315,7 @@ spec:
   securityContext:
     seccompProfile:
       type: Localhost
-      localhostProfile: operator/seccomp-demo/hello-profile
+      localhostProfile: operator/seccomp-demo/hello-profile.json
 ```
 
 We have this change already applied in the `confined.yaml` file. To apply
@@ -349,10 +349,8 @@ pod:
 
 ```bash
 $ kubectl exec -it -n seccomp-demo hello-python -- /bin/bash
-OCI runtime exec failed: exec failed: container_linux.go:380: starting
-container process caused: exec: "/bin/bash": stat /bin/bash: operation not
-permitted: unknown
-command terminated with exit code 126
+bash: initialize_job_control: getpgrp failed: Success
+command terminated with exit code 1
 ```
 
 We see that the seccomp profile is preventing this execution, and it will
@@ -375,13 +373,7 @@ namespace "seccomp-demo" deleted
    correctly. You can also look at the `Status` field of the `Trace` for
    other possible errors.
 
-2. If applying the policy causes the pod not to start, check that you're
-   setting `AllowPrivilegeEscalation=false` in the container's security
-   context, as having privilege escalation enabled doesn't work well with
-   seccomp. See [#267](https://github.com/kinvolk/inspektor-gadget/issues/267)
-   for more information.
-
-3. If the confined pod fails to start with this error:
+2. If the confined pod fails to start with this error:
    `cannot load seccomp profile "/var/lib/kubelet/seccomp/operator/seccomp-demo/hello-profile.json"`,
    check that the operator is correctly installed and all pods involved are
    running.

--- a/pkg/gadgets/seccomp/tracer/bpf/seccomp.c
+++ b/pkg/gadgets/seccomp/tracer/bpf/seccomp.c
@@ -9,21 +9,46 @@
 #include <bpf/bpf_helpers.h>
 #include <bpf/bpf_core_read.h>
 #include <bpf/bpf_tracing.h>
+#include <bpf/bpf_tracing.h>
 
 #include "seccomp-common.h"
 
 #define TASK_COMM_LEN 16
 #define TS_COMPAT 0x0002
 
+// prctl syscall number from
+// https://github.com/seccomp/libseccomp/blob/abad8a8f41fc13efbb95fc1ccaa3e181342bade7/src/syscalls.csv#L265
+#ifndef __NR_prctl
+# if defined(bpf_target_x86)
+#  define __NR_prctl 157
+# elif defined(bpf_target_arm64)
+#  define __NR_prctl 167
+# else
+#  error "Unsupported architecture"
+# endif
+#endif
+
+// prclt syscall parameters from
+// https://github.com/torvalds/linux/blob/5147da902e0dd162c6254a61e4c57f21b60a9b1c/include/uapi/linux/prctl.h#L10
+// https://github.com/torvalds/linux/blob/5147da902e0dd162c6254a61e4c57f21b60a9b1c/include/uapi/linux/prctl.h#L175
+#ifndef PR_GET_PDEATHSIG
+# define PR_GET_PDEATHSIG 2
+#endif
+#ifndef PR_SET_NO_NEW_PRIVS
+# define PR_SET_NO_NEW_PRIVS 38
+#endif
+
 // Seccomp syscall number from
 // https://github.com/torvalds/linux/blob/v5.12/tools/testing/selftests/seccomp/seccomp_bpf.c#L115
 // Only x86_64 is supported for now.
 #ifndef __NR_seccomp
-#define __NR_seccomp 317
-#endif
-
-#ifndef SECCOMP_SET_MODE_FILTER
-#define SECCOMP_SET_MODE_FILTER         1
+# if defined(bpf_target_x86)
+#  define __NR_seccomp 317
+# elif defined(bpf_target_arm64)
+#  define __NR_seccomp 277
+# else
+#  error "Unsupported architecture"
+# endif
 #endif
 
 struct {
@@ -77,21 +102,34 @@ int tracepoint__raw_syscalls__sys_enter(struct bpf_raw_tracepoint_args *ctx)
 			return 0;
 	}
 
+	// If it is runc, we want to record only the syscalls executed after the
+	// seccomp profile is actually installed. However, if we are running the
+	// seccomp-advisor gadget, it is very probably that the pod does not have
+	// a seccomp profile yet, so seccomp() will not be called. Therefore, we
+	// decide to start recording from the prctl(PR_GET_PDEATHSIG) call on. It
+	// is a safe place right before all the seccomp() calls that will be always
+	// executed during the runc initialisation:
+	// https://github.com/opencontainers/runc/blob/8b4a8f093d0dbdf45100597f710d16777845ee83/libcontainer/standard_init_linux.go#L148
 	if (is_runc) {
-		/* libseccomp makes invalid calls to seccomp() to determine the api
-		 * level. Ignore those. */
-		if (id == __NR_seccomp &&
-		PT_REGS_PARM1(&regs) == SECCOMP_SET_MODE_FILTER &&
-		PT_REGS_PARM3(&regs) != 0) {
-			/* Mark this container: seccomp has been called. */
-			syscall_bitmap[SYSCALLS_COUNT] = 1;
+		if (syscall_bitmap[SYSCALLS_COUNT] == 0) {
+			if (id == __NR_prctl && PT_REGS_PARM1(&regs) == PR_GET_PDEATHSIG) {
+				// Start recording the runc syscalls from now on.
+				syscall_bitmap[SYSCALLS_COUNT] = 1;
+			}
+
 			return 0;
 		}
-		/* Don't register syscalls performed by runc before the seccomp policy is actually installed */
-		if (syscall_bitmap[SYSCALLS_COUNT] == 0)
+
+		// Record all the runc syscalls after prctl(PR_GET_PDEATHSIG) except
+		// for seccomp() and prctl(PR_SET_NO_NEW_PRIVS) because we know they
+		// are executed before the seccomp profile is installed.
+		if ((id == __NR_prctl && PT_REGS_PARM1(&regs) == PR_SET_NO_NEW_PRIVS) ||
+				(id == __NR_seccomp)) {
 			return 0;
+		}
 	}
 
+	// Record the syscall
 	syscall_bitmap[id] = 0x01;
 
 	return 0;


### PR DESCRIPTION
# Record runc syscalls only after the profile are installed

As discussed in issue https://github.com/kinvolk/inspektor-gadget/issues/267, the policies generated by the seccomp-advisor gadget are not enough to get the pod to run successfully. As a workaround, it is necessary to set `allowPrivilegeEscalation` to `false` to make them work. However, it does not always work.

This PR fixes a bug in the way we collect the syscalls performed by `runc`. It was previously relying on the fact that the `seccomp()` will be called but it is not always true. Actually, it is false in most cases. 

Consider we want to record only the syscalls executed by `runc` after the seccomp profile is actually installed. However, if we are running the seccomp-advisor gadget, it's very probably that the pod does not have a seccomp profile yet, so `seccomp()` will not be called. Therefore, we decide to start recording from the `prctl(PR_GET_PDEATHSIG)` call instead of the `seccomp()` call. It is a safe place right before all the `seccomp()` calls that will be always executed during the `runc` initialisation. See [the `runc` initialisation function](https://github.com/opencontainers/runc/blob/8b4a8f093d0dbdf45100597f710d16777845ee83/libcontainer/standard_init_linux.go#L148).

Notice the syscalls performed by `runc` during the initialisation are not always the same. They depend on the pod configuration, for instance, `allowPrivilegeEscalation` (which implies `no_new_privileges`) and the pod capabilities (e.g. `CAP_SYS_ADMIN`).

## How to use

Generate and apply a policy without setting `allowPrivilegeEscalation=false`. 

## Further possible improvements
If the involved pod has a seccomp profile already applied, we could rely on the `seccomp()` call as a signal to start recording. In the code, it implies removing the syscalls recorded before the `seccomp()` call and keeps `syscall_bitmap[SYSCALLS_COUNT] = 1`.

## Testing done

```
# Run gadget
$ kubectl gadget seccomp-advisor start -m seccomp-profile --seccomp-profile-name seccomp-demo/hello-profile -p hello-python -n seccomp-demo
BqDHtD2fDzz9Gxes

# Deploy unconfined workload
$ kubectl apply -f docs/examples/seccomp/unconfined.yaml
pod/hello-python created
$ kubectl wait -n seccomp-demo --for=condition=ready pod/hello-python
pod/hello-python condition met

# Interact with workload
$ kubectl port-forward service/hello-python-service -n seccomp-demo 8080:6000 &
[3] 80963
Forwarding from 127.0.0.1:8080 -> 80
Forwarding from [::1]:8080 -> 80
$ curl localhost:8080
Handling connection for 8080
Hello World!

# Terminate pod to generate profile
$ kubectl delete -f docs/examples/seccomp/unconfined.yaml
pod "hello-python" deleted
$ kubectl get seccompprofile -n gadget
NAME                  STATUS      AGE
seccomp-cs8dk-glkcs   Installed   7s

# Stop gadget (Error management to be improved)
$ kubectl gadget seccomp-advisor stop BqDHtD2fDzz9Gxes
Failed to run the gadget on all nodes: Pod seccomp-demo/hello-python not found
Error: Failed to run the gadget on all nodes: None of them succeeded

# Edit securityContext to use the just generated profile: seccomp-cs8dk-glkcs
$ vi docs/examples/seccomp/confined.yaml

# Deploy confined workload
$ kubectl apply -f docs/examples/seccomp/confined.yaml
pod/hello-python created
$ kubectl get pods -n seccomp-demo
NAME           READY   STATUS    RESTARTS   AGE
hello-python   1/1     Running   0          20s

# Interact with workload to ensure it is working properly
$ kubectl port-forward service/hello-python-service -n seccomp-demo 8080:6000 &
[4] 81448
Forwarding from 127.0.0.1:8080 -> 80
Forwarding from [::1]:8080 -> 80
$ curl localhost:8080
Handling connection for 8080
Hello World!

# Verify that other system calls are not allowed
$ kubectl exec -it -n seccomp-demo hello-python -- /bin/bash
bash: initialize_job_control: getpgrp failed: Success
command terminated with exit code 1
```
