### PR TITLE
k8s: Fix log format when container pid is not found

### DIFF
--- a/pkg/gadgettracermanager/k8s/k8s.go
+++ b/pkg/gadgettracermanager/k8s/k8s.go
@@ -17,8 +17,9 @@ package k8s
 import (
 	"context"
 	"fmt"
-	"log"
 	"strings"
+
+	log "github.com/sirupsen/logrus"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -130,11 +131,11 @@ func (k *K8sClient) PodToContainers(pod *v1.Pod) []pb.ContainerDefinition {
 
 		pid, err := k.criClient.PidFromContainerId(s.ContainerID)
 		if err != nil {
-			log.Printf("Skip pod %s/%s: cannot find pid: %v", pod.GetNamespace(), pod.GetName(), err)
+			log.Warnf("Skip pod %s/%s: cannot find pid: %v", pod.GetNamespace(), pod.GetName(), err)
 			continue
 		}
 		if pid == 0 {
-			log.Printf("Skip pod %s/%s: got zero pid", pod.GetNamespace(), pod.GetName())
+			log.Warnf("Skip pod %s/%s: got zero pid", pod.GetNamespace(), pod.GetName())
 			continue
 		}
 


### PR DESCRIPTION
# Fix log format when container pid is not found

Align these two logs to the same format as other logs:

Before this PR:
```
time="2022-02-17T15:13:06Z" level=info msg="pubsub: ADD_CONTAINER: openshift-marketplace/community-operators-ll4dn/registry-server"
time="2022-02-17T15:13:14Z" level=info msg="pubsub: REMOVE_CONTAINER: openshift-marketplace/community-operators-ll4dn/registry-server"
time="2022-02-17T15:13:39Z" level=info msg="pubsub: ADD_CONTAINER: openshift-marketplace/redhat-operators-xgmgs/registry-server"
time="2022-02-17T15:13:46Z" level=info msg="pubsub: REMOVE_CONTAINER: openshift-marketplace/redhat-operators-xgmgs/registry-server"
2022/02/17 15:13:53 Skip pod default/mypod: cannot find pid: couldn't extract pid from container status reply: {"sandboxID":"aca1f72fe633bb310ae2941874ad4e0b19bf70373e7831691a8374669486f943","pid":0," ...
```
After this PR:
```
time="2022-02-17T16:04:01Z" level=info msg="pubsub: ADD_CONTAINER: default/mypod/mypod"
time="2022-02-17T16:04:19Z" level=warning msg="Skip pod default/mypod: cannot find pid: couldn't extract pid from container status reply: {\"sandboxID\":\"e9706ffd8327ca213fa825fab031c97e2e7b31fa0385de652a868edd643d4821\",\"pid\":0,\ ...
```