### PR TITLE
integration-tests: Do not run tests if pods are not ready

### DIFF
--- a/integration/Makefile
+++ b/integration/Makefile
@@ -18,13 +18,13 @@ push:
 test:
 	if [ "x$(KUBECONFIG)" = "x" ] ; then \
 		echo "Running tests without KUBECONFIG variable" ; \
-		docker run -i \
+		docker run --rm -i \
 			--net=host \
 			$(TESTS_DOCKER_ARGS) \
 			$(CONTAINER_REPO)test:$(IMAGE_TAG) ; \
 	else \
 		echo "Running tests with KUBECONFIG = $(KUBECONFIG)" ; \
-		docker run -i \
+		docker run --rm -i \
 			--net=host \
 			-e KUBECONFIG=/opt/kubeconfig/$(shell basename "$(KUBECONFIG)") \
 			-v $(shell dirname "$(KUBECONFIG)"):/opt/kubeconfig \

--- a/integration/command.go
+++ b/integration/command.go
@@ -70,7 +70,15 @@ var deployInspektorGadget *command = &command{
 
 var waitUntilInspektorGadgetPodsDeployed *command = &command{
 	name: "Wait until the gadget pods are started",
-	cmd:  "for POD in $(sleep 5 ; kubectl get pod -n gadget -l k8s-app=gadget -o name) ; do kubectl wait --timeout=30s -n gadget --for=condition=ready $POD ; done ; kubectl get pod -n gadget",
+	cmd: `
+	for POD in $(sleep 5; kubectl get pod -n gadget -l k8s-app=gadget -o name) ; do
+		kubectl wait --timeout=30s -n gadget --for=condition=ready $POD
+		if [ $? -ne 0 ]; then
+			kubectl get pod -n gadget
+			kubectl describe $POD -n gadget
+			exit 1
+		fi
+	done`,
 }
 
 var waitUntilInspektorGadgetPodsInitialized *command = &command{


### PR DESCRIPTION
# Do not run tests if pods are not ready

If `kubectl wait` goes in timeout because the pod is not yet ready (Or will never be ready, e.g. fail to pull image), the tests will start unnecessary running anyway using resources that can be used by others.