### PR TITLE
Prevent releasing if a job failed.

### DIFF
--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -389,8 +389,6 @@ jobs:
         echo "Using IMAGE_TAG=$IMAGE_TAG"
 
         tar zxvf /home/runner/work/inspektor-gadget/kubectl-gadget-linux-amd64.tar.gz
-
-        tar zxvf /home/runner/work/inspektor-gadget/kubectl-gadget-linux-amd64.tar.gz
         mv kubectl-gadget kubectl-gadget-linux-amd64
 
         TESTS_DOCKER_ARGS="-e KUBECONFIG=/root/.kube/config -v /home/runner/.kube:/root/.kube -v /home/runner/work/_temp/.minikube:/home/runner/work/_temp/.minikube" \
@@ -418,7 +416,7 @@ jobs:
   release:
     name: Release
     # level: 2
-    needs: test-integration
+    needs: [documentation-checks, lint, test-integration, test-local-gadget]
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
     steps:


### PR DESCRIPTION
Hi.

Before this PR, it was possible to do a release if the linter, document checks or the local-gadget unit tests failed.
This PR corrects this bad behavior:
* [Linter failed and no release is published](https://github.com/eiffel-fl/inspektor-gadget/actions/runs/1790422149).
* [Everything is OK and release is published](https://github.com/eiffel-fl/inspektor-gadget/actions/runs/1790720493).

Best regards.