### PR TITLE
kubectl-gadget/deploy: Add cluster role rule needed for SPO integration

### DIFF
--- a/cmd/kubectl-gadget/deploy.go
+++ b/cmd/kubectl-gadget/deploy.go
@@ -132,6 +132,10 @@ rules:
   resources: ["deployments", "replicasets", "statefulsets", "daemonsets", "jobs", "cronjobs", "replicationcontrollers"]
   # Required to retrieve the owner references used by the seccomp gadget.
   verbs: ["get"]
+- apiGroups: ["security-profiles-operator.x-k8s.io"]
+  resources: ["seccompprofiles"]
+  # Required for integration with the Kubernetes Security Profiles Operator
+  verbs: ["list", "watch", "create"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
# Add cluster role rule needed for SPO integration

As #466, these rules were missed in #429 to allow the integration with the Kubernetes Security Profiles Operator (SPO).

## How to use

Generate a seccomp profile using the integration with the SPO.

## Testing done

### Before this PR
```
$ kubectl apply -f https://raw.githubusercontent.com/kubernetes/website/main/content/en/examples/controllers/nginx-deployment.yaml
deployment.apps/nginx-deployment created

$ kubectl get pods
NAME                                READY   STATUS    RESTARTS   AGE
nginx-deployment-66b6c48dd5-2l6nt   1/1     Running   0          17s
nginx-deployment-66b6c48dd5-s7h6t   1/1     Running   0          17s
nginx-deployment-66b6c48dd5-xb89p   1/1     Running   0          17s

$ ./kubectl-gadget seccomp-advisor start -m seccomp-profile -p nginx-deployment-66b6c48dd5-2l6nt
vu5JsBXFrrbgVTjJ

$ kubectl delete -f https://raw.githubusercontent.com/kubernetes/website/main/content/en/examples/controllers/nginx-deployment.yaml
deployment.apps "nginx-deployment" deleted

# No SeccompProfiles are created
$ kubectl get sp -n gadget
No resources found in gadget namespace.

# Gadget failed to create the SeccompProfile
$ kubectl logs -n gadget <gadget-pod>
... 
time="2022-01-13T15:44:41Z" level=info msg="pubsub: REMOVE_CONTAINER: default/nginx-deployment-66b6c48dd5-2l6nt/nginx"
E0113 15:44:41.297204    3982 reflector.go:138] pkg/mod/k8s.io/client-go@v0.21.2/tools/cache/reflector.go:167: Failed to watch *v1alpha1.SeccompProfile: failed to list *v1alpha1.SeccompProfile: seccompprofiles.security-profiles-operator.x-k8s.io is forbidden: User "system:serviceaccount:gadget:gadget" cannot list resource "seccompprofiles" in API group "security-profiles-operator.x-k8s.io" at the cluster scope
E0113 15:44:42.805316    3982 reflector.go:138] pkg/mod/k8s.io/client-go@v0.21.2/tools/cache/reflector.go:167: Failed to watch *v1alpha1.SeccompProfile: failed to list *v1alpha1.SeccompProfile: seccompprofiles.security-profiles-operator.x-k8s.io is forbidden: User "system:serviceaccount:gadget:gadget" cannot list resource "seccompprofiles" in API group "security-profiles-operator.x-k8s.io" at the cluster scope
E0113 15:44:45.211330    3982 reflector.go:138] pkg/mod/k8s.io/client-go@v0.21.2/tools/cache/reflector.go:167: Failed to watch *v1alpha1.SeccompProfile: failed to list *v1alpha1.SeccompProfile: seccompprofiles.security-profiles-operator.x-k8s.io is forbidden: User "system:serviceaccount:gadget:gadget" cannot list resource "seccompprofiles" in API group "security-profiles-operator.x-k8s.io" at the cluster scope
E0113 15:44:51.252181    3982 reflector.go:138] pkg/mod/k8s.io/client-go@v0.21.2/tools/cache/reflector.go:167: Failed to watch *v1alpha1.SeccompProfile: failed to list *v1alpha1.SeccompProfile: seccompprofiles.security-profiles-operator.x-k8s.io is forbidden: User "system:serviceaccount:gadget:gadget" cannot list resource "seccompprofiles" in API group "security-profiles-operator.x-k8s.io" at the cluster scope
...

$ ./kubectl-gadget seccomp-advisor stop vu5JsBXFrrbgVTjJ
Failed to run the gadget on all nodes: Pod default/nginx-deployment-66b6c48dd5-2l6nt not found
Error: timed out waiting for the condition
```

### After this PR
```
$ kubectl apply -f https://raw.githubusercontent.com/kubernetes/website/main/content/en/examples/controllers/nginx-deployment.yaml
deployment.apps/nginx-deployment created

$ kubectl get pods
NAME                                READY   STATUS    RESTARTS   AGE
nginx-deployment-66b6c48dd5-fj4cb   1/1     Running   0          7s
nginx-deployment-66b6c48dd5-gf8x7   1/1     Running   0          7s
nginx-deployment-66b6c48dd5-vfhh8   1/1     Running   0          7s

$ ./kubectl-gadget seccomp-advisor start -m seccomp-profile -p nginx-deployment-66b6c48dd5-fj4cb
5ckT3sX5gSU0ziot

$ kubectl delete -f https://raw.githubusercontent.com/kubernetes/website/main/content/en/examples/controllers/nginx-deployment.yaml
deployment.apps "nginx-deployment" deleted

$ kubectl get sp -n gadget
NAME                                STATUS      AGE
nginx-deployment-66b6c48dd5-fj4cb   Installed   7s

$ kubectl get sp -n gadget nginx-deployment-66b6c48dd5-fj4cb -o yaml | grep ownerReference
    seccomp.gadget.kinvolk.io/ownerReference-ApiVersion: apps/v1
    seccomp.gadget.kinvolk.io/ownerReference-Kind: Deployment
    seccomp.gadget.kinvolk.io/ownerReference-Name: nginx-deployment
    seccomp.gadget.kinvolk.io/ownerReference-UID: c9fa21ac-0b7e-4e7c-a0d2-ce5c1a5a02c5

$ ./kubectl-gadget seccomp-advisor stop 5ckT3sX5gSU0ziot
Successfully created seccomp profile
```

## TODO for future PR

- [ ] Fix integration tests for seccomp gadget and add a new test for integration with the SOP