### PR TITLE
Increase CI speed.

### DIFF
--- a/.github/actions/install-debian-packages/action.yml
+++ b/.github/actions/install-debian-packages/action.yml
@@ -1,0 +1,34 @@
+name: "Install debian packages"
+description: "Install debian packages needed by inspektor-gadget"
+
+inputs:
+  cache-hit:
+    description: "Whether debian packages are already present in cache."
+    required: true
+    default: 'false'
+  libbpf-version:
+    description: "Version of the libbpf to install."
+    default: "1:0.4.0-1ubuntu1"
+  libseccomp-version:
+    description: "Version of the libseccomp to install."
+    default: "2.5.1-1ubuntu1~20.04.2"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install debian packages
+      shell: bash
+      run: |
+        if [[ "${{inputs.cache-hit}}" == 'true' ]]; then
+          sudo cp --verbose --force --recursive ~/cache-debs/* /
+        else
+          sudo apt install -y software-properties-common
+          sudo add-apt-repository -y ppa:tuxinvader/kernel-build-tools
+          sudo apt-get update
+          sudo apt install -y libbpf-dev="${{inputs.libbpf-version}}" libseccomp-dev="${{inputs.libseccomp-version}}"
+          mkdir -p ~/cache-debs
+          sudo dpkg -L libbpf-dev libseccomp-dev | \
+              while IFS= read -r f; do \
+                  if test -f $f; then echo $f; fi; \
+              done | xargs cp --parents --target-directory ~/cache-debs/
+        fi

--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -1,65 +1,28 @@
-name: Compile Inspektor Gadget
+name: Inspektor Gadget CI
+env:
+  CONTAINER_REPO: ${{ secrets.CONTAINER_REPO }}
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
 on:
   push:
 
+# Jobs are given a level in a comment.
+# Jobs of the same level run in parallel.
+# Jobs of level N depend of, at least, one job on level N - 1 expect job whom
+# level is 0.
 jobs:
-
-  build:
-    name: Build
+  documentation-checks:
+    name: Documentation checks
+    # level: 0
     runs-on: ubuntu-latest
-    env:
-      CONTAINER_REPO: ${{ secrets.CONTAINER_REPO }}
     steps:
-
-    - name: Set up Go 1.17
+    - name: Setup go 1.17
       uses: actions/setup-go@v1
       with:
         go-version: 1.17
       id: go
-
-    - name: Check out code
-      uses: actions/checkout@v1
-
-    - name: Cache external deps
-      uses: actions/cache@v2
-      with:
-        # - Tests (tests.mk) need etcd, kube-apiserver, kubectl
-        # - Generating code (crd.mk) needs controller-gen
-        path: |
-          bin/etcd
-          bin/kube-apiserver
-          bin/kubectl
-          bin/controller-gen
-        key: ${{ runner.os }}-${{ hashFiles('tests.mk', 'crd.mk', '.github/workflows/inspektor-gadget.yml') }}
-
-    - name: Cache deb packages
-      uses: actions/cache@v2
-      id: cache-debs
-      with:
-        path: "~/cache-debs"
-        key: cache-debs-libbpf-1:0.4.0-1ubuntu1-libseccomp-2.5.1-1ubuntu1~20.04.1
-
-    - name: Install deb packages
-      env:
-        CACHE_HIT: ${{steps.cache-debs.outputs.cache-hit}}
-        LIBBPF_VERSION: "1:0.4.0-1ubuntu1"
-        LIBSECCOMP_VERSION: "2.5.1-1ubuntu1~20.04.1"
-      run: |
-          if [[ "$CACHE_HIT" == 'true' ]]; then
-            sudo cp --verbose --force --recursive ~/cache-debs/* /
-          else
-            sudo apt install -y software-properties-common
-            sudo add-apt-repository -y ppa:tuxinvader/kernel-build-tools
-            sudo apt-get update
-            sudo apt install -y libbpf-dev="$LIBBPF_VERSION" libseccomp-dev="$LIBSECCOMP_VERSION"
-            mkdir -p ~/cache-debs
-            sudo dpkg -L libbpf-dev libseccomp-dev | \
-                while IFS= read -r f; do \
-                    if test -f $f; then echo $f; fi; \
-                done | xargs cp --parents --target-directory ~/cache-debs/
-          fi
-
-    - name: Cache Go modules
+    - name: Cache go 1.17
       uses: actions/cache@v2
       with:
         path: |
@@ -68,7 +31,93 @@ jobs:
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-go-
+    - name: Check out code
+      uses: actions/checkout@v1
+    - name: Check if generated files are updated
+      run: |
+        make manifests generate generate-documentation
+        git diff --exit-code HEAD --
 
+  lint:
+    name: Lint
+    # level: 0
+    runs-on: ubuntu-latest
+    steps:
+    - name: Setup go 1.17
+      uses: actions/setup-go@v1
+      with:
+        go-version: 1.17
+      id: go
+    - name: Cache go 1.17
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.cache/go-build
+          ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
+    - name: Check out code
+      uses: actions/checkout@v1
+    - name: Cache debian packages
+      uses: actions/cache@v2
+      id: cache-debs
+      with:
+        path: "~/cache-debs"
+        key: cache-debs-libbpf-1:0.4.0-1ubuntu1-libseccomp-2.5.1-1ubuntu1~20.04.1
+    - name: Install debian packages
+      # ALERT This action must be run after code was checkout otherwise it will
+      # not find this file.
+      uses: ./.github/actions/install-debian-packages
+      with:
+        cache-hit: ${{steps.cache-debs.outputs.cache-hit}}
+    - name: Build eBPF objects
+      run: |
+        make -C gadget-container ebpf-objects
+    - name: Lint
+      uses: golangci/golangci-lint-action@v2
+      with:
+        version: v1.43.0
+        working-directory: /home/runner/work/inspektor-gadget/inspektor-gadget
+
+  build-kubectl-gadget:
+    name: Build kubectl-gadget
+    # level: 0
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [linux, darwin, windows]
+        arch: [amd64, arm64]
+        exclude:
+          - os: windows
+            arch: arm64
+    steps:
+    - name: Setup go 1.17
+      uses: actions/setup-go@v1
+      with:
+        go-version: 1.17
+      id: go
+    - name: Cache go 1.17
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.cache/go-build
+          ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
+    - name: Check out code
+      uses: actions/checkout@v1
+    - name: Cache debian packages
+      uses: actions/cache@v2
+      id: cache-debs
+      with:
+        path: "~/cache-debs"
+        key: cache-debs-libbpf-1:0.4.0-1ubuntu1-libseccomp-2.5.1-1ubuntu1~20.04.1
+    - name: Install debian packages
+      uses: ./.github/actions/install-debian-packages
+      with:
+        cache-hit: ${{steps.cache-debs.outputs.cache-hit}}
     - name: Set IMAGE_TAG
       run: |
         TMP1=${GITHUB_REF#*/}
