### PR TITLE
cmd: Fix return code when SIGINT

### DIFF
--- a/cmd/kubectl-gadget/utils/trace.go
+++ b/cmd/kubectl-gadget/utils/trace.go
@@ -573,8 +573,11 @@ func sigHandler(traceID *string) {
 		if *traceID != "" {
 			DeleteTrace(*traceID)
 		}
-
-		os.Exit(1)
+		if sig == syscall.SIGINT {
+			os.Exit(0)
+		} else {
+			os.Exit(1)
+		}
 	}()
 }
 


### PR DESCRIPTION
The return code when the user presses Ctrl + C should be 0 instead
of 1.

TODO: 
- [ ] I'm not sure what the return code for other signals should be. I think 1 is fine. 