### PR TITLE
Fix localtime volume

### DIFF
--- a/cmd/kubectl-gadget/deploy.go
+++ b/cmd/kubectl-gadget/deploy.go
@@ -310,8 +310,6 @@ spec:
           mountPath: /sys/fs/cgroup
         - name: bpffs
           mountPath: /sys/fs/bpf
-        - name: localtime
-          mountPath: /etc/localtime
       tolerations:
       - effect: NoSchedule
         operator: Exists
@@ -336,9 +334,6 @@ spec:
       - name: debugfs
         hostPath:
           path: /sys/kernel/debug
-      - name: localtime
-        hostPath:
-          path: /etc/localtime
 `
 
 type parameters struct {

--- a/gadget.Dockerfile
+++ b/gadget.Dockerfile
@@ -65,7 +65,8 @@ RUN set -ex; \
 	apt-get update && \
 	apt-get install -y --no-install-recommends \
 		ca-certificates curl jq wget xz-utils binutils rpm2cpio cpio && \
-		rmdir /usr/src && ln -sf /host/usr/src /usr/src
+		rmdir /usr/src && ln -sf /host/usr/src /usr/src && \
+		rm /etc/localtime && ln -sf /host/etc/localtime /etc/localtime
 
 COPY gadget-container/entrypoint.sh gadget-container/cleanup.sh /
 


### PR DESCRIPTION
/etc/localtime is normally a symlink to a regular file such as
/usr/share/zoneinfo/Etc/UTC. However, recent versions of Flatcar don't
have it anymore, and it could be created as a directory.

The gadget pod cannot control whether /etc/localtime on the host is a
directory or a file. This means it is not safe to have a host volume in
the gadget pod with the /etc/localtime -> /etc/localtime bind mount.

As a workaround, remove this host volume and instead let's have a
symlink /etc/localtime -> /host/etc/localtime in the pod. As opposed to
bind mounts, symlinks can be created regardless if the target is a
directory or a file.

See also: https://github.com/flatcar-linux/Flatcar/issues/324