### PR TITLE
Add undeploy cmd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -161,10 +161,8 @@ minikube-install: gadget-container kubectl-gadget
 	# versions. And new versions of minikube don't support all eBPF
 	# features. So we have to keep "docker-save|docker-load" for now.
 	docker save $(CONTAINER_REPO):$(IMAGE_TAG) $(PV) | (eval $(shell $(MINIKUBE) -p minikube docker-env | grep =) && docker load)
-	# Delete traces CRD first: the gadget DaemonSet needs to be running
-	# because of Finalizers.
-	kubectl delete crd traces.gadget.kinvolk.io || true
-	./kubectl-gadget deploy | kubectl delete -f - || true
+	# Remove all resources created by Inspektor Gadget.
+	./kubectl-gadget undeploy || true
 	time kubectl wait --for=delete namespace gadget 2>/dev/null || true
 	time kubectl wait --for=delete daemonset -n kube-system gadget 2>/dev/null || true
 	./kubectl-gadget deploy --hook-mode=fanotify \

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Available Commands:
   biotop            Trace block device I/O
   capabilities      Suggest Security Capabilities for securityContext
   completion        generate the autocompletion script for the specified shell
-  deploy            Deploy Inspektor Gadget on the worker nodes
+  deploy            Deploy Inspektor Gadget on the cluster
   dns               Trace DNS requests
   execsnoop         Trace new processes
   help              Help about any command
@@ -46,11 +46,13 @@ Available Commands:
   opensnoop         Trace open() system calls
   process-collector Gather information about running processes
   profile           Profile CPU usage by sampling stack traces
+  seccomp-advisor   Generate seccomp policies based on recorded syscalls activity
   socket-collector  Gather information about network sockets
   tcpconnect        Trace TCP connect() system calls
   tcptop            Show the TCP traffic in a pod
   tcptracer         Trace tcp connect, accept and close
   traceloop         Get strace-like logs of a pod from the past
+  undeploy          Undeploy Inspektor Gadget from cluster
   version           Show version
 
 ...

--- a/cmd/kubectl-gadget/deploy.go
+++ b/cmd/kubectl-gadget/deploy.go
@@ -26,7 +26,7 @@ import (
 
 var deployCmd = &cobra.Command{
 	Use:   "deploy",
-	Short: "Deploy Inspektor Gadget on the worker nodes",
+	Short: "Deploy Inspektor Gadget on the cluster",
 	RunE:  runDeploy,
 }
 

--- a/cmd/kubectl-gadget/undeploy.go
+++ b/cmd/kubectl-gadget/undeploy.go
@@ -1,0 +1,163 @@
+// Copyright 2021 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/kinvolk/inspektor-gadget/cmd/kubectl-gadget/utils"
+	"github.com/kinvolk/inspektor-gadget/pkg/k8sutil"
+	"github.com/spf13/cobra"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+)
+
+var undeployCmd = &cobra.Command{
+	Use:          "undeploy",
+	Short:        "Undeploy Inspektor Gadget from cluster",
+	RunE:         runUndeploy,
+	SilenceUsage: true,
+}
+
+func init() {
+	rootCmd.AddCommand(undeployCmd)
+}
+
+func runUndeploy(cmd *cobra.Command, args []string) error {
+	traceClient, err := utils.GetTraceClient()
+	if err != nil {
+		return fmt.Errorf("failed to get trace client: %w", err)
+	}
+
+	k8sClient, err := k8sutil.NewClientsetFromConfigFlags(utils.KubernetesConfigFlags)
+	if err != nil {
+		return fmt.Errorf("Error setting up Kubernetes client: %w", err)
+	}
+
+	config, err := utils.KubernetesConfigFlags.ToRESTConfig()
+	if err != nil {
+		return fmt.Errorf("Error creating RESTConfig: %w", err)
+	}
+
+	crdClient, err := clientset.NewForConfig(config)
+	if err != nil {
+		return fmt.Errorf("Error setting up CRD client: %w", err)
+	}
+
+	errs := []string{}
+
+	// 1. remove traces
+
+	// We need to wait a bit after removing the traces and before
+	// removing the daemon set to give the trace controller an
+	// opportunity to remove it. If there are still traces after
+	// waiting, we patch them removing the finalizers to let Kubernetes
+	// remove them.
+	// ref https://github.com/kubernetes/kubernetes/issues/60538#issuecomment-369099998
+	delay := 10
+	i := 0
+	n := 7
+
+again:
+	err = traceClient.GadgetV1alpha1().Traces("gadget").DeleteCollection(
+		context.TODO(), metav1.DeleteOptions{}, metav1.ListOptions{},
+	)
+	if err != nil {
+		errs = append(errs, fmt.Sprintf("failed to remove the traces: %s", err))
+	}
+
+	time.Sleep(time.Duration(delay) * time.Millisecond)
+
+	traces, err := traceClient.GadgetV1alpha1().Traces("gadget").List(
+		context.TODO(), metav1.ListOptions{},
+	)
+	if err == nil && len(traces.Items) != 0 {
+		i++
+		if i < n {
+			delay = 2 * delay
+			goto again
+		}
+
+		// It's taking too long to delete the traces. Remove the
+		// finalizers and let k8s remove them immediately.
+		for _, trace := range traces.Items {
+			data := []byte("{\"metadata\":{\"finalizers\":[]}}")
+			_, err := traceClient.GadgetV1alpha1().Traces("gadget").Patch(
+				context.TODO(), trace.Name, types.MergePatchType, data, metav1.PatchOptions{},
+			)
+			if err != nil {
+				errs = append(
+					errs, fmt.Sprintf("failed to patch trace %q: %s", trace.Name, err),
+				)
+			}
+		}
+	}
+
+	// 2. remove crd
+	err = crdClient.ApiextensionsV1().CustomResourceDefinitions().Delete(
+		context.TODO(), "traces.gadget.kinvolk.io", metav1.DeleteOptions{},
+	)
+	if err != nil {
+		errs = append(
+			errs, fmt.Sprintf("failed to remove \"traces.gadget.kinvolk.io\" CRD: %s", err),
+		)
+	}
+
+	// 3. gadget daemon set
+	err = k8sClient.AppsV1().DaemonSets("kube-system").Delete(
+		context.TODO(), "gadget", metav1.DeleteOptions{},
+	)
+	if err != nil {
+		errs = append(errs, fmt.Sprintf("failed to remove \"gadget\" daemonset: %s", err))
+	}
+
+	// 4. gadget service account
+	err = k8sClient.CoreV1().ServiceAccounts("kube-system").Delete(
+		context.TODO(), "gadget", metav1.DeleteOptions{},
+	)
+	if err != nil {
+		errs = append(errs, fmt.Sprintf("failed to remove \"gadget\" service account: %s", err))
+	}
+
+	// 5. gadget cluster role binding
+	err = k8sClient.RbacV1().ClusterRoleBindings().Delete(
+		context.TODO(), "gadget", metav1.DeleteOptions{},
+	)
+	if err != nil {
+		errs = append(
+			errs, fmt.Sprintf("failed to remove \"gadget\" cluster role bindings: %s", err),
+		)
+	}
+
+	// 6. gadget namespace
+	err = k8sClient.CoreV1().Namespaces().Delete(
+		context.TODO(), "gadget", metav1.DeleteOptions{},
+	)
+	if err != nil {
+		errs = append(errs, fmt.Sprintf("failed to remove \"gadget\" namespace: %s", err))
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf("error undeploying IG:\n%s", strings.Join(errs, "\n"))
+	}
+
+	return nil
+}

