### PR TITLE
process-collector: Refactor the gadget and add node to output.

### DIFF
--- a/cmd/kubectl-gadget/collector.go
+++ b/cmd/kubectl-gadget/collector.go
@@ -91,6 +91,7 @@ func processCollectorCmdRun(cmd *cobra.Command, args []string) {
 			KubernetesNamespace string `json:"namespace,omitempty"`
 			KubernetesPod       string `json:"pod,omitempty"`
 			KubernetesContainer string `json:"container,omitempty"`
+			KubernetesNode      string `json:"node,omitempty"`
 		}
 		allProcesses := []Process{}
 
@@ -112,6 +113,8 @@ func processCollectorCmdRun(cmd *cobra.Command, args []string) {
 		sort.Slice(allProcesses, func(i, j int) bool {
 			pi, pj := allProcesses[i], allProcesses[j]
 			switch {
+			case pi.KubernetesNode != pj.KubernetesNode:
+				return pi.KubernetesNode < pj.KubernetesNode
 			case pi.KubernetesNamespace != pj.KubernetesNamespace:
 				return pi.KubernetesNamespace < pj.KubernetesNamespace
 			case pi.KubernetesPod != pj.KubernetesPod:
@@ -151,9 +154,10 @@ func processCollectorCmdRun(cmd *cobra.Command, args []string) {
 		default:
 			w := tabwriter.NewWriter(os.Stdout, 0, 0, 4, ' ', 0)
 			if processCollectorParamThreads {
-				fmt.Fprintln(w, "NAMESPACE\tPOD\tCONTAINER\tCOMM\tTGID\tPID\t")
+				fmt.Fprintln(w, "NODE\tNAMESPACE\tPOD\tCONTAINER\tCOMM\tTGID\tPID\t")
 				for _, p := range allProcesses {
-					fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%d\t%d\t\n",
+					fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%d\t%d\t\n",
+						p.KubernetesNode,
 						p.KubernetesNamespace,
 						p.KubernetesPod,
 						p.KubernetesContainer,
@@ -163,9 +167,10 @@ func processCollectorCmdRun(cmd *cobra.Command, args []string) {
 					)
 				}
 			} else {
-				fmt.Fprintln(w, "NAMESPACE\tPOD\tCONTAINER\tCOMM\tPID\t")
+				fmt.Fprintln(w, "NODE\tNAMESPACE\tPOD\tCONTAINER\tCOMM\tPID\t")
 				for _, p := range allProcesses {
-					fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%d\t\n",
+					fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%d\t\n",
+						p.KubernetesNode,
 						p.KubernetesNamespace,
 						p.KubernetesPod,
 						p.KubernetesContainer,

--- a/pkg/gadgets/process-collector/gadget.go
+++ b/pkg/gadgets/process-collector/gadget.go
@@ -65,7 +65,7 @@ func (f *TraceFactory) Operations() map[string]gadgets.TraceOperation {
 }
 
 func (t *Trace) Collect(trace *gadgetv1alpha1.Trace) {
-	events, err := tracer.RunCollector(t.resolver, gadgets.TracePinPath(trace.ObjectMeta.Namespace, trace.ObjectMeta.Name))
+	events, err := tracer.RunCollector(t.resolver, trace.Spec.Node, gadgets.TracePinPath(trace.ObjectMeta.Namespace, trace.ObjectMeta.Name))
 	if err != nil {
 		gadgets.CleanupTraceStatus(trace)
 		trace.Status.OperationError = err.Error()

--- a/pkg/gadgets/process-collector/gadget.go
+++ b/pkg/gadgets/process-collector/gadget.go
@@ -15,6 +15,9 @@
 package processcollector
 
 import (
+	"encoding/json"
+	"fmt"
+
 	gadgetv1alpha1 "github.com/kinvolk/inspektor-gadget/pkg/apis/gadget/v1alpha1"
 	"github.com/kinvolk/inspektor-gadget/pkg/gadgets"
 	"github.com/kinvolk/inspektor-gadget/pkg/gadgets/process-collector/tracer"
@@ -62,22 +65,27 @@ func (f *TraceFactory) Operations() map[string]gadgets.TraceOperation {
 }
 
 func (t *Trace) Collect(trace *gadgetv1alpha1.Trace) {
-	selector := gadgets.ContainerSelectorFromContainerFilter(trace.Spec.Filter)
-	if len(t.resolver.GetContainersBySelector(selector)) == 0 {
-		gadgets.CleanupTraceStatus(trace)
-		trace.Status.OperationWarning = "No container matches the requested filter"
-		return
-	}
-
-	output, err := tracer.RunCollector(
-		gadgets.TracePinPath(trace.ObjectMeta.Namespace, trace.ObjectMeta.Name),
-	)
+	events, err := tracer.RunCollector(t.resolver, gadgets.TracePinPath(trace.ObjectMeta.Namespace, trace.ObjectMeta.Name))
 	if err != nil {
 		gadgets.CleanupTraceStatus(trace)
 		trace.Status.OperationError = err.Error()
 		return
 	}
+
+	if len(events) == 0 {
+		gadgets.CleanupTraceStatus(trace)
+		trace.Status.OperationWarning = "No container matches the requested filter"
+		return
+	}
+
+	output, err := json.MarshalIndent(events, "", " ")
+	if err != nil {
+		gadgets.CleanupTraceStatus(trace)
+		trace.Status.OperationError = fmt.Sprintf("failed marshalling processes: %s", err)
+		return
+	}
+
 	trace.Status.OperationError = ""
-	trace.Status.Output = output
+	trace.Status.Output = string(output)
 	trace.Status.State = "Completed"
 }

--- a/pkg/gadgets/process-collector/tracer/tracer.go
+++ b/pkg/gadgets/process-collector/tracer/tracer.go
@@ -32,7 +32,7 @@ const (
 	BPF_ITER_NAME = "dump_task"
 )
 
-func RunCollector(resolver gadgets.Resolver, mntnsmap string) ([]processcollectortypes.Event, error) {
+func RunCollector(resolver gadgets.Resolver, node, mntnsmap string) ([]processcollectortypes.Event, error) {
 	var prog []byte
 	if mntnsmap == "" {
 		prog = ebpfProg
@@ -104,6 +104,7 @@ func RunCollector(resolver gadgets.Resolver, mntnsmap string) ([]processcollecto
 
 		events = append(events, processcollectortypes.Event{
 			Event: eventtypes.Event{
+				Node:      node,
 				Namespace: container.Namespace,
 				Pod:       container.Podname,
 				Container: container.Name,

--- a/pkg/gadgets/process-collector/types/process-collector.go
+++ b/pkg/gadgets/process-collector/types/process-collector.go
@@ -1,0 +1,27 @@
+// Copyright 2022 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import (
+	eventtypes "github.com/kinvolk/inspektor-gadget/pkg/types"
+)
+
+type Event struct {
+	eventtypes.Event
+	Tgid    int    `json:"tgid"`
+	Pid     int    `json:"pid"`
+	Command string `json:"comm"`
+	MntNsId uint64 `json:"mntns"`
+}

--- a/pkg/gadgettracermanager/bpf-maps.h
+++ b/pkg/gadgettracermanager/bpf-maps.h
@@ -5,13 +5,6 @@
 
 #include "common.h"
 
-struct {
-	__uint(type, BPF_MAP_TYPE_HASH);
-	__type(key, __u64);
-	__type(value, struct container);
-	__uint(max_entries, MAX_CONTAINERS_PER_NODE);
-} containers SEC(".maps");
-
 #ifdef WITH_FILTER
 struct {
 	__uint(type, BPF_MAP_TYPE_HASH);


### PR DESCRIPTION
Hi.


In this PR, I refactored `process-collector` gadget thus it works like `socket-collector` on the `gadget-container` side.
That is to say, information related to kubernetes (_e.g._ namespace, pod and container name) are taken from `golang` while information related to process (_e.g._ PID and TID) are taken from eBPF.
With this, it is now possible to filter with container (I think this was not functional before but I cannot ensure it):

```bash
$ ./kubectl-gadget process-collector -A -c mypod
NAMESPACE    POD      CONTAINER    COMM     PID     
demo         mypod    mypod        nginx    7175    
demo         mypod    mypod        nginx    7211    
demo         mypod    mypod        nginx    7212
```

I also added the container's node to gadget's output:

```bash
$ ./kubectl-gadget process-collector -n demo
NODE        NAMESPACE    POD      CONTAINER    COMM     PID     
minikube    demo         mypod    mypod        nginx    7175    
minikube    demo         mypod    mypod        nginx    7211    
minikube    demo         mypod    mypod        nginx    7212 
```

It also works with several nodes:

```bash
./kubectl-gadget process-collector -n kube-system
NODE            NAMESPACE      POD                                 CONTAINER                  COMM               PID     
minikube        kube-system    coredns-78fcd69978-vgzpr            coredns                    coredns            3711    
minikube        kube-system    etcd-minikube                       etcd                       etcd               1808    
minikube        kube-system    gadget-hp9px                        gadget                     gadgettracerman    8166    
minikube        kube-system    kindnet-9dt7x                       kindnet-cni                kindnetd           3338    
minikube        kube-system    kube-apiserver-minikube             kube-apiserver             kube-apiserver     1929    
minikube        kube-system    kube-controller-manager-minikube    kube-controller-manager    kube-controller    2657    
minikube        kube-system    kube-proxy-2nv2q                    kube-proxy                 kube-proxy         2982    
minikube        kube-system    kube-scheduler-minikube             kube-scheduler             kube-scheduler     1878    
minikube        kube-system    storage-provisioner                 storage-provisioner        storage-provisi    3774    
minikube-m02    kube-system    gadget-4ncp6                        gadget                     gadgettracerman    6101    
minikube-m02    kube-system    kindnet-6dzbx                       kindnet-cni                kindnetd           1850    
minikube-m02    kube-system    kube-proxy-z8lpm                    kube-proxy                 kube-proxy         1567
```

This contribution fixes #356 and supersedes #446.


Best regards.