### PR TITLE
Increase traceloop opened file limit.

### DIFF
--- a/cmd/kubectl-gadget/deploy.go
+++ b/cmd/kubectl-gadget/deploy.go
@@ -291,7 +291,8 @@ spec:
               # https://elixir.bootlin.com/linux/v5.14.14/source/kernel/ptrace.c#L284
               - SYS_PTRACE
 
-              # Needed by setrlimit in gadgettracermanager.
+              # Needed by setrlimit in gadgettracermanager and by the traceloop
+              # gadget.
               - SYS_RESOURCE
 
               # Needed for gadgets that don't dumb the memory rlimit.

--- a/pkg/gadgets/traceloop/gadget.go
+++ b/pkg/gadgets/traceloop/gadget.go
@@ -121,6 +121,13 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 		echo "-:pfree_uts_ns" >> /sys/kernel/debug/tracing/kprobe_events 2>/dev/null || true
 		echo "-:pcap_capable" >> /sys/kernel/debug/tracing/kprobe_events 2>/dev/null || true
 
+		# Remove the opened files limit to avoid getting this error:
+		# error while loading "tracepoint/raw_syscalls/sys_enter" (too many open files):
+		# Indeed, traceloop creates a lof of tracers which each has maps and events:
+		# https://github.com/kinvolk/traceloop/blob/6f4efc6fca46d92c75f4ec4e6c6e1d829bdeaddf/bpf/straceback-guess-bpf.h#L27-L28
+		# So, this can generate a lof ot opened files.
+		ulimit -n unlimited
+
 		rm -f /run/traceloop.socket
 		exec /bin/traceloop k8s
 	`)


### PR DESCRIPTION
Hi.

In this PR, I increased the gadget container opened file limit from 1024 to 2048, using `ulimit -n`, right before running `traceloop`.
This is needed in CBL Mariner to avoid this type of error:

```
I0204 11:03:10.222056  197541 podinformer.go:282] Starting Pod controller
error while loading "tracepoint/raw_syscalls/sys_enter" (too many open files):
processed 2529 insns (limit 1000000) max_states_per_insn 4 total_states 209 peak_states 209 mark_read 7
```

Since now all gadgets work on CBL Mariner, merging this PR will fix #401. 

Best regards.