### PR TITLE
github action: print lint output

### DIFF
--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -79,6 +79,9 @@ jobs:
       with:
         version: v1.43.0
         working-directory: /home/runner/work/inspektor-gadget/inspektor-gadget
+        # Workaround to display the output:
+        # https://github.com/golangci/golangci-lint-action/issues/119#issuecomment-981090648
+        args: "--out-${NO_FUTURE}format colored-line-number"
 
   build-kubectl-gadget:
     name: Build kubectl-gadget


### PR DESCRIPTION
An issue with GitHub Actions not printing annotations and golangci/golangci-lint-action block the output from being printed. This patch is a workaround for this.

See https://github.com/golangci/golangci-lint-action/issues/119#issuecomment-981090648