@@ -78,54 +127,10 @@ jobs:
             IMAGE_TAG="latest"
         fi
         echo IMAGE_TAG=$IMAGE_TAG >> $GITHUB_ENV
-
-    - name: Check if generated files are updated
+    - name: Build kubectl-gadget-${{ matrix.os }}-${{ matrix.arch }}
       run: |
-        make manifests generate generate-documentation
-        git diff --exit-code HEAD --
+        git checkout
 
-    - name: Set up Docker Buildx
-      id: buildx
-      uses: docker/setup-buildx-action@v1
-
-    - name: Cache Docker layers
-      uses: actions/cache@v2
-      with:
-        path: /tmp/.buildx-cache
-        key: ${{ runner.os }}-single-buildx-${{ hashFiles('gadget.Dockerfile') }}
-        restore-keys: |
-          ${{ runner.os }}-single-buildx
-
-    - name: Login to Container Registry
-      uses: docker/login-action@v1
-      with:
-        registry: ${{ secrets.CONTAINER_REGISTRY }}
-        username: ${{ secrets.CONTAINER_REGISTRY_USERNAME }}
-        password: ${{ secrets.CONTAINER_REGISTRY_PASSWORD }}
-
-    - name: Build gadget container
-      uses: docker/build-push-action@v2
-      with:
-        context: .
-        file: gadget.Dockerfile
-        build-args: |
-          ENABLE_BTFGEN=true
-        # TODO: how to avoid pushing a container before running integration tests
-        push: true
-        tags: ${{ secrets.CONTAINER_REPO }}:${{ env.IMAGE_TAG }}
-        cache-from: type=local,src=/tmp/.buildx-cache
-        cache-to: type=local,dest=/tmp/.buildx-cache-new
-
-    # Temp fix
-    # https://github.com/docker/build-push-action/issues/252
-    # https://github.com/moby/buildkit/issues/1896
-    - name: Move Docker layers cache
-      run: |
-        rm -rf /tmp/.buildx-cache
-        mv /tmp/.buildx-cache-new /tmp/.buildx-cache
-
-    - name: Build kubectl gadget plugin for all platforms
-      run: |
         # Prevent releases with -dirty suffix due to forgotten entries in
         # .gitignore.
         changes="$(git status --porcelain)"
