### PR TITLE
Add inode number to `socket-collector`

### DIFF
--- a/docs/guides/socket-collector.md
+++ b/docs/guides/socket-collector.md
@@ -53,6 +53,14 @@ NODE       NAMESPACE               POD          PROTOCOL    LOCAL           REMO
 my-node    test-socketcollector    nginx-app    TCP         0.0.0.0:8080    0.0.0.0:0    LISTEN
 ```
 
+To get extended information, like the socket inode number, just the `-e` or `--extend` flag:
+
+```bash
+$ kubectl gadget socket-collector -n test-socketcollector -e
+NODE       NAMESPACE               POD          PROTOCOL    LOCAL           REMOTE       STATUS         INODE
+my-node    test-socketcollector    nginx-app    TCP         0.0.0.0:8080    0.0.0.0:0    LISTEN         22866
+```
+
 We can also get the information in JSON format, by passing the `-o json` flag.
 Just take into account that IP address and port are displayed separated with this format:
 

--- a/pkg/gadgets/socket-collector/tracer/bpf/socket-common.h
+++ b/pkg/gadgets/socket-collector/tracer/bpf/socket-common.h
@@ -59,7 +59,7 @@ static unsigned long sock_i_ino(const struct sock *sk)
 static inline void socket_bpf_seq_print(struct seq_file *seq,
                 const char* protocol, const __be32 src,
                 const __u16 srcp, const __be32 dest,
-                const __u16 destp, const unsigned char state)
+                const __u16 destp, const unsigned char state, long ino)
 {
     /*
      * Notice that client side program is expecting socket information exactly
@@ -68,10 +68,11 @@ static inline void socket_bpf_seq_print(struct seq_file *seq,
      * protocol: "TCP" or "UDP"
      * IP addresses and ports: Hexadecimal in host-byte order.
      * state: Hexadecimal of https://github.com/torvalds/linux/blob/v5.13/include/net/tcp_states.h#L12-L24
+     * ino: unsigned long.
      */
-    BPF_SEQ_PRINTF(seq, "%s %08X %04X %08X %04X %02X\n",
+    BPF_SEQ_PRINTF(seq, "%s %08X %04X %08X %04X %02X %lu\n",
         protocol, bpf_ntohl(src), bpf_ntohs(srcp),
-        bpf_ntohl(dest), bpf_ntohs(destp), state);
+        bpf_ntohl(dest), bpf_ntohs(destp), state, ino);
 }
 
 #endif /* __GADGET_SOCKET_COMMON_H__ */

--- a/pkg/gadgets/socket-collector/tracer/bpf/socket-common.h
+++ b/pkg/gadgets/socket-collector/tracer/bpf/socket-common.h
@@ -29,6 +29,29 @@
 #define tw_rcv_saddr    __tw_common.skc_rcv_saddr
 #define tw_dport        __tw_common.skc_dport
 
+/**
+ * sock_i_ino - Returns the inode identifier associated to a socket.
+ * @sk: The socket whom inode identifier will be returned.
+ *
+ * Returns the inode identifier corresponding to the given as parameter socket.
+ *
+ * Returns:
+ * * The inode identifier associated to the socket.
+ */
+static unsigned long sock_i_ino(const struct sock *sk)
+{
+	const struct socket *sk_socket = sk->sk_socket;
+	const struct inode *inode;
+	unsigned long ino;
+
+	if (!sk_socket)
+		return 0;
+
+	inode = &container_of(sk_socket, struct socket_alloc, socket)->vfs_inode;
+	bpf_probe_read_kernel(&ino, sizeof(ino), &inode->i_ino);
+	return ino;
+}
+
 /*
  * This function receives arguments as they are stored
  * in the different socket structure, i.e. network-byte order.

--- a/pkg/gadgets/socket-collector/tracer/bpf/udp4-collector.c
+++ b/pkg/gadgets/socket-collector/tracer/bpf/udp4-collector.c
@@ -44,7 +44,7 @@ int dump_udp4(struct bpf_iter__udp *ctx)
 
 	socket_bpf_seq_print(seq, proto, inet->inet_rcv_saddr,
 		inet->inet_sport, inet->inet_daddr,
-		inet->inet_dport, inet->sk.sk_state);
+		inet->inet_dport, inet->sk.sk_state, sock_i_ino(&inet->sk));
 
 	return 0;
 }

--- a/pkg/gadgets/socket-collector/tracer/tracer.go
+++ b/pkg/gadgets/socket-collector/tracer/tracer.go
@@ -140,12 +140,13 @@ func RunCollector(pid uint32, podname, namespace, node string, proto socketcolle
 				var destp, srcp uint16
 				var dest, src uint32
 				var hexStatus uint8
+				var inodeNumber uint64
 
 				// Format from socket_bpf_seq_print() in bpf/socket_common.h
 				// IP addresses and ports are in host-byte order
-				len, err := fmt.Sscanf(scanner.Text(), "%s %08X %04X %08X %04X %02X",
-					&proto, &src, &srcp, &dest, &destp, &hexStatus)
-				if err != nil || len != 6 {
+				len, err := fmt.Sscanf(scanner.Text(), "%s %08X %04X %08X %04X %02X %d",
+					&proto, &src, &srcp, &dest, &destp, &hexStatus, &inodeNumber)
+				if err != nil || len != 7 {
 					return fmt.Errorf("failed to parse sockets information: %w", err)
 				}
 
@@ -166,6 +167,7 @@ func RunCollector(pid uint32, podname, namespace, node string, proto socketcolle
 					RemoteAddress: parseIPv4(dest),
 					RemotePort:    destp,
 					Status:        status,
+					InodeNumber:   inodeNumber,
 				})
 			}
 

--- a/pkg/gadgets/socket-collector/types/socket-collector.go
+++ b/pkg/gadgets/socket-collector/types/socket-collector.go
@@ -45,6 +45,7 @@ type Event struct {
 	RemoteAddress string `json:"remote_address"`
 	RemotePort    uint16 `json:"remote_port"`
 	Status        string `json:"status"`
+	InodeNumber   uint64 `json:"inode_number"`
 }
 
 func ParseProtocol(protocol string) (Proto, error) {


### PR DESCRIPTION
Hi.


In this PR, I added inode number to `socket-collector` for TCP and UPD socket:

```bash
$ ./kubectl-gadget socket-collector -n kube-system | head
NODE        NAMESPACE      POD                                 PROTOCOL    LOCAL                   REMOTE                  STATUS         INODE
minikube    kube-system    coredns-78fcd69978-ds8tc            TCP         172.17.0.2:57272         10.96.0.1:443           ESTABLISHED    49410
minikube    kube-system    coredns-78fcd69978-ds8tc            TCP         127.0.0.1:34372          127.0.0.1:8080          TIME_WAIT      0
minikube    kube-system    coredns-78fcd69978-ds8tc            TCP         127.0.0.1:34380          127.0.0.1:8080          TIME_WAIT      0
minikube    kube-system    coredns-78fcd69978-ds8tc            TCP         127.0.0.1:34384          127.0.0.1:8080          TIME_WAIT      0
minikube    kube-system    coredns-78fcd69978-ds8tc            TCP         127.0.0.1:34388          127.0.0.1:8080          TIME_WAIT      0
minikube    kube-system    coredns-78fcd69978-ds8tc            TCP         127.0.0.1:34392          127.0.0.1:8080          TIME_WAIT      0
minikube    kube-system    coredns-78fcd69978-ds8tc            TCP         127.0.0.1:34400          127.0.0.1:8080          TIME_WAIT      0
minikube    kube-system    coredns-78fcd69978-ds8tc            TCP         127.0.0.1:34406          127.0.0.1:8080          TIME_WAIT      0
minikube    kube-system    coredns-78fcd69978-ds8tc            TCP         127.0.0.1:34410          127.0.0.1:8080          TIME_WAIT      0
```

Sadly, it does not work for `tcp_timewait_sock` and `tcp_request_sock`.
Indeed, I am not sure if this `sock` have a `struct socket` and those are file backed.


Best regards.