### PR TITLE
entrypoint: Install OCI hooks also in /etc/containers/oci/hooks.d

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -82,11 +82,24 @@ $ kubectl gadget deploy --image=docker.io/myfork/gadget:tag | kubectl apply -f -
 Inspektor Gadget needs to detect when containers are started and stopped.
 The different supported modes can be set by using the `hook-mode` option:
 
-- `auto`(default): Inspektor Gadget will try to find the best option based on the system it is running on.
-- `crio`: Use the [CRIO hooks](https://github.com/containers/podman/blob/v3.0.0-rc3/pkg/hooks/docs/oci-hooks.5.md) support. Inspektor Gadget installs the required hooks in `/usr/share/containers/oci/hooks.d`, be sure that path is part of the `hooks_dir` option on [crio.conf](https://github.com/cri-o/cri-o/blob/v1.20.0/docs/crio.conf.5.md#crioruntime-table). If `hooks_dir` is not declared at all that path is considered by default.
-- `podinformer`: Use a Kubernetes controller to get information about new pods. This option is racy and the first events produced by a container could be lost. This mode is selected when `auto` is used and the above modes are not available.
-- `nri`: Use the [Node Resource Interface](https://github.com/containerd/nri). It requires containerd v1.5 and it's not considered when `auto` is used.
-- `fanotify`: Uses the Linux [fanotify](https://man7.org/linux/man-pages/man7/fanotify.7.html) API. It only works with runc.
+- `auto`(default): Inspektor Gadget will try to find the best option based on
+  the system it is running on.
+- `crio`: Use the [CRIO
+  hooks](https://github.com/containers/podman/blob/v3.4.4/pkg/hooks/docs/oci-hooks.5.md)
+  support. Inspektor Gadget installs the required hooks in
+  `/etc/containers/oci/hooks.d`, be sure that path is part of the `hooks_dir`
+  option on
+  [crio.conf](https://github.com/cri-o/cri-o/blob/v1.20.0/docs/crio.conf.5.md#crioruntime-table).
+  If `hooks_dir` is not declared at all, that path is considered by default.
+- `podinformer`: Use a Kubernetes controller to get information about new pods.
+  This option is racy and the first events produced by a container could be
+  lost. This mode is selected when `auto` is used and the above modes are not
+  available.
+- `nri`: Use the [Node Resource Interface](https://github.com/containerd/nri).
+  It requires containerd v1.5 and it's not considered when `auto` is used.
+- `fanotify`: Uses the Linux
+  [fanotify](https://man7.org/linux/man-pages/man7/fanotify.7.html) API. It only
+  works with runc.
 
 ### Specific Information for Different Platforms
 

--- a/gadget-container/cleanup.sh
+++ b/gadget-container/cleanup.sh
@@ -22,8 +22,8 @@ for i in ocihookgadget prestart.sh poststop.sh ; do
 done
 
 # CRIO hooks
-rm -f /host/usr/share/containers/oci/hooks.d/gadget-prestart.json
-rm -f /host/usr/share/containers/oci/hooks.d/gadget-poststop.json
+rm -f /host/etc/containers/oci/hooks.d/gadget-prestart.json
+rm -f /host/etc/containers/oci/hooks.d/gadget-poststop.json
 
 # ld preload support
 if [ -f "/host/etc/ld.so.preload" ] ; then

--- a/gadget-container/entrypoint.sh
+++ b/gadget-container/entrypoint.sh
@@ -137,12 +137,16 @@ if [ "$HOOK_MODE" = "crio" ] ; then
     cp /opt/hooks/oci/$i /host/opt/hooks/oci/
   done
 
-  echo "Installing OCI hooks configuration in /usr/share/containers/oci/hooks.d"
-  mkdir -p /host/usr/share/containers/oci/hooks.d
-  cp /opt/hooks/crio/gadget-prestart.json /host/usr/share/containers/oci/hooks.d/gadget-prestart.json
-  cp /opt/hooks/crio/gadget-poststop.json /host/usr/share/containers/oci/hooks.d/gadget-poststop.json
+  echo "Installing OCI hooks configuration in /etc/containers/oci/hooks.d"
+  mkdir -p /host/etc/containers/oci/hooks.d
+  cp /opt/hooks/crio/gadget-prestart.json /host/etc/containers/oci/hooks.d/ 2>/dev/null || true
+  cp /opt/hooks/crio/gadget-poststop.json /host/etc/containers/oci/hooks.d/ 2>/dev/null || true
 
-  echo "Hooks installation done"
+  if ! ls /host/etc/containers/oci/hooks.d/gadget-{prestart,poststop}.json > /dev/null 2>&1; then
+    echo "Couldn't install OCI hooks configuration" >&2
+  else
+    echo "Hooks installation done"
+  fi
 fi
 
 if [ "$HOOK_MODE" = "nri" ] ; then


### PR DESCRIPTION
# Install OCI hooks also in /etc/containers/oci/hooks.d

Testing IG on [OpenShift 4.9](https://developers.redhat.com/courses/explore-openshift/openshift-49-playground) and [Azure Red Hat Openshift](https://docs.microsoft.com/en-us/azure/openshift/) (OpenShift 4.8), the gadget pod is not able to install the hooks configurations because the folder `/host/usr/share/containers/oci/hooks.d/` is read-only:

```bash
$ kubectl logs -n gadget <gadget-name>
OS detected: "Red Hat Enterprise Linux CoreOS 48.84.202110270303-0 (Ootpa)"
Kernel detected: 4.18.0-305.19.1.el8_4.x86_64
bcc detected: 0.24.0-1
Gadget image: joseregistry.azurecr.io/gadget:latest
Deployment options:
INSPEKTOR_GADGET_OPTION_FALLBACK_POD_INFORMER=true
INSPEKTOR_GADGET_OPTION_TOOLS_MODE=core
INSPEKTOR_GADGET_OPTION_HOOK_MODE=auto
Inspektor Gadget version: v0.4.2-115-g40b27d56ec9d-dirty
CRI-O detected.
hook mode cri-o detected.
Installing hooks scripts on host...
Installing ocihookgadget...
Installing prestart.sh...
Installing poststop.sh...
Installing OCI hooks configuration in /usr/share/containers/oci/hooks.d
cp: cannot create regular file '/host/usr/share/containers/oci/hooks.d/gadget-prestart.json': Read-only file system
```

## How to use

Try IG on  OpenShift 4.9 or ARO.

## Testing done

After applying this PR, the hooks are installed correctly:

```bash
$ kubectl logs -n gadget <gadget-name>
OS detected: "Red Hat Enterprise Linux CoreOS 48.84.202110270303-0 (Ootpa)"
Kernel detected: 4.18.0-305.19.1.el8_4.x86_64
bcc detected: 0.24.0-1
Gadget image: joseregistry.azurecr.io/gadget:jose-oci-hooks
Deployment options:
INSPEKTOR_GADGET_OPTION_FALLBACK_POD_INFORMER=true
INSPEKTOR_GADGET_OPTION_TOOLS_MODE=core
INSPEKTOR_GADGET_OPTION_HOOK_MODE=auto
Inspektor Gadget version: v0.4.2-117-g3284ccbc2839
CRI-O detected.
Fetching kernel-devel from CentOS 8.
hook mode cri-o detected.
Installing hooks scripts on host...
Installing ocihookgadget...
Installing prestart.sh...
Installing poststop.sh...
Installing OCI hooks configuration in /etc/containers/oci/hooks.d and /usr/share/containers/oci/hooks.d
Hooks installation done
```