@@ -134,44 +139,195 @@ jobs:
           exit 1
         fi
 
-        make kubectl-gadget-all
+        kubectl_gadget=kubectl-gadget-${{ matrix.os }}-${{ matrix.arch }}
+
+        make $kubectl_gadget
 
         # Prepare assets for release and actions artifacts
-        for target in $(make list-kubectl-gadget-targets); do
-          platform=$(echo $target|cut -d- -f3-4)
-          mkdir $platform
-          cp kubectl-gadget-$platform $platform/kubectl-gadget
-          cp LICENSE $platform/
-          tar --sort=name --owner=root:0 --group=root:0 \
-            -czf inspektor-gadget-$platform.tar.gz -C $platform \
-            kubectl-gadget LICENSE
-          rm -rf $platform
-        done
+        platform=$(echo ${kubectl_gadget} | cut -d- -f3-4)
+        mkdir $platform
+        cp $kubectl_gadget $platform/kubectl-gadget
+        cp LICENSE $platform/
+        tar --sort=name --owner=root:0 --group=root:0 \
+          -czf ${kubectl_gadget}.tar.gz -C $platform \
+          kubectl-gadget LICENSE
+        rm -rf $platform
+    - name: Add kubectl-gadget-${{ matrix.os }}-${{ matrix.arch }}.tar.gz as artifact.
+      uses: actions/upload-artifact@master
+      with:
+        name: kubectl-gadget-${{ matrix.os }}-${{ matrix.arch }}-tar-gz
+        path: /home/runner/work/inspektor-gadget/inspektor-gadget/kubectl-gadget-${{ matrix.os }}-${{ matrix.arch }}.tar.gz
 
-    - name: Build local-gadget for all platforms
+  build-local-gadget:
+    name: Build local-gadget
+    # level: 0
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # TODO add local-gadget-linux-arm64
+        local-gadget-target: [local-gadget-linux-amd64]
+    steps:
+    - name: Setup go 1.17
+      uses: actions/setup-go@v1
+      with:
+        go-version: 1.17
+      id: go
+    - name: Cache go 1.17
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.cache/go-build
+          ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
+    - name: Check out code
+      uses: actions/checkout@v1
+    - name: Cache debian packages
+      uses: actions/cache@v2
+      id: cache-debs
+      with:
+        path: "~/cache-debs"
+        key: cache-debs-libbpf-1:0.4.0-1ubuntu1-libseccomp-2.5.1-1ubuntu1~20.04.1
+    - name: Install debian packages
+      # ALERT This action must be run after code was checkout otherwise it will
+      # not find this file.
+      uses: ./.github/actions/install-debian-packages
+    - name: Build ${{ matrix.local-gadget-target }}
       run: |
-        make local-gadget-all
+        make ${{ matrix.local-gadget-target }}
 
         # Prepare assets for release and actions artifacts
-        for target in $(make list-local-gadget-targets); do
-          platform=$(echo $target|cut -d- -f3-4)
-          mkdir $platform
-          cp local-gadget-$platform $platform/local-gadget
-          cp LICENSE $platform/
-          tar --sort=name --owner=root:0 --group=root:0 \
-            -czf local-gadget-$platform.tar.gz -C $platform \
-            local-gadget LICENSE
-          rm -rf $platform
-        done
+        platform=$(echo ${{ matrix.local-gadget-target }} | cut -d- -f3-4)
+        mkdir $platform
+        cp ${{ matrix.local-gadget-target }} $platform/local-gadget
+        cp LICENSE $platform/
+        tar --sort=name --owner=root:0 --group=root:0 \
+          -czf ${{ matrix.local-gadget-target }}.tar.gz -C $platform \
+          local-gadget LICENSE
+        rm -rf $platform
+    - name: Add ${{ matrix.local-gadget-target }}.tar.gz as artifact.
+      uses: actions/upload-artifact@master
+      with:
+        name: ${{ matrix.local-gadget-target }}-tar-gz
+        path: /home/runner/work/inspektor-gadget/inspektor-gadget/${{ matrix.local-gadget-target }}.tar.gz
 
