### PR TITLE
cmd/kubectl-gadget: Implement tools-mode flag per gadget

### DIFF
--- a/cmd/kubectl-gadget/deploy.go
+++ b/cmd/kubectl-gadget/deploy.go
@@ -38,7 +38,7 @@ var (
 	imagePullPolicy     string
 	hookMode            string
 	livenessProbe       bool
-	toolsMode           string
+	DefaultToolMode     string
 	fallbackPodInformer bool
 )
 
@@ -64,10 +64,10 @@ func init() {
 		true,
 		"enable liveness probes")
 	deployCmd.PersistentFlags().StringVarP(
-		&toolsMode,
-		"tools-mode", "",
+		&DefaultToolMode,
+		"default-tool-mode", "",
 		"standard",
-		"which kind of tools to use (auto, core, standard)")
+		"default kind of tools to use (auto, core, standard)")
 	deployCmd.PersistentFlags().BoolVarP(
 		&fallbackPodInformer,
 		"fallback-podinformer", "",
@@ -223,8 +223,8 @@ spec:
             value: {{.Version}}
           - name: INSPEKTOR_GADGET_OPTION_HOOK_MODE
             value: "{{.HookMode}}"
-          - name: INSPEKTOR_GADGET_OPTION_TOOLS_MODE
-            value: "{{.ToolsMode}}"
+          - name: INSPEKTOR_GADGET_OPTION_DEFAULT_TOOL_MODE
+            value: "{{.DefaultToolMode}}"
           - name: INSPEKTOR_GADGET_OPTION_FALLBACK_POD_INFORMER
             value: "{{.FallbackPodInformer}}"
         securityContext:
@@ -339,7 +339,7 @@ type parameters struct {
 	Version             string
 	HookMode            string
 	LivenessProbe       bool
-	ToolsMode           string
+	DefaultToolMode     string
 	FallbackPodInformer bool
 }
 
@@ -352,8 +352,8 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("invalid argument %q for --hook-mode=[auto,crio,podinformer,nri,fanotify]", hookMode)
 	}
 
-	if toolsMode != "auto" && toolsMode != "core" && toolsMode != "standard" {
-		return fmt.Errorf("invalid argument %q for --tools-mode=[auto,core,standard]", toolsMode)
+	if DefaultToolMode != "auto" && DefaultToolMode != "core" && DefaultToolMode != "standard" {
+		return fmt.Errorf("invalid argument %q for --tools-mode=[auto,core,standard]", DefaultToolMode)
 	}
 
 	t, err := template.New("deploy.yaml").Parse(deployYamlTmpl)
@@ -367,7 +367,7 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 		version,
 		hookMode,
 		livenessProbe,
-		toolsMode,
+		DefaultToolMode,
 		fallbackPodInformer,
 	}
 

--- a/gadget-container/entrypoint.sh
+++ b/gadget-container/entrypoint.sh
@@ -172,29 +172,6 @@ else
   fi
 fi
 
-# Choose what kind of tools based on the configuration detected
-TOOLS_MODE="$INSPEKTOR_GADGET_OPTION_TOOLS_MODE"
-
-if [ "$TOOLS_MODE" = "auto" ] || [ -z "$TOOLS_MODE" ] ; then
-  if test -f /sys/kernel/btf/vmlinux; then
-    echo "BTF is available at /sys/kernel/btf/vmlinux: Using CO-RE based tools"
-    TOOLS_MODE="core"
-  elif test -f /boot/vmlinux-$KERNEL; then
-    echo "BTF is available at /boot/vmlinux-$KERNEL: Using CO-RE based tools"
-    TOOLS_MODE="core"
-  else
-    echo "vmlinux not found. Using standard tools"
-    TOOLS_MODE="standard"
-  fi
-fi
-
-# Create symlinks for tools according to the value of TOOLS_MODE
-if [ "$TOOLS_MODE" = "core" ] ; then
-  ln -s /bin/libbpf-tools/ /bin/gadgets
-elif [ "$TOOLS_MODE" = "standard" ] ; then
-  ln -s /usr/share/bcc/tools/ /bin/gadgets
-fi
-
 echo "Starting the Gadget Tracer Manager..."
 rm -f /run/gadgettracermanager.socket
 exec /bin/gadgettracermanager -serve -hook-mode=$GADGET_TRACER_MANAGER_HOOK_MODE \


### PR DESCRIPTION
The deploy command has a "tools-mode" flag that indicates which kind of
gadgets to use. The container entrypoint script has some logic to
determine the kind of tool to use when this is "auto". This logic
it not totally precise and some gadgets could not support the core
mode in some cases even if that logic indicates so.

In order to avoid the user having to redeploy IG, this commit adds a new
flag to each tool, so the user can choose the mode each time the tool is
run.

The previous existing "tools-mode" flag on the deploy command is renamed
to "default-tools-mode" as this can be useful to avoid having to pass
the mode each time a tool is executed.

---

Fixes https://github.com/kinvolk/inspektor-gadget/issues/349
