### PR TITLE
`biotop`: Added container information to output.

### DIFF
--- a/cmd/kubectl-gadget/bcck8s.go
+++ b/cmd/kubectl-gadget/bcck8s.go
@@ -227,7 +227,7 @@ func bccCmd(subCommand, bccScript string) func(*cobra.Command, []string) {
 		gadgetParams := ""
 
 		// add container info to gadgets that support it
-		if subCommand != "tcptop" && subCommand != "profile" && subCommand != "biotop" {
+		if subCommand != "tcptop" && subCommand != "profile" {
 			gadgetParams = "--containersmap /sys/fs/bpf/gadget/containers"
 		}
 

--- a/docs/guides/biotop.md
+++ b/docs/guides/biotop.md
@@ -15,9 +15,8 @@ The gadget doesn't support the following flags:
 $ kubectl gadget biotop --node ip-10-0-30-247 --all-namespaces
 
 14:28:17 loadavg: 0.53 0.32 0.34 8/528 43043
-
-PID    COMM             D MAJ MIN DISK       I/O  Kbytes  AVGms
-1860   etcd             W 253 0   vda          3      24   0.38
+NAMESPACE        POD              CONTAINER        PID    COMM             D MAJ MIN DISK       I/O  Kbytes  AVGms
+kube-system      etcd-minikube    etcd             1860   etcd             W 253 0   vda          3      24   0.38
 ```
 
 We can leave the monitoring with Ctrl-C.

--- a/gadget.Dockerfile
+++ b/gadget.Dockerfile
@@ -2,7 +2,7 @@
 
 # BCC built from the gadget branch in the kinvolk/bcc fork.
 # See BCC section in docs/CONTRIBUTING.md for further details.
-ARG BCC="quay.io/kinvolk/bcc:520591c0fc491862c12337609ff9cbc9375d4de3-focal-release"
+ARG BCC="quay.io/kinvolk/bcc:7c454d02d25fac3c0cebb902225b88309842a1a5-focal-release"
 ARG OS_TAG=20.04
 
 FROM ${BCC} as bcc

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -144,7 +144,7 @@ func TestBiotop(t *testing.T) {
 	biotopCmd := &command{
 		name:           "Start biotop gadget",
 		cmd:            "$KUBECTL_GADGET biotop --node $(kubectl get node --no-headers | cut -d' ' -f1)",
-		expectedRegexp: `etcd`,
+		expectedRegexp: `kube-system\s+etcd[\w-]+\s+etcd\s+\d+\s+etcd`,
 		startAndStop:   true,
 	}
 


### PR DESCRIPTION
Hi.


In this PR, I added container information to biotop output:

```bash
$ ./kubectl-gadget biotop --node minikube
17:39:37 loadavg: 0.25 0.40 0.46 1/385 58375

NAMESPACE        POD              CONTAINER        PID    COMM             D MAJ MIN DISK       I/O  Kbytes  AVGms
kube-system      etcd-minikube    etcd             1963   etcd             W 253 0   vda          7      32   0.26
<>               <>               <>               244    jbd2/vda1-8      W 253 0   vda          2      16   0.19
<>               <>               <>               0 
```

TODO:
- [ ] Wait for kinvolk/bcc#17 to be merged.


Best regards.