### PR TITLE
Build inspektor-gadget docker image for arm in our CI

### DIFF
--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -84,6 +84,10 @@ jobs:
         make manifests generate generate-documentation
         git diff --exit-code HEAD --
 
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v1
+      if: github.ref == 'refs/heads/francis/arm'
+
     - name: Set up Docker Buildx
       id: buildx
       uses: docker/setup-buildx-action@v1
@@ -103,8 +107,26 @@ jobs:
         username: ${{ secrets.CONTAINER_REGISTRY_USERNAME }}
         password: ${{ secrets.CONTAINER_REGISTRY_PASSWORD }}
 
+    - name: Cross build gadget container for amd64 and arm64.
+      uses: docker/build-push-action@v2
+      # We cross build only on release because it takes a lot of time.
+      if: github.ref == 'refs/heads/francis/arm'
+      with:
+        context: .
+        file: gadget.Dockerfile
+        build-args: |
+          ENABLE_BTFGEN=true
+        # TODO: how to avoid pushing a container before running integration tests
+        push: true
+        tags: ${{ secrets.CONTAINER_REPO }}:${{ env.IMAGE_TAG }}
+        cache-from: type=local,src=/tmp/.buildx-cache
+        cache-to: type=local,dest=/tmp/.buildx-cache-new
+        # For the moment, we only support these two platforms.
+        platforms: linux/amd64,linux/arm64
+
     - name: Build gadget container
       uses: docker/build-push-action@v2
+      if: github.ref != 'refs/heads/francis/arm'
       with:
         context: .
         file: gadget.Dockerfile

--- a/gadget.Dockerfile
+++ b/gadget.Dockerfile
@@ -2,7 +2,7 @@
 
 # BCC built from the gadget branch in the kinvolk/bcc fork.
 # See BCC section in docs/CONTRIBUTING.md for further details.
-ARG BCC="quay.io/kinvolk/bcc:520591c0fc491862c12337609ff9cbc9375d4de3-focal-release"
+ARG BCC="quay.io/kinvolk/bcc:302235e016b9a5255037c9075d28478557c0fc16-focal-release"
 ARG OS_TAG=20.04
 
 FROM ${BCC} as bcc
@@ -15,11 +15,13 @@ RUN set -ex; \
 	export DEBIAN_FRONTEND=noninteractive; \
 	apt-get update && \
 	apt-get install -y gcc make golang-1.16 ca-certificates git clang \
-		software-properties-common libseccomp-dev && \
-	add-apt-repository -y ppa:tuxinvader/kernel-build-tools && \
-	apt-get update && \
-	apt-get install -y libbpf-dev && \
+		software-properties-common libseccomp-dev libelf-dev pkg-config && \
 	ln -s /usr/lib/go-1.16/bin/go /bin/go
+
+# Install libbpf-dev from source to be cross-platform.
+RUN git clone https://github.com/libbpf/libbpf.git && \
+	cd libbpf/src && \
+	make install
 
 # Download BTFHub files
 COPY ./tools /btf-tools
@@ -53,7 +55,7 @@ RUN set -ex; \
 # - https://github.com/kinvolk/traceloop/actions
 # - https://hub.docker.com/r/kinvolk/traceloop/tags
 
-FROM docker.io/kinvolk/traceloop:20211109004128958575 as traceloop
+FROM docker.io/kinvolk/traceloop:2059b729c0ac8aa79016dacb06fbdaa1867c1446 as traceloop
 
 # Main gadget image
 


### PR DESCRIPTION
Hi.

This PR cross-builds `inspektor-gadget` docker image for arm64 architecture.
I needed to add a step inside our Dockerfile to build `libbpf-dev` from source because it does not exist a package version of this library for arm64.

The build will only be triggered when pushing to main branch.
The build was already tested and arm64 image were successfully generated:
https://hub.docker.com/layers/kinvolk/gadget/francis-arm/images/sha256-ce3704558e2f42f19b21356a8d0d1e53f2386d9f68656808c5ecda3887d9189c?context=explore

I am currently testing it and it seems a majority of our gadget work:

```
```

TODO:
[ ] Wait for traceloop/66 to be merged and adapt Dockerfile.
[ ] Wait for bcc/16 to be merged and adapt Dockerfile.
[ ] Change `ref/heads` to main.

Best regards.