+  build-docker-image:
+    name: Build gadget container image
+    # level: 0
+    runs-on: ubuntu-latest
+    steps:
+    - name: Set up Docker Buildx
+      id: buildx
+      uses: docker/setup-buildx-action@v1
+    - name: Cache Docker layers
+      uses: actions/cache@v2
+      with:
+        path: /tmp/.buildx-cache
+        key: ${{ runner.os }}-single-buildx-${{ hashFiles('gadget.Dockerfile') }}
+        restore-keys: |
+          ${{ runner.os }}-single-buildx
+    - name: Login to Container Registry
+      uses: docker/login-action@v1
+      with:
+        registry: ${{ secrets.CONTAINER_REGISTRY }}
+        username: ${{ secrets.CONTAINER_REGISTRY_USERNAME }}
+        password: ${{ secrets.CONTAINER_REGISTRY_PASSWORD }}
+    - name: Check out code
+      uses: actions/checkout@v1
+    - name: Set IMAGE_TAG
+      run: |
+        TMP1=${GITHUB_REF#*/}
+        TMP2=${TMP1#*/}
+        IMAGE_TAG=${TMP2//\//-}
+        if [ "$IMAGE_TAG" = "main" ]; then
+            IMAGE_TAG="latest"
+        fi
+        echo IMAGE_TAG=$IMAGE_TAG >> $GITHUB_ENV
+    - name: Build gadget container
+      uses: docker/build-push-action@v2
+      with:
+        context: /home/runner/work/inspektor-gadget/inspektor-gadget/
+        file: /home/runner/work/inspektor-gadget/inspektor-gadget/gadget.Dockerfile
+        build-args: |
+          ENABLE_BTFGEN=true
+        # TODO: how to avoid pushing a container before running integration tests
+        # Answer: push to runner registry first, if integration tests are OK
+        # push to final registry
+        push: true
+        tags: ${{ secrets.CONTAINER_REPO }}:${{ env.IMAGE_TAG }}
+        cache-from: type=local,src=/tmp/.buildx-cache
+        cache-to: type=local,dest=/tmp/.buildx-cache-new
+
+  test-unit:
+    name: Unit tests
+    # level: 0
+    runs-on: ubuntu-latest
+    steps:
+    - name: Setup go 1.17
+      uses: actions/setup-go@v1
+      with:
+        go-version: 1.17
+      id: go
+    - name: Cache go 1.17
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.cache/go-build
+          ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
+    - name: Check out code
+      uses: actions/checkout@v1
+    - name: Cache debian packages
+      uses: actions/cache@v2
+      id: cache-debs
+      with:
+        path: "~/cache-debs"
+        key: cache-debs-libbpf-1:0.4.0-1ubuntu1-libseccomp-2.5.1-1ubuntu1~20.04.1
+    - name: Install debian packages
+      uses: ./.github/actions/install-debian-packages
+      with:
+        cache-hit: ${{steps.cache-debs.outputs.cache-hit}}
     - name: Basic unit tests
       run: |
         make test
-
-    - name: Unit tests for the controller
+    - name: Controller unit tests
       run: |
         make controller-tests
 
+  test-local-gadget:
+    name: Unit tests for local-gadget
+    # level: 0
+    runs-on: ubuntu-latest
+    steps:
+    - name: Setup go 1.17
+      uses: actions/setup-go@v1
+      with:
+        go-version: 1.17
+      id: go
+    - name: Cache go 1.17
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.cache/go-build
+          ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
+    - name: Check out code
+      uses: actions/checkout@v1
+    - name: Cache debian packages
+      uses: actions/cache@v2
+      id: cache-debs
+      with:
+        path: "~/cache-debs"
+        key: cache-debs-libbpf-1:0.4.0-1ubuntu1-libseccomp-2.5.1-1ubuntu1~20.04.1
+    - name: Install debian packages
+      uses: ./.github/actions/install-debian-packages
+      with:
+        cache-hit: ${{steps.cache-debs.outputs.cache-hit}}
     - name: Unit tests for local-gadget (as root)
       run: |
         KERNEL=$(uname -r)
@@ -200,31 +356,75 @@ jobs:
 
         make local-gadget-tests
 
-    - name: Lint
-      uses: golangci/golangci-lint-action@v2
-      with:
-        version: v1.43.0
-
+  test-integration:
+    name: Integration tests
+    # level: 1
+    needs: [test-unit, build-kubectl-gadget, build-local-gadget, build-docker-image]
+    runs-on: ubuntu-latest
+    steps:
     - name: Setup Minikube
       uses: manusa/actions-setup-minikube@v2.4.2
       with:
         minikube version: 'v1.9.2'
         kubernetes version: 'v1.18.2'
         github token: ${{ secrets.GITHUB_TOKEN }}
-
+    - name: Set IMAGE_TAG
+      run: |
+        TMP1=${GITHUB_REF#*/}
+        TMP2=${TMP1#*/}
+        IMAGE_TAG=${TMP2//\//-}
+        if [ "$IMAGE_TAG" = "main" ]; then
+            IMAGE_TAG="latest"
+        fi
+        echo IMAGE_TAG=$IMAGE_TAG >> $GITHUB_ENV
+    - name: Check out code
+      uses: actions/checkout@v1
+    - name: Get kubectl-gadget-linux-amd64.tar.gz from artifact.
+      uses: actions/download-artifact@v2
+      with:
+        name: kubectl-gadget-linux-amd64-tar-gz
+        path: /home/runner/work/inspektor-gadget/
     - name: Integration tests
       run: |
         echo "Using IMAGE_TAG=$IMAGE_TAG"
+
+        tar zxvf /home/runner/work/inspektor-gadget/kubectl-gadget-linux-amd64.tar.gz
+
+        tar zxvf /home/runner/work/inspektor-gadget/kubectl-gadget-linux-amd64.tar.gz
+        mv kubectl-gadget kubectl-gadget-linux-amd64
 
         TESTS_DOCKER_ARGS="-e KUBECONFIG=/root/.kube/config -v /home/runner/.kube:/root/.kube -v /home/runner/work/_temp/.minikube:/home/runner/work/_temp/.minikube" \
             make -C integration build test
 
         sed -i "s/latest/$IMAGE_TAG/g" integration/gadget-integration-tests-job.yaml
+    - name: Add integration asset as artifact.
+      if: startsWith(github.ref, 'refs/tags/v')
+      uses: actions/upload-artifact@master
+      with:
+        name: integration-asset
+        path: /home/runner/work/inspektor-gadget/inspektor-gadget/integration/gadget-integration-tests-job.yaml
+    - name: Login to Container Registry
+      if: startsWith(github.ref, 'refs/tags/v')
+      uses: docker/login-action@v1
+      with:
+        registry: ${{ secrets.CONTAINER_REGISTRY }}
+        username: ${{ secrets.CONTAINER_REGISTRY_USERNAME }}
+        password: ${{ secrets.CONTAINER_REGISTRY_PASSWORD }}
+    - name: Push Integration Test Image
+      if: startsWith(github.ref, 'refs/tags/v')
+      run: |
+        make -C integration push
 
+  release:
+    name: Release
+    # level: 2
+    needs: test-integration
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v')
+    steps:
     - name: Create Release
       id: create_release
       uses: actions/create-release@v1.0.0
-      if: startsWith(github.ref, 'refs/tags/v')
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
@@ -232,34 +432,29 @@ jobs:
         release_name: Release ${{ github.ref }}
         draft: false
         prerelease: false
-
-    - name: Upload Gadget Release Assets
+    - name: Get all artifacts.
+      uses: actions/download-artifact@v2
+    - name: Upload Gadget Release *-gadget-*-*.tar.gz
       uses: csexton/release-asset-action@v2
-      if: startsWith(github.ref, 'refs/tags/v')
       with:
-        pattern: "*-gadget-*-*.tar.gz"
+        pattern: "*-gadget-*-*-tar-gz/*-gadget-*-*.tar.gz"
         github-token: ${{ secrets.GITHUB_TOKEN }}
         release-url: ${{ steps.create_release.outputs.upload_url }}
-
     - name: Upload Testing Asset
       id: upload-release-asset-testing
       uses: actions/upload-release-asset@v1.0.1
-      if: startsWith(github.ref, 'refs/tags/v')
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: integration/gadget-integration-tests-job.yaml
+        asset_path: integration-asset/gadget-integration-tests-job.yaml
         asset_name: gadget-integration-tests-job.yaml
         asset_content_type: application/x-yaml
-
-    - name: Push Integration Test Image
-      if: startsWith(github.ref, 'refs/tags/v')
-      run: |
-        make -C integration push
-
+    - name: Check out code
+      uses: actions/checkout@v1
     - name: Update new version in krew-index
-      if: |
-        startsWith(github.ref, 'refs/tags/v')
-        && github.repository == 'kinvolk/inspektor-gadget'
+      if: github.repository == 'kinvolk/inspektor-gadget'
       uses: rajatjindal/krew-release-bot@v0.0.40
+      with:
+        workdir: /home/runner/work/inspektor-gadget/inspektor-gadget
+        krew_template_file: .krew.yaml

--- a/.krew.yaml
+++ b/.krew.yaml
@@ -30,33 +30,33 @@ spec:
       matchLabels:
         os: linux
         arch: amd64
-    {{addURIAndSha "https://github.com/kinvolk/inspektor-gadget/releases/download/{{ .TagName }}/inspektor-gadget-linux-amd64.tar.gz" .TagName }}
+    {{addURIAndSha "https://github.com/kinvolk/inspektor-gadget/releases/download/{{ .TagName }}/kubectl-gadget-linux-amd64.tar.gz" .TagName }}
     bin: kubectl-gadget
 
   - selector:
       matchLabels:
         os: linux
         arch: arm64
-    {{addURIAndSha "https://github.com/kinvolk/inspektor-gadget/releases/download/{{ .TagName }}/inspektor-gadget-linux-arm64.tar.gz" .TagName }}
+    {{addURIAndSha "https://github.com/kinvolk/inspektor-gadget/releases/download/{{ .TagName }}/kubectl-gadget-linux-arm64.tar.gz" .TagName }}
     bin: kubectl-gadget
 
   - selector:
       matchLabels:
         os: darwin
         arch: amd64
-    {{addURIAndSha "https://github.com/kinvolk/inspektor-gadget/releases/download/{{ .TagName }}/inspektor-gadget-darwin-amd64.tar.gz" .TagName }}
+    {{addURIAndSha "https://github.com/kinvolk/inspektor-gadget/releases/download/{{ .TagName }}/kubectl-gadget-darwin-amd64.tar.gz" .TagName }}
     bin: kubectl-gadget
 
   - selector:
       matchLabels:
         os: darwin
         arch: arm64
-    {{addURIAndSha "https://github.com/kinvolk/inspektor-gadget/releases/download/{{ .TagName }}/inspektor-gadget-darwin-arm64.tar.gz" .TagName }}
+    {{addURIAndSha "https://github.com/kinvolk/inspektor-gadget/releases/download/{{ .TagName }}/kubectl-gadget-darwin-arm64.tar.gz" .TagName }}
     bin: kubectl-gadget
 
   - selector:
       matchLabels:
         os: windows
         arch: amd64
-    {{addURIAndSha "https://github.com/kinvolk/inspektor-gadget/releases/download/{{ .TagName }}/inspektor-gadget-windows-amd64.tar.gz" .TagName }}
+    {{addURIAndSha "https://github.com/kinvolk/inspektor-gadget/releases/download/{{ .TagName }}/kubectl-gadget-windows-amd64.tar.gz" .TagName }}
     bin: kubectl-gadget


### PR DESCRIPTION
Hi.

In this PR, I parallelized CI jobs, thus CI time was divided by approximately 1.5, from around 35 minutes to around 20 minutes.
Everything was tested and validated even [release](https://github.com/eiffel-fl/inspektor-gadget/releases/tag/vtest20) [jobs](https://github.com/eiffel-fl/inspektor-gadget/actions/runs/1718575715).

I would like to have your opinion about it because there are several caveats:

1. There are several places where I do the same action, _e.g._ getting go 1.17, but I do not want to share it between jobs as artifact.
2. I bumped `libseccomp` from `2.5.1-1ubuntu1~20.04.1` to `2.5.1-1ubuntu1~20.04.2` because it seems to not exist anymore in `ubuntu-latest`.
3. I was not able to test `rajatjindal/krew-release-bot` due to a [strange behavior](https://github.com/eiffel-fl/inspektor-gadget/runs/4868928501?check_suite_focus=true#step:5:17).
4. `local-gadget` for arm64 was removed from build and release artifact due to #471.
5. In release artifact, ` inspektor-gadget-*tar.gz ` was replaced by ` kubectl-gadget-*tar.gz `.

Best regards.