### PR TITLE
cmd/kubectl-gadget: Fix handling of trace operation warning

### DIFF
--- a/cmd/kubectl-gadget/utils/trace.go
+++ b/cmd/kubectl-gadget/utils/trace.go
@@ -503,11 +503,7 @@ func waitForTraceState(traceID string, expectedState string) (*gadgetv1alpha1.Tr
 		trace := event.Object.(*gadgetv1alpha1.Trace)
 
 		if trace.Status.OperationWarning != "" {
-			watchedTracesNumber++
-
 			nodeWarnings[trace.Spec.Node] = trace.Status.OperationWarning
-
-			return false, nil
 		}
 
 		if trace.Status.OperationError != "" {


### PR DESCRIPTION
An operation warning doesn't mean an error, hence the logic should
just store the warning and continue ahead instead of returning.

ref https://github.com/kinvolk/inspektor-gadget/pull/438#discussion_r793902479

