### PR TITLE
entrypoint: Fix kernel-header download for CentOS

### DIFF
--- a/gadget.Dockerfile
+++ b/gadget.Dockerfile
@@ -64,7 +64,7 @@ RUN set -ex; \
 	export DEBIAN_FRONTEND=noninteractive; \
 	apt-get update && \
 	apt-get install -y --no-install-recommends \
-		ca-certificates curl jq wget xz-utils binutils && \
+		ca-certificates curl jq wget xz-utils binutils rpm2cpio cpio && \
 		rmdir /usr/src && ln -sf /host/usr/src /usr/src
 
 COPY gadget-container/entrypoint.sh gadget-container/cleanup.sh /


### PR DESCRIPTION
# Fix kernel-header download for CentOS

Testing IG on [OpenShift 4.9](https://developers.redhat.com/courses/explore-openshift/openshift-49-playground) and [Azure Red Hat Openshift](https://docs.microsoft.com/en-us/azure/openshift/) (OpenShift 4.8), the gadget pod is not able to download the kernel headers which makes the container fail:

```
# kubectl logs -n kube-system <gadget-pod>
OS detected: "Red Hat Enterprise Linux CoreOS 49.84.202110081407-0 (Ootpa)"
Kernel detected: 4.18.0-305.19.1.el8_4.x86_64
bcc detected: 0.24.0-1
Gadget image: joseregistry.azurecr.io/gadget:latest
Deployment options:
INSPEKTOR_GADGET_OPTION_FALLBACK_POD_INFORMER=true
INSPEKTOR_GADGET_OPTION_TOOLS_MODE=standard
INSPEKTOR_GADGET_OPTION_HOOK_MODE=auto
Inspektor Gadget version: v0.4.2
CRI-O detected.
Fetching kernel-devel from CentOS 8.
curl: (22) The requested URL returned error: 404 Not Found
```

Then, when the URL was fixed, the `entrypoint` scripts fail to extract files from the RPM package:
 
```
Fetching kernel-devel from CentOS 8.
chroot: cannot change root directory to '/host': Operation not permitted
```
## Implementation details

- This PR updates the URL from http://mirror.centos.org/ (where only the latest kernel headers are available) to http://vault.centos.org/ (where all the versions are available).
- I found that the CentOS version is composed by `<RHEL_VERSION>.<RELEASE_YEAR><RELEASE_MONTH>` and I retrieved all the Red Hat Enterprise Linux 8 from [this blog post](https://access.redhat.com/articles/3078#RHEL8).
- This PR installs `rpm2cpio` and `cpio` directly in the gadget pod given that it is not always possible to make chroot on `/host`.
- In addition, this PR does not install any temporary file on the host and the whole job is done on the gadget container itself.

## How to use

Try IG on any cluster where nodes use `Red Hat Enterprise Linux CoreOS`, e.g. OpenShift 4.9 or ARO.

## Testing done

Tested in OpenShift 4.9 or ARO and ensure gadgets were working using the standard tools-mode.

**NOTE**: There is a warning when running gadgets but it will be handled in another PR:

```
# kubectl gadget execsnoop -n kube-system
In file included from <built-in>:2:
In file included from /virtual/include/bcc/bpf.h:12:In file included from include/linux/types.h:6:
In file included from include/uapi/linux/types.h:14:
In file included from include/uapi/linux/posix_types.h:5:
In file included from include/linux/stddef.h:5:
In file included from include/uapi/linux/stddef.h:2:
In file included from include/linux/compiler_types.h:78:
include/linux/compiler-clang.h:29:9: warning: '__no_sanitize_address' macro redefined [-Wmacro-redefined]#define __no_sanitize_address
        ^
include/linux/compiler-gcc.h:339:9: note: previous definition is here
#define __no_sanitize_address __attribute__((no_sanitize_address))
        ^1 warning generated.
NODE             NAMESPACE        POD              CONTAINER        PCOMM            PID    PPID   RET ARGS
^C
Terminating...
crc-dzk9v-master-0 kube-system      gadget-5b9cd     gadget           sh               184444 184434   0 /bin/sh -c exec /opt/bcck8s/bcc-wrapper.sh --tracerid 20220131155949_125a5ab0fd6e --stop
crc-dzk9v-master-0 kube-system      gadget-5b9cd     gadget           bcc-wrapper.sh   184444 184434   0 /opt/bcck8s/bcc-wrapper.sh --tracerid 20220131155949_125a5ab0fd6e --stop
crc-dzk9v-master-0 kube-system      gadget-5b9cd     gadget           gadgettracerman  184454 184444   0 /bin/gadgettracermanager -call remove-tracer -tracerid 20220131155949_125a5ab0fd6e
crc-dzk9v-master-0 kube-system      gadget-5b9cd     gadget           cat              184464 184444   0 /usr/bin/cat /run/bcc-wrapper-20220131155949_125a5ab0fd6e.pid
```