### PR TITLE
cmd/kubectl-gadget: Uniform errors between gadgets

### DIFF
--- a/cmd/kubectl-gadget/bindsnoop.go
+++ b/cmd/kubectl-gadget/bindsnoop.go
@@ -67,7 +67,7 @@ var bindsnoopCmd = &cobra.Command{
 
 		err := utils.RunTraceAndPrintStream(config, bindsnoopTransformLine)
 		if err != nil {
-			return fmt.Errorf("failed to run tracer: %w", err)
+			return utils.WrapInErrRunGadget(err)
 		}
 
 		return nil
@@ -108,7 +108,7 @@ func bindsnoopTransformLine(line string) string {
 	var e types.Event
 
 	if err := json.Unmarshal([]byte(line), &e); err != nil {
-		fmt.Fprintf(os.Stderr, "error unmarshalling json: %s", err)
+		fmt.Fprintf(os.Stderr, "Error: %s", utils.WrapInErrUnmarshalOutput(err))
 		return ""
 	}
 

--- a/cmd/kubectl-gadget/biolatency.go
+++ b/cmd/kubectl-gadget/biolatency.go
@@ -88,13 +88,13 @@ func init() {
 
 func runBiolatencyStart(cmd *cobra.Command, args []string) error {
 	if params.Node == "" {
-		return fmt.Errorf("%s only works with --node", GADGET_NAME)
+		return utils.WrapInErrMissingArgs("--node")
 	}
 
 	biolatencyTraceConfig.Operation = "start"
 	traceID, err := utils.CreateTrace(biolatencyTraceConfig)
 	if err != nil {
-		return fmt.Errorf("failure creating trace: %w", err)
+		return utils.WrapInErrRunGadget(err)
 	}
 
 	fmt.Printf("%s\n", traceID)
@@ -104,13 +104,13 @@ func runBiolatencyStart(cmd *cobra.Command, args []string) error {
 
 func runBiolatencyStop(cmd *cobra.Command, args []string) error {
 	if len(args) != 1 {
-		return fmt.Errorf("it is necessary to specify a <trace-id>")
+		return utils.WrapInErrMissingArgs("<trace-id>")
 	}
 	traceID := args[0]
 
 	err := utils.SetTraceOperation(traceID, "stop")
 	if err != nil {
-		return err
+		return utils.WrapInErrStopGadget(err)
 	}
 
 	displayResultsCallback := func(results []gadgetv1alpha1.Trace) error {
@@ -127,7 +127,7 @@ func runBiolatencyStop(cmd *cobra.Command, args []string) error {
 	err = utils.PrintTraceOutputFromStatus(traceID,
 		biolatencyTraceConfig.TraceOutputState, displayResultsCallback)
 	if err != nil {
-		return fmt.Errorf("failure printing the trace output: %w", err)
+		return utils.WrapInErrGetGadgetOutput(err)
 	}
 
 	return nil
@@ -136,7 +136,7 @@ func runBiolatencyStop(cmd *cobra.Command, args []string) error {
 func runBiolatencyList(cmd *cobra.Command, args []string) error {
 	err := utils.PrintAllTraces(biolatencyTraceConfig)
 	if err != nil {
-		return fmt.Errorf("failure collecting the running traces: %w", err)
+		return utils.WrapInErrListGadgetTraces(err)
 	}
 	return nil
 }

--- a/cmd/kubectl-gadget/deploy.go
+++ b/cmd/kubectl-gadget/deploy.go
@@ -361,7 +361,7 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 
 	t, err := template.New("deploy.yaml").Parse(deployYamlTmpl)
 	if err != nil {
-		return fmt.Errorf("failed to parse template %w", err)
+		return fmt.Errorf("failed to parse template: %w", err)
 	}
 
 	p := parameters{
@@ -377,7 +377,7 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 	fmt.Printf("%s\n---\n", resources.TracesCustomResource)
 	err = t.Execute(os.Stdout, p)
 	if err != nil {
-		return fmt.Errorf("failed to generate deploy template %w", err)
+		return fmt.Errorf("failed to generate deploy template: %w", err)
 	}
 
 	return nil

--- a/cmd/kubectl-gadget/dns.go
+++ b/cmd/kubectl-gadget/dns.go
@@ -39,7 +39,7 @@ var colLens = map[string]int{
 var dnsCmd = &cobra.Command{
 	Use:   "dns",
 	Short: "Trace DNS requests",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		transform := transformLine
 
 		switch {
@@ -76,10 +76,10 @@ var dnsCmd = &cobra.Command{
 
 		err := utils.RunTraceAndPrintStream(config, transform)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "%s\n", err)
-
-			os.Exit(1)
+			return utils.WrapInErrRunGadget(err)
 		}
+
+		return nil
 	},
 }
 
@@ -91,7 +91,8 @@ func init() {
 func transformLine(line string) string {
 	event := &dnstypes.Event{}
 	if err := json.Unmarshal([]byte(line), event); err != nil {
-		return fmt.Sprintf("error unmarshaling event: %s", err)
+		fmt.Fprintf(os.Stderr, "Error: %s", utils.WrapInErrUnmarshalOutput(err))
+		return ""
 	}
 
 	podMsgSuffix := ""

--- a/cmd/kubectl-gadget/execsnoop.go
+++ b/cmd/kubectl-gadget/execsnoop.go
@@ -50,7 +50,7 @@ var execsnoopCmd = &cobra.Command{
 
 		err := utils.RunTraceAndPrintStream(config, execsnoopTransformLine)
 		if err != nil {
-			return fmt.Errorf("failed to run tracer: %w", err)
+			return utils.WrapInErrRunGadget(err)
 		}
 
 		return nil
@@ -69,13 +69,13 @@ func execsnoopTransformLine(line string) string {
 	var e types.Event
 
 	if err := json.Unmarshal([]byte(line), &e); err != nil {
-		fmt.Fprintf(os.Stderr, "error unmarshalling json: %s", err)
+		fmt.Fprintf(os.Stderr, "Error: %s", utils.WrapInErrUnmarshalOutput(err))
 		return ""
 	}
 
 	if e.Type == eventtypes.ERR || e.Type == eventtypes.WARN ||
 		e.Type == eventtypes.DEBUG || e.Type == eventtypes.INFO {
-		fmt.Fprintf(os.Stderr, "%s: node %s: %s", e.Type, e.Node, e.Message)
+		fmt.Fprintf(os.Stderr, "%s: node %q: %s", e.Type, e.Node, e.Message)
 		return ""
 	}
 

--- a/cmd/kubectl-gadget/mountsnoop.go
+++ b/cmd/kubectl-gadget/mountsnoop.go
@@ -50,7 +50,7 @@ var mountsnoopCmd = &cobra.Command{
 
 		err := utils.RunTraceAndPrintStream(config, mountsnoopTransformLine)
 		if err != nil {
-			return fmt.Errorf("failed to run tracer: %w", err)
+			return utils.WrapInErrRunGadget(err)
 		}
 
 		return nil
@@ -83,13 +83,13 @@ func mountsnoopTransformLine(line string) string {
 	var e types.Event
 
 	if err := json.Unmarshal([]byte(line), &e); err != nil {
-		fmt.Fprintf(os.Stderr, "error unmarshalling json: %s", err)
+		fmt.Fprintf(os.Stderr, "Error: %s", utils.WrapInErrUnmarshalOutput(err))
 		return ""
 	}
 
 	if e.Type == eventtypes.ERR || e.Type == eventtypes.WARN ||
 		e.Type == eventtypes.DEBUG || e.Type == eventtypes.INFO {
-		fmt.Fprintf(os.Stderr, "%s: node %s: %s", e.Type, e.Node, e.Message)
+		fmt.Fprintf(os.Stderr, "%s: node %q: %s", e.Type, e.Node, e.Message)
 		return ""
 	}
 

--- a/cmd/kubectl-gadget/oomkill.go
+++ b/cmd/kubectl-gadget/oomkill.go
@@ -48,7 +48,12 @@ var oomkillCmd = &cobra.Command{
 			CommonFlags:      &params,
 		}
 
-		return utils.RunTraceAndPrintStream(config, oomkillTransformLine)
+		err := utils.RunTraceAndPrintStream(config, oomkillTransformLine)
+		if err != nil {
+			return utils.WrapInErrRunGadget(err)
+		}
+
+		return nil
 	},
 }
 
@@ -64,13 +69,13 @@ func oomkillTransformLine(line string) string {
 	var e types.Event
 
 	if err := json.Unmarshal([]byte(line), &e); err != nil {
-		fmt.Fprintf(os.Stderr, "error unmarshalling json: %s", err)
+		fmt.Fprintf(os.Stderr, "Error: %s", utils.WrapInErrUnmarshalOutput(err))
 		return ""
 	}
 
 	if e.Type == eventtypes.ERR || e.Type == eventtypes.WARN ||
 		e.Type == eventtypes.DEBUG || e.Type == eventtypes.INFO {
-		fmt.Fprintf(os.Stderr, "%s: node %s: %s", e.Type, e.Node, e.Message)
+		fmt.Fprintf(os.Stderr, "%s: node %q: %s", e.Type, e.Node, e.Message)
 		return ""
 	}
 

--- a/cmd/kubectl-gadget/opensnoop.go
+++ b/cmd/kubectl-gadget/opensnoop.go
@@ -50,7 +50,7 @@ var opensnoopCmd = &cobra.Command{
 
 		err := utils.RunTraceAndPrintStream(config, opensnoopTransformLine)
 		if err != nil {
-			return fmt.Errorf("failed to run tracer: %w", err)
+			return utils.WrapInErrRunGadget(err)
 		}
 
 		return nil
@@ -69,13 +69,13 @@ func opensnoopTransformLine(line string) string {
 	var e types.Event
 
 	if err := json.Unmarshal([]byte(line), &e); err != nil {
-		fmt.Fprintf(os.Stderr, "error unmarshalling json: %s", err)
+		fmt.Fprintf(os.Stderr, "Error: %s", utils.WrapInErrUnmarshalOutput(err))
 		return ""
 	}
 
 	if e.Type == eventtypes.ERR || e.Type == eventtypes.WARN ||
 		e.Type == eventtypes.DEBUG || e.Type == eventtypes.INFO {
-		fmt.Fprintf(os.Stderr, "%s: node %s: %s", e.Type, e.Node, e.Message)
+		fmt.Fprintf(os.Stderr, "%s: node %q: %s", e.Type, e.Node, e.Message)
 		return ""
 	}
 

--- a/cmd/kubectl-gadget/sigsnoop.go
+++ b/cmd/kubectl-gadget/sigsnoop.go
@@ -60,7 +60,12 @@ var sigsnoopCmd = &cobra.Command{
 			},
 		}
 
-		return utils.RunTraceAndPrintStream(config, sigsnoopTransformLine)
+		err := utils.RunTraceAndPrintStream(config, sigsnoopTransformLine)
+		if err != nil {
+			return utils.WrapInErrRunGadget(err)
+		}
+
+		return nil
 	},
 }
 
@@ -96,13 +101,13 @@ func sigsnoopTransformLine(line string) string {
 	var e types.Event
 
 	if err := json.Unmarshal([]byte(line), &e); err != nil {
-		fmt.Fprintf(os.Stderr, "error unmarshalling json: %s", err)
+		fmt.Fprintf(os.Stderr, "Error: %s", utils.WrapInErrUnmarshalOutput(err))
 		return ""
 	}
 
 	if e.Type == eventtypes.ERR || e.Type == eventtypes.WARN ||
 		e.Type == eventtypes.DEBUG || e.Type == eventtypes.INFO {
-		fmt.Fprintf(os.Stderr, "%s: node %s: %s", e.Type, e.Node, e.Message)
+		fmt.Fprintf(os.Stderr, "%s: node %q: %s", e.Type, e.Node, e.Message)
 		return ""
 	}
 

--- a/cmd/kubectl-gadget/snisnoop.go
+++ b/cmd/kubectl-gadget/snisnoop.go
@@ -17,6 +17,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
 
@@ -70,7 +71,7 @@ var snisnoopCmd = &cobra.Command{
 
 		err := utils.RunTraceAndPrintStream(config, transform)
 		if err != nil {
-			return err
+			return utils.WrapInErrRunGadget(err)
 		}
 
 		return nil
@@ -85,7 +86,7 @@ func init() {
 func snisnoopTransformLine(line string) string {
 	event := &snitypes.Event{}
 	if err := json.Unmarshal([]byte(line), event); err != nil {
-		return fmt.Sprintf("error unmarshaling event: %s", err)
+		fmt.Fprintf(os.Stderr, "Error: %s", utils.WrapInErrUnmarshalOutput(err))
 	}
 
 	podMsgSuffix := ""

--- a/cmd/kubectl-gadget/tcpconnect.go
+++ b/cmd/kubectl-gadget/tcpconnect.go
@@ -50,7 +50,7 @@ var tcpconnectCmd = &cobra.Command{
 
 		err := utils.RunTraceAndPrintStream(config, tcpconnectTransformLine)
 		if err != nil {
-			return fmt.Errorf("failed to run gadget: %w", err)
+			return utils.WrapInErrRunGadget(err)
 		}
 
 		return nil
@@ -69,7 +69,7 @@ func tcpconnectTransformLine(line string) string {
 	var e types.Event
 
 	if err := json.Unmarshal([]byte(line), &e); err != nil {
-		fmt.Fprintf(os.Stderr, "Error: failed to unmarshal event: %s", err)
+		fmt.Fprintf(os.Stderr, "Error: %s", utils.WrapInErrUnmarshalOutput(err))
 		return ""
 	}
 

--- a/cmd/kubectl-gadget/undeploy.go
+++ b/cmd/kubectl-gadget/undeploy.go
@@ -49,17 +49,17 @@ func runUndeploy(cmd *cobra.Command, args []string) error {
 
 	k8sClient, err := k8sutil.NewClientsetFromConfigFlags(utils.KubernetesConfigFlags)
 	if err != nil {
-		return fmt.Errorf("Error setting up Kubernetes client: %w", err)
+		return utils.WrapInErrSetupK8sClient(err)
 	}
 
 	config, err := utils.KubernetesConfigFlags.ToRESTConfig()
 	if err != nil {
-		return fmt.Errorf("Error creating RESTConfig: %w", err)
+		return fmt.Errorf("failed to create RESTConfig: %w", err)
 	}
 
 	crdClient, err := clientset.NewForConfig(config)
 	if err != nil {
-		return fmt.Errorf("Error setting up CRD client: %w", err)
+		return fmt.Errorf("failed to set up CRD client: %w", err)
 	}
 
 	errs := []string{}

--- a/cmd/kubectl-gadget/utils/errors.go
+++ b/cmd/kubectl-gadget/utils/errors.go
@@ -1,0 +1,88 @@
+// Copyright 2019-2021 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"errors"
+	"fmt"
+)
+
+// Gadget pod
+var (
+	ErrGadgetPodNotFound      = errors.New("gadget pod not found")
+	ErrMultipleGadgetPodFound = errors.New("multiple gadget pods found")
+)
+
+// Kubernetes client
+func WrapInErrSetupK8sClient(err error) error {
+	return fmt.Errorf("failed to set up Kubernetes client: %w", err)
+}
+
+func WrapInErrListNodes(err error) error {
+	return fmt.Errorf("failed to list nodes: %w", err)
+}
+
+// Gadget operations
+func WrapInErrRunGadget(err error) error {
+	return fmt.Errorf("failed to run gadget: %w", err)
+}
+
+func WrapInErrRunGadgetOnNode(node string, err error) error {
+	return fmt.Errorf("failed to run gadget on node %q: %w", node, err)
+}
+
+func WrapInErrRunGadgetOnAllNode(err error) error {
+	return fmt.Errorf("failed to run gadget on all nodes: %w", err)
+}
+
+func WrapInErrStopGadget(err error) error {
+	return fmt.Errorf("failed to stop gadget: %w", err)
+}
+
+func WrapInErrGenGadgetOutput(err error) error {
+	return fmt.Errorf("failed to generate gadget's output: %w", err)
+}
+
+func WrapInErrGetGadgetOutput(err error) error {
+	return fmt.Errorf("failed to get gadget's output: %w", err)
+}
+
+func WrapInErrListGadgetTraces(err error) error {
+	return fmt.Errorf("failed to list the running traces: %w", err)
+}
+
+// Arguments
+var ErrJsonNotSupported = errors.New("JSON output format is not supported")
+
+func WrapInErrArgsNotSupported(args string) error {
+	return fmt.Errorf("arguments not supported: %s", args)
+}
+
+func WrapInErrMissingArgs(args string) error {
+	return fmt.Errorf("missing required arguments: %s", args)
+}
+
+func WrapInErrInvalidArg(arg string, err error) error {
+	return fmt.Errorf("invalid argument '%s': %w", arg, err)
+}
+
+// JSON parsing
+func WrapInErrUnmarshalOutput(err error) error {
+	return fmt.Errorf("failed to unmarshal output: %w", err)
+}
+
+func WrapInErrMarshalOutput(err error) error {
+	return fmt.Errorf("failed to marshal output: %w", err)
+}

--- a/cmd/kubectl-gadget/utils/exec.go
+++ b/cmd/kubectl-gadget/utils/exec.go
@@ -17,7 +17,6 @@ package utils
 import (
 	"bytes"
 	"context"
-	"errors"
 	"fmt"
 	"io"
 
@@ -27,11 +26,6 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/remotecommand"
-)
-
-var (
-	ErrGadgetPodNotFound      = errors.New("Gadget pod not found")
-	ErrMultipleGadgetPodFound = errors.New("Multiple gadget pods found")
 )
 
 func ExecPodSimple(client *kubernetes.Clientset, node string, podCmd string) string {

--- a/cmd/kubectl-gadget/utils/table.go
+++ b/cmd/kubectl-gadget/utils/table.go
@@ -99,7 +99,7 @@ func (t *TableFormater) GetTransformFunc() func(string) string {
 
 		err := json.Unmarshal([]byte(line), &event)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "json.Unmarshal error: %v\n", err)
+			fmt.Fprintf(os.Stderr, "Error: %s", WrapInErrUnmarshalOutput(err))
 			return ""
 		}
 

--- a/cmd/kubectl-gadget/utils/trace_test.go
+++ b/cmd/kubectl-gadget/utils/trace_test.go
@@ -77,10 +77,10 @@ func TestPrintTraceFeedback(t *testing.T) {
 
 	var out string
 
-	runprintTraceFeedback := func(m map[string]string, n int) string {
+	runprintTraceFeedback := func(p string, m map[string]string, n int) string {
 		r, w, _ := os.Pipe()
 		os.Stderr = w
-		printTraceFeedback(m, n)
+		printTraceFeedback(p, m, n)
 		w.Close()
 		out, _ := ioutil.ReadAll(r)
 		os.Stderr = originalStderr
@@ -93,8 +93,8 @@ func TestPrintTraceFeedback(t *testing.T) {
 		"node": "Err/Warn Message",
 	}
 
-	out = runprintTraceFeedback(m, 1)
-	expected := "Failed to run the gadget on node \"node\": Err/Warn Message\n"
+	out = runprintTraceFeedback("MyPrefix", m, 1)
+	expected := "MyPrefix: failed to run gadget on node \"node\": Err/Warn Message\n"
 	if expected != out {
 		t.Fatalf("'%v' != '%v'", out, expected)
 	}
@@ -105,9 +105,9 @@ func TestPrintTraceFeedback(t *testing.T) {
 		"node2": "Err/Warn Message 2",
 		"node3": "Err/Warn Message 2",
 	}
-	out = runprintTraceFeedback(m, 3)
+	out = runprintTraceFeedback("MyPrefix2", m, 3)
 	for node, msg := range m {
-		expected = fmt.Sprintf("Failed to run the gadget on node \"%s\": %s", node, msg)
+		expected = fmt.Sprintf("MyPrefix2: failed to run gadget on node \"%s\": %s", node, msg)
 		if !strings.Contains(out, expected) {
 			t.Fatalf("Output '%v' does not contain '%v'", out, expected)
 		}
@@ -115,15 +115,15 @@ func TestPrintTraceFeedback(t *testing.T) {
 
 	// It should print all the messages because even if they are all the same,
 	// there was a node that didn't report an error. Therefore, the final error
-	// message can say "Failed to run the gadget on all nodes" but only on the
-	// ones that it really failed.
+	// message can say "failed to run gadget on all nodes" but only on the ones
+	// that it really failed.
 	m = map[string]string{
 		"node2": "Err/Warn Message 2",
 		"node3": "Err/Warn Message 2",
 	}
-	out = runprintTraceFeedback(m, 3)
+	out = runprintTraceFeedback("MyPrefix3", m, 3)
 	for node, msg := range m {
-		expected = fmt.Sprintf("Failed to run the gadget on node \"%s\": %s", node, msg)
+		expected = fmt.Sprintf("MyPrefix3: failed to run gadget on node \"%s\": %s", node, msg)
 		if !strings.Contains(out, expected) {
 			t.Fatalf("Output '%v' does not contain '%v'", out, expected)
 		}
@@ -135,8 +135,8 @@ func TestPrintTraceFeedback(t *testing.T) {
 		"node2": "Err/Warn Message",
 		"node3": "Err/Warn Message",
 	}
-	out = runprintTraceFeedback(m, 3)
-	expected = "Failed to run the gadget on all nodes: Err/Warn Message\n"
+	out = runprintTraceFeedback("MyPrefix4", m, 3)
+	expected = "MyPrefix4: failed to run gadget on all nodes: Err/Warn Message\n"
 	if expected != out {
 		t.Fatalf("'%v' != '%v'", out, expected)
 	}


### PR DESCRIPTION
# Uniform errors between gadgets

This PR tries to uniform the way kubectl-gadget CLI shows errors to the users.

I created a set of functions to ease the adoption of this uniformity for new gadgets, see [cmd/utils/errors.go](https://github.com/kinvolk/inspektor-gadget/blob/jose/uniform-errors/cmd/kubectl-gadget/utils/errors.go).


TODO in other PRs:
- [ ] Uniform how events different than `NORMAL` are printed. For instance, ensure `DEBUG` events are only printed if `params.Verbose` was set or `ERR` events are printed to `Stderr`: https://github.com/kinvolk/inspektor-gadget/issues/546
- [ ] Add `go-staticcheck` to the CI: https://github.com/kinvolk/inspektor-gadget/pull/542

