### PR TITLE
gadgets: Fix error handling when perf ring buffer is closed

### DIFF
--- a/pkg/gadgets/dns/tracer/tracer.go
+++ b/pkg/gadgets/dns/tracer/tracer.go
@@ -17,6 +17,7 @@ package tracer
 import (
 	"bytes"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"os"
 	"sync"
@@ -300,7 +301,7 @@ func (t *Tracer) listen(key string, rd *perf.Reader, f func(name, pktType, qType
 	for {
 		record, err := rd.Read()
 		if err != nil {
-			if perf.IsClosed(err) {
+			if errors.Is(err, perf.ErrClosed) {
 				return
 			}
 			log.Errorf("Error while reading from perf event reader (%s): %s", key, err)

--- a/pkg/gadgets/execsnoop/tracer/core/tracer.go
+++ b/pkg/gadgets/execsnoop/tracer/core/tracer.go
@@ -22,6 +22,7 @@ package tracer
 import "C"
 
 import (
+	"errors"
 	"fmt"
 	"path/filepath"
 	"unsafe"
@@ -148,7 +149,7 @@ func (t *Tracer) run() {
 	for {
 		record, err := t.reader.Read()
 		if err != nil {
-			if err == perf.ErrClosed {
+			if errors.Is(err, perf.ErrClosed) {
 				// nothing to do, we're done
 				return
 			}

--- a/pkg/gadgets/oomkill/tracer/tracer.go
+++ b/pkg/gadgets/oomkill/tracer/tracer.go
@@ -22,6 +22,7 @@ package tracer
 import "C"
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -142,7 +143,7 @@ func (t *Tracer) run() {
 	for {
 		record, err := t.reader.Read()
 		if err != nil {
-			if err == perf.ErrClosed {
+			if errors.Is(err, perf.ErrClosed) {
 				return
 			}
 


### PR DESCRIPTION
Use "errors.Is(err, perf.ErrClosed)" as "err == perf.ErrClosed" doesn't
work because the error is wrapped. Also avoid using "perf.IsClosed()"
as it will be removed in cilium/ebpf@v0.8.0 [1].

[1] https://github.com/cilium/ebpf/commit/a02484a72f85d00556bbf48ca89dfe68aea92a28

