### PR TITLE
kubectl-gadget: tolerate errors on some nodes

### DIFF
--- a/cmd/kubectl-gadget/utils/exec.go
+++ b/cmd/kubectl-gadget/utils/exec.go
@@ -29,6 +29,11 @@ import (
 	"k8s.io/client-go/tools/remotecommand"
 )
 
+var (
+	ErrGadgetPodNotFound      = errors.New("Gadget pod not found")
+	ErrMultipleGadgetPodFound = errors.New("Multiple gadget pods found")
+)
+
 func ExecPodSimple(client *kubernetes.Clientset, node string, podCmd string) string {
 	stdout, stderr, err := ExecPodCapture(client, node, podCmd)
 	if err != nil {
@@ -54,10 +59,10 @@ func ExecPod(client *kubernetes.Clientset, node string, podCmd string, cmdStdout
 		return err
 	}
 	if len(pods.Items) == 0 {
-		return errors.New("Gadget Daemon not found")
+		return ErrGadgetPodNotFound
 	}
 	if len(pods.Items) != 1 {
-		return errors.New("Multiple Gadget Daemons found")
+		return ErrMultipleGadgetPodFound
 	}
 	podName := pods.Items[0].Name
 


### PR DESCRIPTION
# kubectl-gadget: tolerate errors on some nodes

Ideally, there is one gadget pod on each worker node and it is in the
'running' phase. However, it could be that the gadget pod does not run
properly on one node. For example, Kubernetes could have a worker pool
with Windows and since the gadget container does not support Windows,
those containers are not running.

In this situation, it would still be useful to be able to use Inspektor
Gadget to inspect the other nodes. Currently, the kubectl-gadget CLI
fails immediately if one node does not work well.

This patch makes the CLI more tolerant of errors.

## How to use


## Testing done

Failure when testing on a single node:
```
$ ./kubectl-gadget execsnoop --node aksalbanw000000
Node aksalbanw000000: Gadget pod not found
```

Failure when testing on all nodes:
```
$ ./kubectl-gadget execsnoop
Node aksalbanw000000: Gadget pod not found
NODE             NAMESPACE        POD              CONTAINER        PCOMM            PID    PPID   RET ARGS
^C
Terminating...
```