### PR TITLE
`tcptracer`: Add guide and integration test

### DIFF
--- a/docs/guides/oomkill.md
+++ b/docs/guides/oomkill.md
@@ -23,7 +23,7 @@ NODE             NAMESPACE        POD              CONTAINER        KPID   KCOMM
 ```
 
 Indeed, it is waiting for OOM killer to kick in and kills a process in `oomkill-demo` namespace (you can use `-A` to monitor all namespaces and then be sure to not miss any event).
-So, in *an other terminal*, `exec` a container and run this `perl` one-liner to exhaust the memory:
+So, in *an other terminal*, `exec` a container and run this command to exhaust the memory:
 
 ```bash
 $ kubectl get pod -n oomkill-demo

--- a/docs/guides/tcptracer.md
+++ b/docs/guides/tcptracer.md
@@ -1,0 +1,116 @@
+---
+title: 'The "tcptracer" gadget'
+weight: 10
+---
+
+The `tcptracer` gadget is used to monitor tcp connections.
+
+## How to use it?
+
+First, we need to create one pod:
+
+```bash
+$ kubectl run busybox --image busybox:latest sleep inf
+pod/busybox created
+```
+
+You can now use the gadget, but output will be empty:
+
+```bash
+$ kubectl gadget tcptracer
+NODE             NAMESPACE        POD              CONTAINER        KPID   KCOMM            PAGES  TPID             TCOMM
+```
+
+Indeed, it is waiting for TCP connection to be established in the `default` namespace (you can use `-A` to monitor all namespaces and then be sure to not miss any event).
+So, in *an other terminal*, `exec` a container and run this `wget`:
+
+```bash
+$ kubectl exec -ti busybox -- wget https://www.kinvolk.io
+Connecting to www.kinvolk.io (188.114.97.3:443)
+wget: note: TLS certificate validation not implemented
+saving to 'index.html'
+index.html           100% |*************************************************************************************************| 42627  0:00:00 ETA
+'index.html' saved
+```
+
+Go back to *the first terminal* and see:
+
+```bash
+NODE             NAMESPACE        POD              CONTAINER        T PID    COMM             IP  SADDR            DADDR            SPORT   DPORT
+minikube         <>               <>               <>               C 16266  wget             4   172.17.0.3       188.114.97.3     34878   443
+```
+
+The printed lined correspond to TCP connection established with the socket.
+Here is the full legend of all the fields:
+
+* `T`: How the TCP connection was established, it can be one of the following values:
+	* `C`: The TCP connection was established after a `connect()` system call.
+	* `A`: The TCP connection was established after an `accept()` system call.
+	* `X`: The TCP connection was closed following the `close()` system call.
+	* `U`: The TCP connection was either established or closed following an unknown reason.
+* `PID`: The PID which established the TCP connection.
+* `COMM`: The command corresponding to the PID.
+* `IP`: The IP version (either 4 or 6).
+* `SADDR`: The source IP address.
+* `DADDR`: The destination IP address.
+* `SPORT`: The source port.
+* `DPORT`: The destination port.
+
+So, the above line should be read like this: "Command `wget`, which has PID 19981, established a TCP connection through IP version 4, using the `connect()` system call, from address 172.17.0.3 and port 16266 towards address 188.114.97.3 and port 433"
+
+Note that, IP 188.114.97.3 corresponds to `kinvolk.io` while port 443 is the port generally used for HTTPS.
+
+## Only print some information
+
+You can restrain the information printed using `-o custom-columns=column0,...,columnN`.
+This command will only show the PID and command:
+
+```bash
+$ kubectl gadget tcptracer -A -o custom-columns=pid,comm
+PID    COMM
+28489  wget
+```
+
+The following command is the same as default printing:
+
+```bash
+$ kubectl gadget tcptracer -A -o custom-columns=node,namespace,container,pod,t,pid,comm,ip,saddr,daddr,sport,dport
+NODE             NAMESPACE        CONTAINER        POD              T PID    COMM             IP  SADDR            DADDR            SPORT   DPORT
+minikube         <>               <>               <>               C 16266  wget             4   172.17.0.3       188.114.97.3     34878   443
+```
+
+## Use JSON output
+
+This gadget supports JSON output, for this simply use `-o json`:
+
+```bash
+$ kubectl gadget tcptracer -o json
+{"type":"normal","node":"minikube","namespace":"\u003c\u003e","pod":"\u003c\u003e","container":"\u003c\u003e","pid":16734,"comm":"wget","ipversion":4,"saddr":"172.17.0.3","daddr":"188.114.97.3","sport":35186,"dport":443,"operation":"connect"}
+# You can use jq to make the output easier to read:
+$ kubectl gadget tcptracer -o json | jq
+{
+  "type": "normal",
+  "node": "minikube",
+  "namespace": "<>",
+  "pod": "<>",
+  "container": "<>",
+  "pid": 16734,
+  "comm": "wget",
+  "ipversion": 4,
+  "saddr": "172.17.0.3",
+  "daddr": "188.114.97.3",
+  "sport": 35186,
+  "dport": 443,
+  "operation": "connect"
+}
+```
+
+## Clean everything
+
+Congratulations! You reached the end of this guide!
+You can now delete the resource we created:
+
+```bash
+$ kubectl delete pod busybox
+pod "busybox" deleted
+```

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -246,33 +246,6 @@ func TestDns(t *testing.T) {
 	runCommands(commands, t)
 }
 
