### PR TITLE
container-collection: Do not request cgroup v1 and v2

### DIFF
--- a/pkg/container-collection/options.go
+++ b/pkg/container-collection/options.go
@@ -425,7 +425,7 @@ func WithKubernetesEnrichment(nodeName string) ContainerCollectionOption {
 				return true
 			}
 
-			if containerDefinition.CgroupV1 == "" || containerDefinition.CgroupV2 == "" {
+			if containerDefinition.CgroupV1 == "" && containerDefinition.CgroupV2 == "" {
 				log.Errorf("kubernetes enricher: cannot work without cgroup paths")
 				return true
 			}


### PR DESCRIPTION
# Do not request cgroup v1 and v2 to enrich containers with Kubernetes metadata

When using a cluster where only one version of cgroup is used, the following error is printed and containers are not enriched with Kubernetes metadata:

```
$ kubectl logs -n gadget <gadget-pod>
...
time="2022-01-28T14:55:59Z" level=error msg="kubernetes enricher: cannot work without cgroup paths"
```

It should be enough to have one version of cgroup to be able to enrich the container with Kubernetes metadata.

## How to use

Test IG on a cluster where only one version of cgroup is used. For instance, Openshift uses only v1.

## Testing done

Tested on an ARO cluster (OpenShift 4.8) by starting a pod manually and looking at the logs:

```
# Testing deployment
$ kubectl apply -f https://raw.githubusercontent.com/kubernetes/website/main/content/en/examples/controllers/nginx-deployment.yaml

# Check that nginx container was enriched with k8s metadata: namespace, labels, podname ...
$ kubectl exec -it -n gadget <gadget> -- /bin/bash -c "gadgettracermanager -dump" | grep nginx
id:"5bd37e88d1df878f30d1fcc924026ed5b5bec5447ececaea7d65b210edaef22d" cgroup_path:"/sys/fs/cgroup" mntns:4026533187 namespace:"default" podname:"nginx-deployment-66b6c48dd5-grzzh" name:"nginx" labels:{key:"app" value:"nginx"} labels:{key:"pod-template-hash" value:"66b6c48dd5"} cgroup_v1:"/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-podcd224d17_fec1_47b2_8815_2cf0215d0dfc.slice/crio-5bd37e88d1df878f30d1fcc924026ed5b5bec5447ececaea7d65b210edaef22d.scope" mount_sources:"proc" mount_sources:"tmpfs" mount_sources:"devpts" mount_sources:"mqueue" mount_sources:"sysfs" mount_sources:"cgroup" mount_sources:"/var/run/containers/storage/overlay-containers/b22feaa514b409d76f9c7a66a7f170f0564820effcec5bf0300d435a6f37de55/userdata/shm" mount_sources:"/var/run/containers/storage/overlay-containers/b22feaa514b409d76f9c7a66a7f170f0564820effcec5bf0300d435a6f37de55/userdata/resolv.conf" mount_sources:"/var/run/containers/storage/overlay-containers/b22feaa514b409d76f9c7a66a7f170f0564820effcec5bf0300d435a6f37de55/userdata/hostname" mount_sources:"/var/lib/kubelet/pods/cd224d17-fec1-47b2-8815-2cf0215d0dfc/etc-hosts" mount_sources:"/var/lib/kubelet/pods/cd224d17-fec1-47b2-8815-2cf0215d0dfc/containers/nginx/074cc628" mount_sources:"/var/run/containers/storage/overlay-containers/5bd37e88d1df878f30d1fcc924026ed5b5bec5447ececaea7d65b210edaef22d/userdata/run/secrets" mount_sources:"/var/lib/kubelet/pods/cd224d17-fec1-47b2-8815-2cf0215d0dfc/volumes/kubernetes.io~projected/kube-api-access-t9cwc" pid:2380036 netns:4026532933 owner_reference:{apiversion:"apps/v1" kind:"Deployment" name:"nginx-deployment" uid:"92a7685f-f4fb-4576-a411-f08442d30b35"}
```

