### PR TITLE
Wait end of current operation before modifying trace operation

### DIFF
--- a/cmd/kubectl-gadget/utils/trace.go
+++ b/cmd/kubectl-gadget/utils/trace.go
@@ -371,7 +371,15 @@ func getTraceListFromID(traceID string) (*gadgetv1alpha1.TraceList, error) {
 // SetTraceOperation sets the operation of an existing trace.
 // If trace does not exist an error is returned.
 func SetTraceOperation(traceID string, operation string) error {
-	traces, err := getTraceListFromID(traceID)
+	// We have to wait for the previous operation to start before changing the
+	// trace operation.
+	// The trace controller deletes the GADGET_OPERATION field from Annotations
+	// when it is about to deal with an operation.
+	// Thus, to avoid losing operations, we need to wait for GADGET_OPERATION to
+	// be deleted before changing to the current operation.
+	// It is the same like when you are in the restaurant, you need to wait for
+	// the chef to cook the main dishes before ordering the dessert.
+	traces, err := waitForNoOperation(traceID)
 	if err != nil {
 		return err
 	}

--- a/cmd/kubectl-gadget/utils/trace.go
+++ b/cmd/kubectl-gadget/utils/trace.go
@@ -555,6 +555,19 @@ func waitForTraceState(traceID string, expectedState string) (*gadgetv1alpha1.Tr
 	})
 }
 
+// waitForNoOperation waits for the traces with the ID received as parameter to
+// not have an operation.
+func waitForNoOperation(traceID string) (*gadgetv1alpha1.TraceList, error) {
+	return waitForCondition(traceID, func(trace *gadgetv1alpha1.Trace) bool {
+		if trace.ObjectMeta.Annotations == nil {
+			return true
+		}
+
+		_, present := trace.ObjectMeta.Annotations[GADGET_OPERATION]
+		return !present
+	})
+}
+
 var sigIntReceivedNumber = 0
 
 // sigHandler installs a handler for all signals which cause termination as

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -536,10 +536,6 @@ func TestSeccompadvisor(t *testing.T) {
 
 	t.Parallel()
 
-	if *githubCI {
-		t.Skip("seccomp-advisor timed out within GitHub CI.")
-	}
-
 	commands := []*command{
 		createTestNamespaceCommand(ns),
 		{


### PR DESCRIPTION
Hi.

Before changing the trace operation, we should ensure there is no running operation.
Indeed, before this commit, we could loose operations if we change, on client side, the operation while it is being processed on trace controller side.

```
Will set trace op to: "stop"
trace: {TypeMeta:{Kind:Trace APIVersion:gadget.kinvolk.io/v1alpha1} ObjectMeta:{Name:seccomp-rlw89 GenerateName:seccomp- Namespace:gadget SelfLink: UID:5bb29a54-0c11-47c6-9978-e670d48e08d6 ResourceVersion:7306 Generation:1 CreationTimestamp:2022-02-08 15:19:36 +0000 UTC DeletionTimestamp:<nil> DeletionGracePeriodSeconds:<nil> Labels:map[containerName: gadgetName:seccomp global-trace-id:k96VNBUizlFupAnj namespace:gadget nodeName: outputMode:Status podName:gadget-8kmhf] Annotations:map[gadget.kinvolk.io/operation:generate]
```

In the above printing, the `stop` operation will replace the `generate` one and the trace controller will execute the `stop` without having executed the `generate` one before.
To avoid this behavior, we wait for trace Annotations to become nil before changing the trace operation.
Indeed, the trace controller sets Annotations to nil when it is dealing with an operation.

Best regards.