-func TestSnisnoop(t *testing.T) {
-	ns := generateTestNamespaceName("test-snisnoop")
-
-	t.Parallel()
-
-	snisnoopCmd := &command{
-		name:           "Start snisnoop gadget",
-		cmd:            fmt.Sprintf("$KUBECTL_GADGET snisnoop -n %s", ns),
-		expectedRegexp: `test-pod\s+kinvolk.io`,
-		startAndStop:   true,
-	}
-
-	commands := []*command{
-		createTestNamespaceCommand(ns),
-		snisnoopCmd,
-		{
-			name:           "Run pod which interacts with snisnoop",
-			cmd:            busyboxPodCommand(ns, "while true; do wget -q -O /dev/null https://kinvolk.io; done"),
-			expectedRegexp: "pod/test-pod created",
-		},
-		waitUntilTestPodReadyCommand(ns),
-		deleteTestNamespaceCommand(ns),
-	}
-
-	runCommands(commands, t)
-}
-
 func TestExecsnoop(t *testing.T) {
 	ns := generateTestNamespaceName("test-execsnoop")
 
@@ -576,6 +549,33 @@ func TestSigsnoop(t *testing.T) {
 	runCommands(commands, t)
 }
 
+func TestSnisnoop(t *testing.T) {
+	ns := generateTestNamespaceName("test-snisnoop")
+
+	t.Parallel()
+
+	snisnoopCmd := &command{
+		name:           "Start snisnoop gadget",
+		cmd:            fmt.Sprintf("$KUBECTL_GADGET snisnoop -n %s", ns),
+		expectedRegexp: `test-pod\s+kinvolk.io`,
+		startAndStop:   true,
+	}
+
+	commands := []*command{
+		createTestNamespaceCommand(ns),
+		snisnoopCmd,
+		{
+			name:           "Run pod which interacts with snisnoop",
+			cmd:            busyboxPodCommand(ns, "while true; do wget -q -O /dev/null https://kinvolk.io; done"),
+			expectedRegexp: "pod/test-pod created",
+		},
+		waitUntilTestPodReadyCommand(ns),
+		deleteTestNamespaceCommand(ns),
+	}
+
+	runCommands(commands, t)
+}
+
 func TestSocketCollector(t *testing.T) {
 	ns := generateTestNamespaceName("test-socket-collector")
 
@@ -615,6 +615,33 @@ func TestTcpconnect(t *testing.T) {
 	commands := []*command{
 		createTestNamespaceCommand(ns),
 		tcpconnectCmd,
+		{
+			name:           "Run pod which opens TCP socket",
+			cmd:            busyboxPodCommand(ns, "while true; do wget -q -O /dev/null -T 3 http://1.1.1.1; done"),
+			expectedRegexp: "pod/test-pod created",
+		},
+		waitUntilTestPodReadyCommand(ns),
+		deleteTestNamespaceCommand(ns),
+	}
+
+	runCommands(commands, t)
+}
+
+func TestTcptracer(t *testing.T) {
+	ns := generateTestNamespaceName("test-tcptracer")
+
+	t.Parallel()
+
+	tcptracerCmd := &command{
+		name:           "Start tcptracer gadget",
+		cmd:            fmt.Sprintf("$KUBECTL_GADGET tcptracer -n %s", ns),
+		expectedRegexp: `C\s+\d+\s+wget\s+\d\s+[\w\.:]+\s+1\.1\.1\.1\s+\d+\s+80`,
+		startAndStop:   true,
+	}
+
+	commands := []*command{
+		createTestNamespaceCommand(ns),
+		tcptracerCmd,
 		{
 			name:           "Run pod which opens TCP socket",
 			cmd:            busyboxPodCommand(ns, "while true; do wget -q -O /dev/null -T 3 http://1.1.1.1; done"),


### PR DESCRIPTION
Hi.


This PR adds a guide and an integration test for `tcptracer`.
It fixes #463.


Best regards.