### PR TITLE
kubectl-gadget/deploy: Add cluster role rule needed by seccomp gadget

### DIFF
--- a/cmd/kubectl-gadget/deploy.go
+++ b/cmd/kubectl-gadget/deploy.go
@@ -128,6 +128,10 @@ rules:
   resources: ["traces", "traces/status"]
   # For traces, we need all rights on them as we define this resource.
   verbs: ["delete", "deletecollection", "get", "list", "patch", "create", "update", "watch"]
+- apiGroups: ["*"]
+  resources: ["deployments", "replicasets", "statefulsets", "daemonsets", "jobs", "cronjobs", "replicationcontrollers"]
+  # Required to retrieve the owner references used by the seccomp gadget.
+  verbs: ["get"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/pkg/container-collection/options.go
+++ b/pkg/container-collection/options.go
@@ -262,6 +262,8 @@ func WithPubSub(funcs ...pubsub.FuncNotify) ContainerCollectionOption {
 // resource kinds. Otherwise, it returns nil.
 func getExpectedOwnerReference(ownerReferences []metav1.OwnerReference) *metav1.OwnerReference {
 	// From: https://kubernetes.io/docs/concepts/workloads/controllers/
+	// Notice that any change on this map needs to be aligned with the gadget
+	// cluster role.
 	expectedResKinds := map[string]struct{}{
 		"Deployment":            {},
 		"ReplicaSet":            {},
@@ -353,7 +355,9 @@ func ownerReferenceEnrichment(
 
 	var highestOwnerRef *metav1.OwnerReference
 
-	// Iterate until we reach the highest level of reference
+	// Iterate until we reach the highest level of reference with one of the
+	// expected resource kind. Take into account that if this logic is changed,
+	// the gadget cluster role needs to be updated accordingly.
 	for {
 		if len(ownerReferences) == 0 {
 			ownerReferences, err = getOwnerReferences(dynamicClient,


### PR DESCRIPTION
# Add cluster role rule needed by seccomp gadget

In order to enrich the containers with the owner reference information, it is necessary to be able to get the information of the pods (There is already a rule that covers it) and a list of specific Kubernetes resources.

## How to use

Check containers are enriched with the owner reference information.

## Testing done

### Before this PR
After #429, this functionality stop working because the cluster role does not allow getting some required Kubernetes resources. The error was reported in the gadget logs:

```
$ kubectl logs -n gadget <gadget-pod> | grep error
time="2022-01-13T04:13:47Z" level=error msg="kubernetes enricher: Failed to enrich with owner reference: failed to get calico-system/daemonsets/apps/v1/calico-node owner reference: cannot fetch daemonsets/apps/v1 calico-system/calico-node: daemonsets.apps \"calico-node\" is forbidden: User \"system:serviceaccount:gadget:gadget\" cannot get resource \"daemonsets\" in API group \"apps\" in the namespace \"calico-system\""
... Same for all the existing pods ...
```

### After this PR
```
# No error reported for the existing pods
$ kubectl logs -n gadget <gadget-pod> | grep error

# Deploying workload to test functionality
$ kubectl apply -f https://raw.githubusercontent.com/kubernetes/website/main/content/en/examples/controllers/nginx-deployment.yaml
deployment.apps/nginx-deployment created

# Check container was enriched with owner reference inforamtion
$ kubectl exec -it -n gadget <gadget-pod> -- /bin/gadgettracermanager -dump | grep "nginx-deployment"
id:"b1f2102c123904a8fb2dcc436feef953ce12068065fcab9d1e436eba0e71a6d4"  cgroup_path:"/sys/fs/cgroup/unified/system.slice/containerd.service"  cgroup_id:4294969262  mntns:4026533446  namespace:"default"  podname:"nginx-deployment-66b6c48dd5-kddmw"  name:"nginx"  labels:{key:"app"  value:"nginx"}  labels:{key:"pod-template-hash"  value:"66b6c48dd5"}  cgroup_v1:"/kubepods/besteffort/pod8f656315-d139-47ff-b08e-f80b01f0aebe/b1f2102c123904a8fb2dcc436feef953ce12068065fcab9d1e436eba0e71a6d4"  cgroup_v2:"/system.slice/containerd.service"  mount_sources:"proc"  mount_sources:"tmpfs"  mount_sources:"devpts"  mount_sources:"mqueue"  mount_sources:"sysfs"  mount_sources:"cgroup"  mount_sources:"/var/lib/kubelet/pods/8f656315-d139-47ff-b08e-f80b01f0aebe/etc-hosts"  mount_sources:"/var/lib/kubelet/pods/8f656315-d139-47ff-b08e-f80b01f0aebe/containers/nginx/fcdf3902"  mount_sources:"/var/lib/containerd/io.containerd.grpc.v1.cri/sandboxes/98ae7719bd53c1c4f8945c12c86f217c008d0e473e261ef5f76ffa83b390cd2b/hostname"  mount_sources:"/var/lib/containerd/io.containerd.grpc.v1.cri/sandboxes/98ae7719bd53c1c4f8945c12c86f217c008d0e473e261ef5f76ffa83b390cd2b/resolv.conf"  mount_sources:"/run/containerd/io.containerd.grpc.v1.cri/sandboxes/98ae7719bd53c1c4f8945c12c86f217c008d0e473e261ef5f76ffa83b390cd2b/shm"  mount_sources:"/var/lib/kubelet/pods/8f656315-d139-47ff-b08e-f80b01f0aebe/volumes/kubernetes.io~projected/kube-api-access-2896g"  pid:19494  netns:4026533374  owner_reference:{apiversion:"apps/v1"  kind:"Deployment"  name:"nginx-deployment"  uid:"87aa2710-4ac0-4d6a-97ab-4f46309d2aac"}
```

## TODO for another PR

- [ ] Add a new integration test to check this functionality. Or at least, one that checks any error is present in the gadget logs after the initialisation phase.