### PR TITLE
kubectl-gadget/deploy: Use `privileged` security context constraint on OpenShift

### DIFF
--- a/cmd/kubectl-gadget/deploy.go
+++ b/cmd/kubectl-gadget/deploy.go
@@ -136,6 +136,14 @@ rules:
   resources: ["seccompprofiles"]
   # Required for integration with the Kubernetes Security Profiles Operator
   verbs: ["list", "watch", "create"]
+- apiGroups: ["security.openshift.io"]
+  # It is necessary to use the 'privileged' security context constraints to be
+  # able mount host directories as volumes, use the host networking, among others.
+  # This will be used only when running on OpenShift:
+  # https://docs.openshift.com/container-platform/4.9/authentication/managing-security-context-constraints.html#default-sccs_configuring-internal-oauth
+  resources: ["securitycontextconstraints"]
+  resourceNames: ["privileged"]
+  verbs: ["use"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
# Use `privileged` security context constraint on OpenShift

When running IG on [OpenShift 4.9](https://developers.redhat.com/courses/explore-openshift/openshift-49-playground) and [Azure Red Hat Openshift](https://docs.microsoft.com/en-us/azure/openshift/) (OpenShift 4.8), the gadge DaemonSet fails to deploy the gadget pods with the following error: 

```bash
$ describe daemonsets -n gadget gadget
...
Error creating: pods "gadget-" is forbidden: unable to validate against any security context constraint: [provider "anyuid": Forbidden: not usable by user or serviceaccount, provider restricted: .spec.securityContext.hostNetwork: Invalid value: true: Host network is not allowed to be used, provider restricted: .spec.securityContext.hostPID: Invalid value: true: Host PID is not allowed to be used, spec.volumes[0]: Invalid value: "hostPath": hostPath volumes are not allowed to be used, spec.volumes[1]: Invalid value: "hostPath": hostPath volumes are not allowed to be used, spec.volumes[2]: Invalid value: "hostPath": hostPath volumes are not allowed to be used, spec.volumes[3]: Invalid value: "hostPath": hostPath volumes are not allowed to be used, spec.volumes[4]: Invalid value: "hostPath": hostPath volumes are not allowed to be used, spec.volumes[5]: Invalid value: "hostPath": hostPath volumes are not allowed to be used, spec.volumes[6]: Invalid value: "hostPath": hostPath volumes are not allowed to be used, spec.containers[0].securityContext.capabilities.add: Invalid value: "IPC_LOCK": capability may not be added, spec.containers[0].securityContext.capabilities.add: Invalid value: "NET_ADMIN": capability may not be added, spec.containers[0].securityContext.capabilities.add: Invalid value: "SYSLOG": capability may not be added, spec.containers[0].securityContext.capabilities.add: Invalid value: "SYS_ADMIN": capability may not be added, spec.containers[0].securityContext.capabilities.add: Invalid value: "SYS_PTRACE": capability may not be added, spec.containers[0].securityContext.capabilities.add: Invalid value: "SYS_RESOURCE": capability may not be added, spec.containers[0].securityContext.hostNetwork: Invalid value: true: Host network is not allowed to be used, spec.containers[0].securityContext.hostPID: Invalid value: true: Host PID is not allowed to be used, provider "nonroot": Forbidden: not usable by user or serviceaccount, provider "hostmount-anyuid": Forbidden: not usable by user or serviceaccount, provider "machine-api-termination-handler": Forbidden: not usable by user or serviceaccount, provider "hostnetwork": Forbidden: not usable by user or serviceaccount, provider "hostaccess": Forbidden: not usable by user or serviceaccount, provider "node-exporter": Forbidden: not usable by user or serviceaccount, provider "privileged": Forbidden: not usable by user or serviceaccount, provider "privileged-genevalogging": Forbidden: not usable by user or serviceaccount
```

I tried to create a customised Security Context Constrains (SCC) resource but deployment would fail on non-OpenShift clusters:

```yaml
kind: SecurityContextConstraints
apiVersion: security.openshift.io/v1
metadata:
  name: gadget-scc
allowHostNetwork: true
allowHostPID: true
allowHostDirVolumePlugin: true
allowedCapabilities: ["*"]
allowHostIPC: false
defaultAllowPrivilegeEscalation: false
allowPrivilegeEscalation: false
allowPrivilegedContainer: false
readOnlyRootFilesystem: false
allowHostPorts: false
runAsUser:
  type: RunAsAny
seLinuxContext:
  type: RunAsAny
seccompProfiles:
  - '*'
```

And, in addition, the `privileged` SCC already provides the permissions IG needs (see options [here](https://docs.openshift.com/container-platform/4.9/authentication/managing-security-context-constraints.html#default-sccs_configuring-internal-oauth)):

<details>
  <summary>Privileged SCC</summary>

```bash
$ oc describe scc privileged
Name:                                           privileged
Priority:                                       <none>
Access:
  Users:                                        system:admin,system:serviceaccount:openshift-infra:build-controller
  Groups:                                       system:cluster-admins,system:nodes,system:masters
Settings:
  Allow Privileged:                             true
  Allow Privilege Escalation:                   true
  Default Add Capabilities:                     <none>
  Required Drop Capabilities:                   <none>
  Allowed Capabilities:                         *
  Allowed Seccomp Profiles:                     *
  Allowed Volume Types:                         *
  Allowed Flexvolumes:                          <all>
  Allowed Unsafe Sysctls:                       *
  Forbidden Sysctls:                            <none>
  Allow Host Network:                           true
  Allow Host Ports:                             true
  Allow Host PID:                               true
  Allow Host IPC:                               true
  Read Only Root Filesystem:                    false
  Run As User Strategy: RunAsAny
    UID:                                        <none>
    UID Range Min:                              <none>
    UID Range Max:                              <none>
  SELinux Context Strategy: RunAsAny
    User:                                       <none>
    Role:                                       <none>
    Type:                                       <none>
    Level:                                      <none>
  FSGroup Strategy: RunAsAny
    Ranges:                                     <none>
  Supplemental Groups Strategy: RunAsAny
    Ranges:                                     <none>
```
</details>

<details>
  <summary>Customised SCC</summary>

```bash
$ oc describe scc gadget-scc
Name:                                           gadget-scc
Priority:                                       <none>
Access:
  Users:                                        <none>
  Groups:                                       <none>
Settings:
  Allow Privileged:                             false
  Allow Privilege Escalation:                   false
  Default Add Capabilities:                     <none>
  Required Drop Capabilities:                   <none>
  Allowed Capabilities:                         *
  Allowed Seccomp Profiles:                     *
  Allowed Volume Types:                         *
  Allowed Flexvolumes:                          <all>
  Allowed Unsafe Sysctls:                       <none>
  Forbidden Sysctls:                            <none>
  Allow Host Network:                           true
  Allow Host Ports:                             false
  Allow Host PID:                               true
  Allow Host IPC:                               false
  Read Only Root Filesystem:                    false
  Run As User Strategy: RunAsAny
    UID:                                        <none>
    UID Range Min:                              <none>
    UID Range Max:                              <none>
  SELinux Context Strategy: RunAsAny
    User:                                       <none>
    Role:                                       <none>
    Type:                                       <none>
    Level:                                      <none>
  FSGroup Strategy: RunAsAny
    Ranges:                                     <none>
  Supplemental Groups Strategy: RunAsAny
    Ranges:                                     <none>
```
</details>

## How to use

Try to deploy IG on OpenShift 4.9 or ARO.
