### PR TITLE
Uniform trace status cleanup

### DIFF
--- a/pkg/controllers/trace_controller.go
+++ b/pkg/controllers/trace_controller.go
@@ -248,6 +248,8 @@ func (r *TraceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 
 	// Call gadget operation
 	traceBeforeOperation := trace.DeepCopy()
+	trace.Status.OperationError = ""
+	trace.Status.OperationWarning = ""
 	patch := client.MergeFrom(traceBeforeOperation)
 	gadgetOperation.Operation(req.NamespacedName.String(), trace)
 

--- a/pkg/gadgets/biolatency/gadget.go
+++ b/pkg/gadgets/biolatency/gadget.go
@@ -89,8 +89,6 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 	}
 
 	if t.started {
-		trace.Status.OperationError = ""
-		trace.Status.Output = ""
 		trace.Status.State = "Started"
 		return
 	}
@@ -107,7 +105,6 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 	}
 	t.started = true
 
-	trace.Status.OperationError = ""
 	trace.Status.Output = ""
 	trace.Status.State = "Started"
 	return
@@ -144,7 +141,6 @@ func (t *Trace) Stop(trace *gadgetv1alpha1.Trace) {
 
 	output := t.stdout.String()
 
-	trace.Status.OperationError = ""
 	trace.Status.Output = output
 	trace.Status.State = "Completed"
 	return

--- a/pkg/gadgets/dns/gadget.go
+++ b/pkg/gadgets/dns/gadget.go
@@ -147,8 +147,6 @@ func (t *Trace) publishEvent(
 
 func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 	if t.started {
-		trace.Status.OperationError = ""
-		trace.Status.Output = ""
 		trace.Status.State = "Started"
 		return
 	}
@@ -220,10 +218,7 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 	}
 	t.started = true
 
-	trace.Status.OperationError = ""
-	trace.Status.Output = ""
 	trace.Status.State = "Started"
-	return
 }
 
 func (t *Trace) Stop(trace *gadgetv1alpha1.Trace) {
@@ -237,7 +232,5 @@ func (t *Trace) Stop(trace *gadgetv1alpha1.Trace) {
 	t.tracer = nil
 	t.started = false
 
-	trace.Status.OperationError = ""
 	trace.Status.State = "Stopped"
-	return
 }

--- a/pkg/gadgets/execsnoop/gadget.go
+++ b/pkg/gadgets/execsnoop/gadget.go
@@ -89,7 +89,6 @@ func (f *TraceFactory) Operations() map[string]gadgets.TraceOperation {
 
 func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 	if t.started {
-		gadgets.CleanupTraceStatus(trace)
 		trace.Status.State = "Started"
 		return
 	}
@@ -128,7 +127,6 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 
 	t.started = true
 
-	gadgets.CleanupTraceStatus(trace)
 	trace.Status.State = "Started"
 }
 
@@ -142,6 +140,5 @@ func (t *Trace) Stop(trace *gadgetv1alpha1.Trace) {
 	t.tracer = nil
 	t.started = false
 
-	trace.Status.OperationError = ""
 	trace.Status.State = "Stopped"
 }

--- a/pkg/gadgets/filetop/gadget.go
+++ b/pkg/gadgets/filetop/gadget.go
@@ -103,7 +103,6 @@ func (f *TraceFactory) Operations() map[string]gadgets.TraceOperation {
 
 func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 	if t.started {
-		gadgets.CleanupTraceStatus(trace)
 		trace.Status.State = "Started"
 		return
 	}
@@ -122,7 +121,6 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 		if val, ok := params["max_rows"]; ok {
 			maxRows, err = strconv.Atoi(val)
 			if err != nil {
-				gadgets.CleanupTraceStatus(trace)
 				trace.Status.OperationError = fmt.Sprintf("%q is not valid for ouput_rows", val)
 				return
 			}
@@ -131,7 +129,6 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 		if val, ok := params["interval"]; ok {
 			intervalSeconds, err = strconv.Atoi(val)
 			if err != nil {
-				gadgets.CleanupTraceStatus(trace)
 				trace.Status.OperationError = fmt.Sprintf("%q is not valid for interval", val)
 				return
 			}
@@ -140,7 +137,6 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 		if val, ok := params["sortby"]; ok {
 			sortBy, err = types.ParseSortBy(val)
 			if err != nil {
-				gadgets.CleanupTraceStatus(trace)
 				trace.Status.OperationError = fmt.Sprintf("%q is not valid for sortby", val)
 				return
 			}
@@ -149,7 +145,6 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 		if val, ok := params["all_files"]; ok {
 			allFiles, err = strconv.ParseBool(val)
 			if err != nil {
-				gadgets.CleanupTraceStatus(trace)
 				trace.Status.OperationError = fmt.Sprintf("%q is not valid for all_files", val)
 				return
 			}
@@ -201,7 +196,6 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 	t.tracer = tracer
 	t.started = true
 
-	gadgets.CleanupTraceStatus(trace)
 	trace.Status.State = "Started"
 }
 
@@ -215,6 +209,5 @@ func (t *Trace) Stop(trace *gadgetv1alpha1.Trace) {
 	t.tracer = nil
 	t.started = false
 
-	gadgets.CleanupTraceStatus(trace)
 	trace.Status.State = "Stopped"
 }

--- a/pkg/gadgets/fsslower/gadget.go
+++ b/pkg/gadgets/fsslower/gadget.go
@@ -96,7 +96,6 @@ func (f *TraceFactory) Operations() map[string]gadgets.TraceOperation {
 
 func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 	if t.started {
-		gadgets.CleanupTraceStatus(trace)
 		trace.Status.State = "Started"
 		return
 	}
@@ -115,7 +114,6 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 	var err error
 
 	if trace.Spec.Parameters == nil {
-		gadgets.CleanupTraceStatus(trace)
 		trace.Status.OperationError = "missing parameters"
 		return
 	}
@@ -124,7 +122,6 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 
 	filesystem, ok := params["filesystem"]
 	if !ok {
-		gadgets.CleanupTraceStatus(trace)
 		trace.Status.OperationError = "missing filesystem"
 		return
 	}
@@ -135,7 +132,6 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 	if ok {
 		minLatencyParsed, err := strconv.ParseUint(val, 10, 32)
 		if err != nil {
-			gadgets.CleanupTraceStatus(trace)
 			trace.Status.OperationError = fmt.Sprintf("%q is not valid for minlatency", val)
 			return
 		}
@@ -149,14 +145,12 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 	}
 	t.tracer, err = coretracer.NewTracer(config, t.resolver, eventCallback, trace.Spec.Node)
 	if err != nil {
-		gadgets.CleanupTraceStatus(trace)
 		trace.Status.OperationError = fmt.Sprintf("failed to create tracer: %s", err)
 		return
 	}
 
 	t.started = true
 
-	gadgets.CleanupTraceStatus(trace)
 	trace.Status.State = "Started"
 }
 
@@ -170,6 +164,5 @@ func (t *Trace) Stop(trace *gadgetv1alpha1.Trace) {
 	t.tracer = nil
 	t.started = false
 
-	trace.Status.OperationError = ""
 	trace.Status.State = "Stopped"
 }

--- a/pkg/gadgets/helpers.go
+++ b/pkg/gadgets/helpers.go
@@ -48,13 +48,6 @@ func TracePinPathFromNamespacedName(n types.NamespacedName) string {
 	return TracePinPath(n.Namespace, n.Name)
 }
 
-func CleanupTraceStatus(trace *gadgetv1alpha1.Trace) {
-	trace.Status.OperationError = ""
-	trace.Status.OperationWarning = ""
-	trace.Status.Output = ""
-	trace.Status.State = ""
-}
-
 func ContainerSelectorFromContainerFilter(f *gadgetv1alpha1.ContainerFilter) *pb.ContainerSelector {
 	if f == nil {
 		return &pb.ContainerSelector{}

--- a/pkg/gadgets/mountsnoop/gadget.go
+++ b/pkg/gadgets/mountsnoop/gadget.go
@@ -89,7 +89,6 @@ func (f *TraceFactory) Operations() map[string]gadgets.TraceOperation {
 
 func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 	if t.started {
-		gadgets.CleanupTraceStatus(trace)
 		trace.Status.State = "Started"
 		return
 	}
@@ -128,7 +127,6 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 
 	t.started = true
 
-	gadgets.CleanupTraceStatus(trace)
 	trace.Status.State = "Started"
 }
 
@@ -142,6 +140,5 @@ func (t *Trace) Stop(trace *gadgetv1alpha1.Trace) {
 	t.tracer = nil
 	t.started = false
 
-	trace.Status.OperationError = ""
 	trace.Status.State = "Stopped"
 }

--- a/pkg/gadgets/networkpolicy/gadget.go
+++ b/pkg/gadgets/networkpolicy/gadget.go
@@ -175,4 +175,5 @@ func (f *Trace) Stop(trace *gadgetv1alpha1.Trace) {
 	log.Infof("Network Policy Advisor output:\n%s\n", output)
 
 	trace.Status.Output = output
+	trace.Status.State = "Stopped"
 }

--- a/pkg/gadgets/networkpolicy/gadget.go
+++ b/pkg/gadgets/networkpolicy/gadget.go
@@ -102,9 +102,8 @@ func (f *TraceFactory) Operations() map[string]gadgets.TraceOperation {
 }
 
 func (f *Trace) Start(trace *gadgetv1alpha1.Trace) {
+	trace.Status.Output = ""
 	if f.started {
-		trace.Status.OperationError = ""
-		trace.Status.Output = ""
 		trace.Status.State = "Started"
 		return
 	}
@@ -130,10 +129,7 @@ func (f *Trace) Start(trace *gadgetv1alpha1.Trace) {
 	}
 	f.started = true
 
-	trace.Status.OperationError = ""
-	trace.Status.Output = ""
 	trace.Status.State = "Started"
-	return
 }
 
 func (f *Trace) UpdateOutput(trace *gadgetv1alpha1.Trace) {
@@ -144,9 +140,7 @@ func (f *Trace) UpdateOutput(trace *gadgetv1alpha1.Trace) {
 	output := f.out.String()
 	log.Infof("Network Policy Advisor output:\n%s\n", output)
 
-	trace.Status.OperationError = ""
 	trace.Status.Output = output
-	return
 }
 
 func (f *Trace) Report(trace *gadgetv1alpha1.Trace) {
@@ -160,9 +154,7 @@ func (f *Trace) Report(trace *gadgetv1alpha1.Trace) {
 	adv.GeneratePolicies()
 	output := adv.FormatPolicies()
 
-	trace.Status.OperationError = ""
 	trace.Status.Output = output
-	return
 }
 
 func (f *Trace) Stop(trace *gadgetv1alpha1.Trace) {
@@ -182,7 +174,5 @@ func (f *Trace) Stop(trace *gadgetv1alpha1.Trace) {
 	output := f.out.String()
 	log.Infof("Network Policy Advisor output:\n%s\n", output)
 
-	trace.Status.OperationError = ""
 	trace.Status.Output = output
-	return
 }

--- a/pkg/gadgets/oomkill/gadget.go
+++ b/pkg/gadgets/oomkill/gadget.go
@@ -85,8 +85,6 @@ func (f *TraceFactory) Operations() map[string]gadgets.TraceOperation {
 
 func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 	if t.started {
-		gadgets.CleanupTraceStatus(trace)
-
 		trace.Status.State = "Started"
 
 		return
@@ -116,7 +114,6 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 
 	t.started = true
 
-	gadgets.CleanupTraceStatus(trace)
 	trace.Status.State = "Started"
 }
 
@@ -130,6 +127,5 @@ func (t *Trace) Stop(trace *gadgetv1alpha1.Trace) {
 	t.tracer = nil
 	t.started = false
 
-	trace.Status.OperationError = ""
 	trace.Status.State = "Stopped"
 }

--- a/pkg/gadgets/opensnoop/gadget.go
+++ b/pkg/gadgets/opensnoop/gadget.go
@@ -89,7 +89,6 @@ func (f *TraceFactory) Operations() map[string]gadgets.TraceOperation {
 
 func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 	if t.started {
-		gadgets.CleanupTraceStatus(trace)
 		trace.Status.State = "Started"
 		return
 	}
@@ -127,8 +126,6 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 	}
 
 	t.started = true
-
-	gadgets.CleanupTraceStatus(trace)
 	trace.Status.State = "Started"
 }
 
@@ -142,6 +139,5 @@ func (t *Trace) Stop(trace *gadgetv1alpha1.Trace) {
 	t.tracer = nil
 	t.started = false
 
-	trace.Status.OperationError = ""
 	trace.Status.State = "Stopped"
 }

--- a/pkg/gadgets/process-collector/gadget.go
+++ b/pkg/gadgets/process-collector/gadget.go
@@ -67,25 +67,21 @@ func (f *TraceFactory) Operations() map[string]gadgets.TraceOperation {
 func (t *Trace) Collect(trace *gadgetv1alpha1.Trace) {
 	events, err := tracer.RunCollector(t.resolver, trace.Spec.Node, gadgets.TracePinPath(trace.ObjectMeta.Namespace, trace.ObjectMeta.Name))
 	if err != nil {
-		gadgets.CleanupTraceStatus(trace)
 		trace.Status.OperationError = err.Error()
 		return
 	}
 
 	if len(events) == 0 {
-		gadgets.CleanupTraceStatus(trace)
 		trace.Status.OperationWarning = "No container matches the requested filter"
 		return
 	}
 
 	output, err := json.MarshalIndent(events, "", " ")
 	if err != nil {
-		gadgets.CleanupTraceStatus(trace)
 		trace.Status.OperationError = fmt.Sprintf("failed marshalling processes: %s", err)
 		return
 	}
 
-	trace.Status.OperationError = ""
 	trace.Status.Output = string(output)
 	trace.Status.State = "Completed"
 }

--- a/pkg/gadgets/seccomp/gadget.go
+++ b/pkg/gadgets/seccomp/gadget.go
@@ -376,10 +376,9 @@ func (t *Trace) containerTerminated(trace *gadgetv1alpha1.Trace, event pubsub.Pu
 }
 
 func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
+	trace.Status.Output = ""
 	if t.started {
-		gadgets.CleanupTraceStatus(trace)
 		trace.Status.State = "Started"
-
 		t.policyGenerated = false
 		return
 	}
@@ -418,7 +417,6 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 	t.started = true
 	t.policyGenerated = false
 
-	gadgets.CleanupTraceStatus(trace)
 	trace.Status.State = "Started"
 }
 
@@ -515,7 +513,6 @@ func (t *Trace) Generate(trace *gadgetv1alpha1.Trace) {
 		}
 
 		trace.Status.Output = string(output)
-		trace.Status.OperationError = ""
 	case "ExternalResource":
 		podName := fmt.Sprintf("%s/%s", trace.Spec.Filter.Namespace, trace.Spec.Filter.Podname)
 
@@ -532,7 +529,6 @@ func (t *Trace) Generate(trace *gadgetv1alpha1.Trace) {
 			trace.Status.OperationError = fmt.Sprintf("Failed to update resource: %s", err)
 			return
 		}
-		trace.Status.OperationError = ""
 	case "File":
 		fallthrough
 	default:

--- a/pkg/gadgets/sigsnoop/gadget.go
+++ b/pkg/gadgets/sigsnoop/gadget.go
@@ -95,10 +95,7 @@ func (f *TraceFactory) Operations() map[string]gadgets.TraceOperation {
 
 func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 	if t.started {
-		gadgets.CleanupTraceStatus(trace)
-
 		trace.Status.State = "Started"
-
 		return
 	}
 
@@ -124,7 +121,6 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 	if pid, ok := params["pid"]; ok {
 		pidParsed, err := strconv.ParseInt(pid, 10, 32)
 		if err != nil {
-			gadgets.CleanupTraceStatus(trace)
 			trace.Status.OperationError = fmt.Sprintf("%q is not valid for PID", pid)
 			return
 		}
@@ -136,7 +132,6 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 	if failed, ok := params["failed"]; ok {
 		failedParsed, err := strconv.ParseBool(failed)
 		if err != nil {
-			gadgets.CleanupTraceStatus(trace)
 			trace.Status.OperationError = fmt.Sprintf("%q is not valid for failed", failed)
 			return
 		}
@@ -160,7 +155,6 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 
 	t.started = true
 
-	gadgets.CleanupTraceStatus(trace)
 	trace.Status.State = "Started"
 }
 
@@ -174,6 +168,5 @@ func (t *Trace) Stop(trace *gadgetv1alpha1.Trace) {
 	t.tracer = nil
 	t.started = false
 
-	trace.Status.OperationError = ""
 	trace.Status.State = "Stopped"
 }

--- a/pkg/gadgets/snisnoop/gadget.go
+++ b/pkg/gadgets/snisnoop/gadget.go
@@ -110,7 +110,6 @@ func genPubSubKey(name string) pubSubKey {
 
 func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 	if t.started {
-		gadgets.CleanupTraceStatus(trace)
 		trace.Status.State = "Started"
 		return
 	}
@@ -243,9 +242,7 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 	}
 	t.started = true
 
-	gadgets.CleanupTraceStatus(trace)
 	trace.Status.State = "Started"
-	return
 }
 
 func (t *Trace) Stop(trace *gadgetv1alpha1.Trace) {
@@ -259,7 +256,5 @@ func (t *Trace) Stop(trace *gadgetv1alpha1.Trace) {
 	t.tracer = nil
 	t.started = false
 
-	gadgets.CleanupTraceStatus(trace)
 	trace.Status.State = "Stopped"
-	return
 }

--- a/pkg/gadgets/traceloop/gadget.go
+++ b/pkg/gadgets/traceloop/gadget.go
@@ -79,8 +79,6 @@ func (f *TraceFactory) Operations() map[string]gadgets.TraceOperation {
 			Operation: func(name string, trace *gadgetv1alpha1.Trace) {
 				t := f.LookupOrCreate(name, n).(*Trace)
 				if t.started {
-					trace.Status.OperationError = ""
-					trace.Status.Output = ""
 					trace.Status.State = "Started"
 					return
 				}
@@ -135,8 +133,6 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 	}
 	t.started = true
 
-	trace.Status.OperationError = ""
-	trace.Status.Output = ""
 	trace.Status.State = "Started"
 }
 
@@ -176,7 +172,5 @@ func (t *Trace) Stop(trace *gadgetv1alpha1.Trace) {
 		return
 	}
 
-	trace.Status.OperationError = ""
-	trace.Status.Output = ""
 	trace.Status.State = "Stopped"
 }


### PR DESCRIPTION
```
    gadgets.CleanupTraceStatus() was being used at some many different
    places decreasing code readability. This commit modifies the trace
    controller to clean the status of the trace before calling the gadget,
    so it doesn't have to worry about cleaning its status up.
```

Fixes https://github.com/kinvolk/inspektor-gadget/issues/522