### PR TITLE
Update BCC version

### DIFF
--- a/gadget.Dockerfile
+++ b/gadget.Dockerfile
@@ -2,7 +2,7 @@
 
 # BCC built from the gadget branch in the kinvolk/bcc fork.
 # See BCC section in docs/CONTRIBUTING.md for further details.
-ARG BCC="quay.io/kinvolk/bcc:7c454d02d25fac3c0cebb902225b88309842a1a5-focal-release"
+ARG BCC="quay.io/kinvolk/bcc:8654cd151c35ad20b3082e7d516a98a4e80d8899-focal-release"
 ARG OS_TAG=20.04
 
 FROM ${BCC} as bcc


### PR DESCRIPTION
Update the base BCC version we use. 

This include PRs like https://github.com/iovisor/bcc/pull/3760 and https://github.com/iovisor/bcc/pull/3810 that fix problems we're having in IG. 

Fixes https://github.com/kinvolk/inspektor-gadget/issues/339

TODO: 
- [x] Update BCC container image tag once https://github.com/kinvolk/bcc/pull/18 is merged 