--- a/cmd/kubectl-gadget/utils/trace.go
+++ b/cmd/kubectl-gadget/utils/trace.go
@@ -151,6 +151,10 @@ func deleteTraces(traceClient *clientset.Clientset, traceID string) {
 	}
 }
 
+func GetTraceClient() (*clientset.Clientset, error) {
+	return getTraceClient()
+}
+
 func getTraceClient() (*clientset.Clientset, error) {
 	config, err := KubernetesConfigFlags.ToRESTConfig()
 	if err != nil {

--- a/docs/install.md
+++ b/docs/install.md
@@ -124,3 +124,11 @@ $ minikube start --driver=docker
 # Deploy Inspektor Gadget in the cluster as described above
 ```
 
+## Uninstalling from the cluster
+
+The following command will remove all the resources created by Inspektor
+Gadget from the cluster:
+
+```
+$ kubectl gadget undeploy
+```

--- a/integration/command.go
+++ b/integration/command.go
@@ -104,10 +104,9 @@ var cleanupTestNamespace *command = &command{
 }
 
 var cleanupInspektorGadget *command = &command{
-	name:           "cleanup gadget deployment",
-	cmd:            "$KUBECTL_GADGET deploy $GADGET_IMAGE_FLAG | kubectl delete --wait=false -f -",
-	expectedRegexp: "\"gadget\" deleted",
-	cleanup:        true,
+	name:    "cleanup gadget deployment",
+	cmd:     "$KUBECTL_GADGET undeploy",
+	cleanup: true,
 }
 
 // run runs the command on the given as parameter test.


### PR DESCRIPTION
Implement undeploy command to fix cases where the deletion gets stuck because there are traces still running. 

Fixes https://github.com/kinvolk/inspektor-gadget/issues/388 
Ref https://github.com/kinvolk/inspektor-gadget/issues/123

TODO:
- [x] Update once is https://github.com/kinvolk/inspektor-gadget/pull/429 merged. 

TODO next PRs:
- [ ] Improvements for the deploy command (https://github.com/kinvolk/inspektor-gadget/issues/123) are future work.