### PR TITLE
gadgettracermanager/crio: Update ContainerStatus() response syntax 

### DIFF
--- a/pkg/gadgettracermanager/containerutils/crio/crio_test.go
+++ b/pkg/gadgettracermanager/containerutils/crio/crio_test.go
@@ -1,0 +1,79 @@
+// Copyright 2019-2021 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package crio
+
+import (
+	"testing"
+)
+
+func TestParseExtraInfo(t *testing.T) {
+	table := []struct {
+		description string
+		info        map[string]string
+		expectedPid int
+	}{
+		// Invalid params
+		{
+			description: "From empty map",
+			info:        map[string]string{},
+			expectedPid: -1,
+		},
+		{
+			description: "Nil map",
+			info:        nil,
+			expectedPid: -1,
+		},
+		// Format < v1.18.0
+		{
+			description: "Format < v1.18.0: No pid entry",
+			info:        map[string]string{"sandboxID": "myID"},
+			expectedPid: -1,
+		},
+		{
+			description: "Format < v1.18.0: Invalid PID",
+			info:        map[string]string{"sandboxID": "myID", "pid": "abc"},
+			expectedPid: -1,
+		},
+		{
+			description: "Format < v1.18.0: Pid 1234",
+			info:        map[string]string{"sandboxID": "myID", "pid": "1234"},
+			expectedPid: 1234,
+		},
+		// Format > v1.18.0
+		{
+			description: "Format > v1.18.0: No pid entry",
+			info:        map[string]string{"info": "{\"sandboxID\":\"myID\"}"},
+			expectedPid: -1,
+		},
+		{
+			description: "Format > v1.18.0: Invalid PID",
+			info:        map[string]string{"info": "{\"sandboxID\":\"myID\",\"pid\":1.2"},
+			expectedPid: -1,
+		},
+		{
+			description: "Format > v1.18.0: Pid 1234",
+			info:        map[string]string{"info": "{\"sandboxID\":\"myID\",\"pid\":1234}"},
+			expectedPid: 1234,
+		},
+	}
+
+	for _, entry := range table {
+		pid, err := parseExtraInfo(entry.info)
+		if entry.expectedPid != pid || (pid == -1 && err == nil) || (pid != -1 && err != nil) {
+			t.Fatalf("Failed test %q: result %d (err %s) vs expected %d",
+				entry.description, pid, err, entry.expectedPid)
+		}
+	}
+}


### PR DESCRIPTION
# Update ContainerStatus() response syntax 

Commit https://github.com/cri-o/cri-o/commit/be8e876cdabec4e055820502fed227aa44971ddc (>= v1.18.0) changed the syntax of the ContainerStatus() response when adding the runtime specs.

From:
```
{
  "status": {
    "id": "325c19b044c9e6af924cd8eecb309e91d4d78468474e7e83670453dbc2a3c501",
    . . .
  },
  "info": {
    "sandboxID": "ef93e1fa5b3ff08f150368cd5a935ca23460e78bd90da7dcd7c6a916872b1728",
    "pid": 8415,
  }
}
```

To:
```
{
  "status": {
    "id": "325c19b044c9e6af924cd8eecb309e91d4d78468474e7e83670453dbc2a3c501",
    . . .
  },
  "info": {
    "info": "{\"sandboxID\":\"ef93e1fa5b3ff08f150368cd5a935ca23460e78bd90da7dcd7c6a916872b1728\",\"pid\":8415,\"runtimeSpec\":{...}}"
  }
}
```

**NOTE**: Is it worth opening a PR upstream? It doesn't make sense to have `info` twice. 

## How to use

Try IG on OpenShift 4.9 or ARO.

## Testing done

Using `crictl` does not show the change because it is internally managed [here](https://github.com/kubernetes-sigs/cri-tools/blob/bdd49eb736138f0bbff536fcb7909ab1706b2961/cmd/crictl/util.go#L242-L286).

**Before this PR:**
`2022/01/21 13:10:57 Skip pod openshift-network-diagnostics/network-check-target-m98tm: cannot find pid: container status reply from runtime doesn't contain 'pid'`

**After this PR:**
No errors are reported and pods are enriched with the `pid1` of the container.
