### PR TITLE
CI: Add go linters stylecheck, staticcheck and errorlint

### DIFF
--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -75,9 +75,9 @@ jobs:
       run: |
         make -C gadget-container ebpf-objects
     - name: Lint
-      uses: golangci/golangci-lint-action@v2
+      uses: golangci/golangci-lint-action@v3.1.0
       with:
-        version: v1.43.0
+        version: v1.44.2
         working-directory: /home/runner/work/inspektor-gadget/inspektor-gadget
         # Workaround to display the output:
         # https://github.com/golangci/golangci-lint-action/issues/119#issuecomment-981090648

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,17 +2,51 @@ output:
   sort-results: true
 
 run:
+  timeout: 3m
   build-tags:
   - withebpf
-  - tools
   - docs
 
 issues:
   exclude-use-default: false
   max-same-issues: 0
   max-issues-per-linter: 0
+  exclude-rules:
+    # Ignore check: Packages must have a package comment
+    - text: "ST1000: at least one file in a package should have a package comment"
+      linters:
+        - stylecheck
+    # FIXME temporarily suppress. See issue #540
+    - text: "SA1016: (syscall.SIGKILL|os.Kill) cannot be trapped \\(did you mean syscall.SIGTERM\\?\\)"
+      linters:
+      - staticcheck
+    # FIXME temporarily suppress. See issue #541
+    - text: "SA1019: grpc.WithDialer is deprecated: use WithContextDialer instead."
+      linters:
+        - staticcheck
 
 linters:
   disable-all: true
   enable:
   - gofumpt
+  - stylecheck
+  - staticcheck
+  - errorlint
+
+linters-settings:
+  gofumpt:
+    lang-version: "1.17"
+  staticcheck:
+    go: "1.17"
+    checks: ["all"]
+  stylecheck:
+    go: "1.17"
+    checks: ["all"]
+  errorlint:
+    # https://github.com/polyfloyd/go-errorlint
+    # Check whether fmt.Errorf uses the %w verb for formatting errors.
+    errorf: true
+    # Check for plain type assertions and type switches (errors.As must be used).
+    asserts: true
+    # Check for plain error comparisons (errors.Is must be used)
+    comparison: true

--- a/cmd/kubectl-gadget/bcck8s.go
+++ b/cmd/kubectl-gadget/bcck8s.go
@@ -133,8 +133,8 @@ func bccCmd(subCommand, bccScript string) func(*cobra.Command, []string) error {
 				return utils.WrapInErrMissingArgs("--node and --podname")
 			}
 
-			if params.OutputMode == utils.OutputModeJson {
-				return utils.ErrJsonNotSupported
+			if params.OutputMode == utils.OutputModeJSON {
+				return utils.ErrJSONNotSupported
 			}
 		}
 
@@ -152,8 +152,8 @@ func bccCmd(subCommand, bccScript string) func(*cobra.Command, []string) error {
 				return utils.WrapInErrArgsNotSupported("--containername and --podname")
 			}
 
-			if params.OutputMode == utils.OutputModeJson {
-				return utils.ErrJsonNotSupported
+			if params.OutputMode == utils.OutputModeJSON {
+				return utils.ErrJSONNotSupported
 			}
 		}
 
@@ -200,10 +200,10 @@ func bccCmd(subCommand, bccScript string) func(*cobra.Command, []string) error {
 
 			// ask the gadget to send the output in json mode to be able to
 			// parse it to print only the columns required by the user
-			params.OutputMode = utils.OutputModeJson
+			params.OutputMode = utils.OutputModeJSON
 		}
 
-		if params.OutputMode == utils.OutputModeJson {
+		if params.OutputMode == utils.OutputModeJSON {
 			gadgetParams += " --json"
 		}
 
@@ -227,11 +227,11 @@ func bccCmd(subCommand, bccScript string) func(*cobra.Command, []string) error {
 			}
 		}
 
-		tracerId := time.Now().Format("20060102150405")
+		tracerID := time.Now().Format("20060102150405")
 		b := make([]byte, 6)
 		_, err = rand.Read(b)
 		if err == nil {
-			tracerId = fmt.Sprintf("%s_%x", tracerId, b)
+			tracerID = fmt.Sprintf("%s_%x", tracerID, b)
 		}
 
 		nodes, err := client.CoreV1().Nodes().List(context.TODO(), metaV1.ListOptions{})
@@ -252,7 +252,7 @@ func bccCmd(subCommand, bccScript string) func(*cobra.Command, []string) error {
 			Flows:         len(nodes.Items),
 			OutStream:     os.Stdout,
 			ErrStream:     os.Stderr,
-			SkipFirstLine: params.OutputMode != utils.OutputModeJson, // skip first line if json is not used
+			SkipFirstLine: params.OutputMode != utils.OutputModeJSON, // skip first line if json is not used
 			Transform:     transform,
 		})
 
@@ -262,7 +262,7 @@ func bccCmd(subCommand, bccScript string) func(*cobra.Command, []string) error {
 			}
 			go func(nodeName string, index int) {
 				cmd := fmt.Sprintf("exec /opt/bcck8s/bcc-wrapper.sh --tracerid %s --gadget %s %s %s %s %s %s -- %s",
-					tracerId, bccScript, labelFilter, namespaceFilter, podnameFilter, containernameFilter, extraParams, gadgetParams)
+					tracerID, bccScript, labelFilter, namespaceFilter, podnameFilter, containernameFilter, extraParams, gadgetParams)
 				var err error
 				if subCommand != "tcptop" {
 					err = utils.ExecPod(client, nodeName, cmd,
@@ -280,7 +280,7 @@ func bccCmd(subCommand, bccScript string) func(*cobra.Command, []string) error {
 		for {
 			select {
 			case <-sigs:
-				if params.OutputMode != utils.OutputModeJson {
+				if params.OutputMode != utils.OutputModeJSON {
 					fmt.Println("\nTerminating...")
 				}
 				break waitingAllNodes
@@ -307,7 +307,7 @@ func bccCmd(subCommand, bccScript string) func(*cobra.Command, []string) error {
 			}
 			// ignore errors, there is nothing the user can do about it
 			utils.ExecPodCapture(client, node.Name,
-				fmt.Sprintf("exec /opt/bcck8s/bcc-wrapper.sh --tracerid %s --stop", tracerId))
+				fmt.Sprintf("exec /opt/bcck8s/bcc-wrapper.sh --tracerid %s --stop", tracerID))
 		}
 		fmt.Printf("\n")
 

--- a/cmd/kubectl-gadget/biolatency.go
+++ b/cmd/kubectl-gadget/biolatency.go
@@ -24,18 +24,11 @@ import (
 	gadgetv1alpha1 "github.com/kinvolk/inspektor-gadget/pkg/apis/gadget/v1alpha1"
 )
 
-const (
-	GADGET_NAME         = "biolatency"
-	GADGET_OUTPUTMODE   = "Status"
-	GADGET_OUTPUTSTATE  = "Completed"
-	GADGET_INITIALSTATE = "Started"
-)
-
 var biolatencyTraceConfig = &utils.TraceConfig{
-	GadgetName:        GADGET_NAME,
-	TraceOutputMode:   GADGET_OUTPUTMODE,
-	TraceOutputState:  GADGET_OUTPUTSTATE,
-	TraceInitialState: GADGET_INITIALSTATE,
+	GadgetName:        "biolatency",
+	TraceOutputMode:   "Status",
+	TraceOutputState:  "Completed",
+	TraceInitialState: "Started",
 	CommonFlags:       &params,
 }
 

--- a/cmd/kubectl-gadget/collector.go
+++ b/cmd/kubectl-gadget/collector.go
@@ -142,7 +142,7 @@ func processCollectorCmdRun(cmd *cobra.Command, args []string) error {
 		})
 
 		switch params.OutputMode {
-		case utils.OutputModeJson:
+		case utils.OutputModeJSON:
 			b, err := json.MarshalIndent(allProcesses, "", "  ")
 			if err != nil {
 				return utils.WrapInErrMarshalOutput(err)
@@ -250,7 +250,7 @@ func socketCollectorCmdRun(cmd *cobra.Command, args []string) error {
 		})
 
 		switch params.OutputMode {
-		case utils.OutputModeJson:
+		case utils.OutputModeJSON:
 			b, err := json.MarshalIndent(allSockets, "", "  ")
 			if err != nil {
 				return utils.WrapInErrMarshalOutput(err)

--- a/cmd/kubectl-gadget/dns.go
+++ b/cmd/kubectl-gadget/dns.go
@@ -27,8 +27,8 @@ import (
 )
 
 const (
-	FMT_SHORT = "%-30.30s %-9.9s %-10.10s %s"
-	FMT_ALL   = "%-16.16s %-16.16s " + FMT_SHORT
+	FmtShortDNS = "%-30.30s %-9.9s %-10.10s %s"
+	FmtAllDNS   = "%-16.16s %-16.16s " + FmtShortDNS
 )
 
 var colLens = map[string]int{
@@ -43,13 +43,13 @@ var dnsCmd = &cobra.Command{
 		transform := transformLine
 
 		switch {
-		case params.OutputMode == utils.OutputModeJson: // don't print any header
+		case params.OutputMode == utils.OutputModeJSON: // don't print any header
 		case params.OutputMode == utils.OutputModeCustomColumns:
 			table := utils.NewTableFormater(params.CustomColumns, colLens)
 			fmt.Println(table.GetHeader())
 			transform = table.GetTransformFunc()
 		case params.AllNamespaces:
-			fmt.Printf(FMT_ALL+"\n",
+			fmt.Printf(FmtAllDNS+"\n",
 				"NODE",
 				"NAMESPACE",
 				"POD",
@@ -58,7 +58,7 @@ var dnsCmd = &cobra.Command{
 				"NAME",
 			)
 		default:
-			fmt.Printf(FMT_SHORT+"\n",
+			fmt.Printf(FmtShortDNS+"\n",
 				"POD",
 				"TYPE",
 				"QTYPE",
@@ -110,8 +110,8 @@ func transformLine(line string) string {
 		return fmt.Sprintf("Debug on node %s%s: %s", event.Node, podMsgSuffix, event.Message)
 	}
 	if params.AllNamespaces {
-		return fmt.Sprintf(FMT_ALL, event.Node, event.Namespace, event.Pod, event.PktType, event.QType, event.DNSName)
+		return fmt.Sprintf(FmtAllDNS, event.Node, event.Namespace, event.Pod, event.PktType, event.QType, event.DNSName)
 	} else {
-		return fmt.Sprintf(FMT_SHORT, event.Pod, event.PktType, event.QType, event.DNSName)
+		return fmt.Sprintf(FmtShortDNS, event.Pod, event.PktType, event.QType, event.DNSName)
 	}
 }

--- a/cmd/kubectl-gadget/filetop.go
+++ b/cmd/kubectl-gadget/filetop.go
@@ -41,10 +41,10 @@ var (
 	interval int = 1
 
 	// flags
-	maxrows    int
-	sortby_str string
-	sortby     types.SortBy
-	allFiles   bool
+	maxRows   int
+	sortByStr string
+	sortBy    types.SortBy
+	allFiles  bool
 )
 
 var filetopCmd = &cobra.Command{
@@ -70,9 +70,9 @@ var filetopCmd = &cobra.Command{
 			TraceOutputState: "Started",
 			CommonFlags:      &params,
 			Parameters: map[string]string{
-				"max_rows":  strconv.Itoa(maxrows),
+				"max_rows":  strconv.Itoa(maxRows),
 				"interval":  strconv.Itoa(interval),
-				"sort_by":   sortby_str,
+				"sort_by":   sortByStr,
 				"all_files": strconv.FormatBool(allFiles),
 			},
 		}
@@ -89,7 +89,7 @@ var filetopCmd = &cobra.Command{
 	SilenceUsage: true,
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		var err error
-		sortby, err = types.ParseSortBy(sortby_str)
+		sortBy, err = types.ParseSortBy(sortByStr)
 		if err != nil {
 			return utils.WrapInErrInvalidArg("--sort", err)
 		}
@@ -100,8 +100,8 @@ var filetopCmd = &cobra.Command{
 }
 
 func init() {
-	filetopCmd.Flags().IntVarP(&maxrows, "maxrows", "r", 20, "Maximum rows to print")
-	filetopCmd.Flags().StringVarP(&sortby_str, "sort", "", "rbytes", "Sort column")
+	filetopCmd.Flags().IntVarP(&maxRows, "maxrows", "r", 20, "Maximum rows to print")
+	filetopCmd.Flags().StringVarP(&sortByStr, "sort", "", "rbytes", "Sort column")
 	filetopCmd.Flags().BoolVarP(&allFiles, "all-files", "a", false, "Include non-regular file types (sockets, FIFOs, etc)")
 
 	rootCmd.AddCommand(filetopCmd)
@@ -150,7 +150,7 @@ func print() {
 
 	mu.Unlock()
 
-	types.SortStats(stats, sortby)
+	types.SortStats(stats, sortBy)
 
 	switch params.OutputMode {
 	case utils.OutputModeColumns:
@@ -163,7 +163,7 @@ func print() {
 			"NODE", "NAMESPACE", "POD", "CONTAINER",
 			"PID", "COMM", "READS", "WRITES", "R_Kb", "W_Kb", "T", "FILE")
 		for idx, event := range stats {
-			if idx == maxrows {
+			if idx == maxRows {
 				break
 			}
 			fmt.Printf("%-16s %-16s %-16s %-16s %-7d %-16s %-6d %-6d %-7d %-7d %c %s\n",
@@ -171,7 +171,7 @@ func print() {
 				event.Pid, event.Comm, event.Reads, event.Writes, event.ReadBytes/1024,
 				event.WriteBytes/1024, event.FileType, event.Filename)
 		}
-	case utils.OutputModeJson:
+	case utils.OutputModeJSON:
 		b, err := json.Marshal(stats)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error: %s", utils.WrapInErrMarshalOutput(err))
@@ -186,7 +186,7 @@ func print() {
 		}
 		fmt.Println(getCustomColsHeader(params.CustomColumns))
 		for idx, stat := range stats {
-			if idx == maxrows {
+			if idx == maxRows {
 				break
 			}
 			fmt.Println(formatEventCostumCols(&stat, params.CustomColumns))

--- a/cmd/kubectl-gadget/fsslower.go
+++ b/cmd/kubectl-gadget/fsslower.go
@@ -94,7 +94,7 @@ var fsslowerCmd = &cobra.Command{
 
 func init() {
 	fsslowerCmd.Flags().UintVarP(
-		&fsslowerMinLatency, "min", "m", types.MIN_LATENCY_DEFAULT,
+		&fsslowerMinLatency, "min", "m", types.MinLatencyDefault,
 		"Min latency to trace, in ms",
 	)
 	fsslowerCmd.Flags().StringVarP(

--- a/cmd/kubectl-gadget/mountsnoop.go
+++ b/cmd/kubectl-gadget/mountsnoop.go
@@ -101,7 +101,7 @@ func mountsnoopTransformLine(line string) string {
 	case utils.OutputModeColumns:
 		sb.WriteString(fmt.Sprintf("%-16s %-16s %-16s %-16s %-16s %-6d %-6d %-10d %s",
 			e.Node, e.Namespace, e.Pod, e.Container,
-			e.Comm, e.Pid, e.Tid, e.MountNsId, getCall(&e)))
+			e.Comm, e.Pid, e.Tid, e.MountNsID, getCall(&e)))
 	case utils.OutputModeCustomColumns:
 		for _, col := range params.CustomColumns {
 			switch col {
@@ -118,7 +118,7 @@ func mountsnoopTransformLine(line string) string {
 			case "tid":
 				sb.WriteString(fmt.Sprintf("%-6d", e.Tid))
 			case "mnt_ns":
-				sb.WriteString(fmt.Sprintf("%-10d", e.MountNsId))
+				sb.WriteString(fmt.Sprintf("%-10d", e.MountNsID))
 			case "comm":
 				sb.WriteString(fmt.Sprintf("%-16s", e.Comm))
 			case "op":

--- a/cmd/kubectl-gadget/seccompadvisor.go
+++ b/cmd/kubectl-gadget/seccompadvisor.go
@@ -158,7 +158,7 @@ func getSeccompProfilesName(traceID string) ([]string, error) {
 	cli := mgr.GetClient()
 
 	profilesList := &seccompprofile.SeccompProfileList{}
-	err = cli.List(context.TODO(), profilesList, client.MatchingLabels{utils.GLOBAL_TRACE_ID: traceID})
+	err = cli.List(context.TODO(), profilesList, client.MatchingLabels{utils.GlobalTraceID: traceID})
 	if err != nil {
 		return nil, fmt.Errorf("failed to list seccomp profiles: %w", err)
 	}

--- a/cmd/kubectl-gadget/sigsnoop.go
+++ b/cmd/kubectl-gadget/sigsnoop.go
@@ -38,7 +38,7 @@ var sigsnoopCmd = &cobra.Command{
 	Short: "Trace signals received by processes",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		switch params.OutputMode {
-		case utils.OutputModeJson: // don't print any header
+		case utils.OutputModeJSON: // don't print any header
 		case utils.OutputModeCustomColumns:
 			fmt.Println(getCustomSigsnoopColsHeader(params.CustomColumns))
 		case utils.OutputModeColumns:

--- a/cmd/kubectl-gadget/snisnoop.go
+++ b/cmd/kubectl-gadget/snisnoop.go
@@ -27,8 +27,8 @@ import (
 )
 
 const (
-	FMT_SNISNOOP_ALL   = "%-16.16s %-16.16s %-30.30s %s"
-	FMT_SNISNOOP_SHORT = "%-30.30s %s"
+	FmtAllSnisnoop   = "%-16.16s %-16.16s %-30.30s %s"
+	FmtShortSniSnoop = "%-30.30s %s"
 )
 
 var colSnisnoopLens = map[string]int{
@@ -42,20 +42,20 @@ var snisnoopCmd = &cobra.Command{
 		transform := snisnoopTransformLine
 
 		switch {
-		case params.OutputMode == utils.OutputModeJson: // don't print any header
+		case params.OutputMode == utils.OutputModeJSON: // don't print any header
 		case params.OutputMode == utils.OutputModeCustomColumns:
 			table := utils.NewTableFormater(params.CustomColumns, colSnisnoopLens)
 			fmt.Println(table.GetHeader())
 			transform = table.GetTransformFunc()
 		case params.AllNamespaces:
-			fmt.Printf(FMT_SNISNOOP_ALL+"\n",
+			fmt.Printf(FmtAllSnisnoop+"\n",
 				"NODE",
 				"NAMESPACE",
 				"POD",
 				"NAME",
 			)
 		default:
-			fmt.Printf(FMT_SNISNOOP_SHORT+"\n",
+			fmt.Printf(FmtShortSniSnoop+"\n",
 				"POD",
 				"NAME",
 			)
@@ -104,8 +104,8 @@ func snisnoopTransformLine(line string) string {
 		return fmt.Sprintf("Debug on node %s%s: %s", event.Node, podMsgSuffix, event.Message)
 	}
 	if params.AllNamespaces {
-		return fmt.Sprintf(FMT_SNISNOOP_ALL, event.Node, event.Namespace, event.Pod, event.Name)
+		return fmt.Sprintf(FmtAllSnisnoop, event.Node, event.Namespace, event.Pod, event.Name)
 	} else {
-		return fmt.Sprintf(FMT_SNISNOOP_SHORT, event.Pod, event.Name)
+		return fmt.Sprintf(FmtShortSniSnoop, event.Pod, event.Name)
 	}
 }

--- a/cmd/kubectl-gadget/utils/errors.go
+++ b/cmd/kubectl-gadget/utils/errors.go
@@ -26,6 +26,7 @@ var (
 )
 
 // Kubernetes client
+
 func WrapInErrSetupK8sClient(err error) error {
 	return fmt.Errorf("failed to set up Kubernetes client: %w", err)
 }
@@ -35,6 +36,7 @@ func WrapInErrListNodes(err error) error {
 }
 
 // Gadget operations
+
 func WrapInErrRunGadget(err error) error {
 	return fmt.Errorf("failed to run gadget: %w", err)
 }
@@ -64,7 +66,8 @@ func WrapInErrListGadgetTraces(err error) error {
 }
 
 // Arguments
-var ErrJsonNotSupported = errors.New("JSON output format is not supported")
+
+var ErrJSONNotSupported = errors.New("JSON output format is not supported")
 
 func WrapInErrArgsNotSupported(args string) error {
 	return fmt.Errorf("arguments not supported: %s", args)
@@ -79,6 +82,7 @@ func WrapInErrInvalidArg(arg string, err error) error {
 }
 
 // JSON parsing
+
 func WrapInErrUnmarshalOutput(err error) error {
 	return fmt.Errorf("failed to unmarshal output: %w", err)
 }

--- a/cmd/kubectl-gadget/utils/flags.go
+++ b/cmd/kubectl-gadget/utils/flags.go
@@ -41,11 +41,11 @@ func cobraInit() {
 
 const (
 	OutputModeColumns       = "columns"
-	OutputModeJson          = "json"
+	OutputModeJSON          = "json"
 	OutputModeCustomColumns = "custom-columns"
 )
 
-var supportedOutputModes = []string{OutputModeColumns, OutputModeJson, OutputModeCustomColumns}
+var supportedOutputModes = []string{OutputModeColumns, OutputModeJSON, OutputModeCustomColumns}
 
 // CommonFlags contains CLI flags common to several gadgets
 type CommonFlags struct {
@@ -148,7 +148,7 @@ func AddCommonFlags(command *cobra.Command, params *CommonFlags) {
 		switch {
 		case params.OutputMode == OutputModeColumns:
 			fallthrough
-		case params.OutputMode == OutputModeJson:
+		case params.OutputMode == OutputModeJSON:
 			return nil
 		case strings.HasPrefix(params.OutputMode, OutputModeCustomColumns):
 			parts := strings.Split(params.OutputMode, "=")

--- a/cmd/local-gadget/main.go
+++ b/cmd/local-gadget/main.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -373,12 +374,12 @@ func main() {
 
 	for {
 		input, err := l.Readline()
-		if err == readline.ErrInterrupt {
+		if errors.Is(err, readline.ErrInterrupt) {
 			if len(input) == 0 {
 				break
 			}
 			continue
-		} else if err == io.EOF {
+		} else if errors.Is(err, io.EOF) {
 			break
 		}
 

--- a/gadget-container/hooks/oci/main.go
+++ b/gadget-container/hooks/oci/main.go
@@ -56,18 +56,18 @@ func main() {
 	}
 
 	if hook != "prestart" && hook != "poststop" {
-		panic(fmt.Errorf("hook %q not supported\n", hook))
+		panic(fmt.Errorf("hook %q not supported", hook))
 	}
 
 	// Parse state from stdin
 	stateBuf, err := ioutil.ReadAll(os.Stdin)
 	if err != nil {
-		panic(fmt.Errorf("cannot read stdin: %v\n", err))
+		panic(fmt.Errorf("cannot read stdin: %w", err))
 	}
 
 	ociStateID, ociStatePid, err := containerutils.ParseOCIState(stateBuf)
 	if err != nil {
-		panic(fmt.Errorf("cannot parse stdin: %v\n%s\n", err, string(stateBuf)))
+		panic(fmt.Errorf("cannot parse stdin: %w\n%s", err, string(stateBuf)))
 	}
 
 	// Validate state
@@ -114,17 +114,17 @@ func main() {
 				ppidStr = strings.TrimSuffix(ppidStr, "\n")
 				ppid, err = strconv.Atoi(ppidStr)
 				if err != nil {
-					panic(fmt.Errorf("cannot parse ppid (%q): %v", ppidStr, err))
+					panic(fmt.Errorf("cannot parse ppid (%q): %w", ppidStr, err))
 				}
 				break
 			}
 		}
 	} else {
-		panic(fmt.Errorf("cannot parse /proc/PID/status: %v", err))
+		panic(fmt.Errorf("cannot parse /proc/PID/status: %w", err))
 	}
 	cmdline, err := ioutil.ReadFile(filepath.Join("/proc", fmt.Sprintf("%d", ppid), "cmdline"))
 	if err != nil {
-		panic(fmt.Errorf("cannot read /proc/PID/cmdline: %v", err))
+		panic(fmt.Errorf("cannot read /proc/PID/cmdline: %w", err))
 	}
 	cmdline = bytes.ReplaceAll(cmdline, []byte{0}, []byte("\n"))
 	r := regexp.MustCompile("--bundle\n([^\n]*)\n")
@@ -135,13 +135,13 @@ func main() {
 	bundle := matches[1]
 	bundleConfig, err := ioutil.ReadFile(filepath.Join(bundle, "config.json"))
 	if err != nil {
-		panic(fmt.Errorf("cannot read config.json from bundle directory %q: %v", bundle, err))
+		panic(fmt.Errorf("cannot read config.json from bundle directory %q: %w", bundle, err))
 	}
 
 	ociSpec := &ocispec.Spec{}
 	err = json.Unmarshal(bundleConfig, ociSpec)
 	if err != nil {
-		panic(fmt.Errorf("cannot parse config.json: %v\n%s\n", err, string(bundleConfig)))
+		panic(fmt.Errorf("cannot parse config.json: %w\n%s", err, string(bundleConfig)))
 	}
 
 	mountSources := []string{}

--- a/integration/command.go
+++ b/integration/command.go
@@ -132,7 +132,7 @@ func (c *command) runWithoutTest() error {
 	cmd := exec.Command("/bin/sh", "-c", c.cmd)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, string(output))
+		fmt.Fprint(os.Stderr, string(output))
 		return err
 	}
 
@@ -142,7 +142,7 @@ func (c *command) runWithoutTest() error {
 	if c.expectedRegexp != "" {
 		r := regexp.MustCompile(c.expectedRegexp)
 		if !r.MatchString(actual) {
-			return fmt.Errorf("regexp didn't match: %s\n%s\n", c.expectedRegexp, actual)
+			return fmt.Errorf("regexp didn't match: %s\n%s", c.expectedRegexp, actual)
 		}
 	}
 

--- a/pkg/container-collection/container-collection.go
+++ b/pkg/container-collection/container-collection.go
@@ -88,7 +88,7 @@ initialContainersLoop:
 
 		cc.containers.Store(container.Id, container)
 		if cc.pubsub != nil {
-			cc.pubsub.Publish(pubsub.EVENT_TYPE_ADD_CONTAINER, *container)
+			cc.pubsub.Publish(pubsub.EventTypeAddContainer, *container)
 		}
 	}
 	cc.initialContainers = nil
@@ -115,7 +115,7 @@ func (cc *ContainerCollection) RemoveContainer(id string) {
 		return
 	}
 
-	cc.pubsub.Publish(pubsub.EVENT_TYPE_REMOVE_CONTAINER, *v.(*pb.ContainerDefinition))
+	cc.pubsub.Publish(pubsub.EventTypeRemoveContainer, *v.(*pb.ContainerDefinition))
 }
 
 // AddContainer adds a container to the collection.
@@ -134,7 +134,7 @@ func (cc *ContainerCollection) AddContainer(container *pb.ContainerDefinition) {
 		return
 	}
 	if cc.pubsub != nil {
-		cc.pubsub.Publish(pubsub.EVENT_TYPE_ADD_CONTAINER, *container)
+		cc.pubsub.Publish(pubsub.EventTypeAddContainer, *container)
 	}
 }
 

--- a/pkg/container-collection/options.go
+++ b/pkg/container-collection/options.go
@@ -508,7 +508,7 @@ func WithRuncFanotify() ContainerCollectionOption {
 	return func(cc *ContainerCollection) error {
 		runcNotifier, err := runcfanotify.NewRuncNotifier(func(notif runcfanotify.ContainerEvent) {
 			switch notif.Type {
-			case runcfanotify.EVENT_TYPE_ADD_CONTAINER:
+			case runcfanotify.EventTypeAddContainer:
 				mountSources := []string{}
 				for _, m := range notif.ContainerConfig.Mounts {
 					mountSources = append(mountSources, m.Source)
@@ -520,7 +520,7 @@ func WithRuncFanotify() ContainerCollectionOption {
 				}
 
 				cc.AddContainer(containerDefinition)
-			case runcfanotify.EVENT_TYPE_REMOVE_CONTAINER:
+			case runcfanotify.EventTypeRemoveContainer:
 				cc.RemoveContainer(notif.ContainerID)
 			}
 		})
@@ -557,10 +557,10 @@ func WithCgroupEnrichment() ContainerCollectionOption {
 				return true
 			}
 			cgroupPathV2WithMountpoint, _ := containerutils.CgroupPathV2AddMountpoint(cgroupPathV2)
-			cgroupId, _ := containerutils.GetCgroupID(cgroupPathV2WithMountpoint)
+			cgroupID, _ := containerutils.GetCgroupID(cgroupPathV2WithMountpoint)
 
 			container.CgroupPath = cgroupPathV2WithMountpoint
-			container.CgroupId = cgroupId
+			container.CgroupId = cgroupID
 			container.CgroupV1 = cgroupPathV1
 			container.CgroupV2 = cgroupPathV2
 			return true

--- a/pkg/controllers/trace_controller_test.go
+++ b/pkg/controllers/trace_controller_test.go
@@ -218,7 +218,7 @@ var _ = Context("Controller with a fake gadget", func() {
 					Name:      traceObjectKey.Name,
 					Namespace: traceObjectKey.Namespace,
 					Annotations: map[string]string{
-						GADGET_OPERATION: "magic",
+						GadgetOperation:  "magic",
 						"hiking.walking": "mountains",
 					},
 				},
@@ -242,7 +242,7 @@ var _ = Context("Controller with a fake gadget", func() {
 				HaveOperationError("FakeError"),
 				HaveOperationWarning("FakeWarning"),
 				HaveOutput("FakeOutput"),
-				HaveAnnotation(GADGET_OPERATION, ""),
+				HaveAnnotation(GadgetOperation, ""),
 				HaveAnnotation("hiking.walking", "mountains"),
 			))
 

--- a/pkg/gadgets/bindsnoop/types/types.go
+++ b/pkg/gadgets/bindsnoop/types/types.go
@@ -28,7 +28,7 @@ type Event struct {
 	Port      uint16 `json:"port,omitempty"`
 	Options   string `json:"opts,omitempty"`
 	Interface string `json:"if,omitempty"`
-	MountNsId uint64 `json:"mountnsid,omitempty"`
+	MountNsID uint64 `json:"mountnsid,omitempty"`
 }
 
 func Base(ev eventtypes.Event) Event {

--- a/pkg/gadgets/dns/gadget.go
+++ b/pkg/gadgets/dns/gadget.go
@@ -196,9 +196,9 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 
 	containerEventCallback := func(event pubsub.PubSubEvent) {
 		switch event.Type {
-		case pubsub.EVENT_TYPE_ADD_CONTAINER:
+		case pubsub.EventTypeAddContainer:
 			attachContainerFunc(&event.Container)
-		case pubsub.EVENT_TYPE_REMOVE_CONTAINER:
+		case pubsub.EventTypeRemoveContainer:
 			detachContainerFunc(&event.Container)
 		}
 	}

--- a/pkg/gadgets/dns/tracer/tracer.go
+++ b/pkg/gadgets/dns/tracer/tracer.go
@@ -36,9 +36,9 @@ import (
 import "C"
 
 const (
-	BPF_PROG_NAME = "bpf_prog1"
-	BPF_MAP_NAME  = "events"
-	SO_ATTACH_BPF = 50
+	BPFProgName     = "bpf_prog1"
+	BPFMapName      = "events"
+	BPFSocketAttach = 50
 )
 
 type link struct {
@@ -93,23 +93,23 @@ func (t *Tracer) Attach(
 		return fmt.Errorf("failed to create BPF collection: %w", err)
 	}
 
-	rd, err := perf.NewReader(coll.Maps[BPF_MAP_NAME], os.Getpagesize())
+	rd, err := perf.NewReader(coll.Maps[BPFMapName], os.Getpagesize())
 	if err != nil {
 		return fmt.Errorf("failed to get a perf reader: %w", err)
 	}
 
-	prog, ok := coll.Programs[BPF_PROG_NAME]
+	prog, ok := coll.Programs[BPFProgName]
 	if !ok {
-		return fmt.Errorf("Failed to find BPF program %q", BPF_PROG_NAME)
+		return fmt.Errorf("failed to find BPF program %q", BPFProgName)
 	}
 
 	sockFd, err := rawsock.OpenRawSock(pid)
 	if err != nil {
-		return fmt.Errorf("Failed to open raw socket: %w", err)
+		return fmt.Errorf("failed to open raw socket: %w", err)
 	}
 
-	if err := syscall.SetsockoptInt(sockFd, syscall.SOL_SOCKET, SO_ATTACH_BPF, prog.FD()); err != nil {
-		return fmt.Errorf("Failed to attach BPF program: %w", err)
+	if err := syscall.SetsockoptInt(sockFd, syscall.SOL_SOCKET, BPFSocketAttach, prog.FD()); err != nil {
+		return fmt.Errorf("failed to attach BPF program: %w", err)
 	}
 
 	l := &link{

--- a/pkg/gadgets/execsnoop/types/types.go
+++ b/pkg/gadgets/execsnoop/types/types.go
@@ -23,8 +23,8 @@ type Event struct {
 
 	Pid       uint32   `json:"pid,omitempty"`
 	Ppid      uint32   `json:"ppid,omitempty"`
-	Uid       uint32   `json:"uid,omitempty"`
-	MountNsId uint64   `json:"mountnsid,omitempty"`
+	UID       uint32   `json:"uid,omitempty"`
+	MountNsID uint64   `json:"mountnsid,omitempty"`
 	Retval    int      `json:"ret,omitempty"`
 	Comm      string   `json:"pcomm,omitempty"`
 	Args      []string `json:"args,omitempty"`

--- a/pkg/gadgets/filetop/gadget.go
+++ b/pkg/gadgets/filetop/gadget.go
@@ -31,10 +31,10 @@ import (
 )
 
 const (
-	MAX_ROWS_DEFAULT  = 20
-	INTERVAL_DEFAULT  = 1
-	SORT_BY_DEFAULT   = types.RBYTES
-	ALL_FILES_DEFAULT = false
+	MaxRowsDefault  = 20
+	IntervalDefault = 1
+	SortByDefault   = types.RBYTES
+	AllFilesDefault = false
 )
 
 type Trace struct {
@@ -61,8 +61,8 @@ The following parameters are supported:
  - interval: Output interval, in seconds. (default %d)
  - max_rows: Maximum rows to print. (default %d)
  - sort: The field to sort the results by (%s). (default %s)`
-	return fmt.Sprintf(t, INTERVAL_DEFAULT, MAX_ROWS_DEFAULT,
-		strings.Join(types.SortBySlice, ","), SORT_BY_DEFAULT)
+	return fmt.Sprintf(t, IntervalDefault, MaxRowsDefault,
+		strings.Join(types.SortBySlice, ","), SortByDefault)
 }
 
 func (f *TraceFactory) OutputModesSupported() map[string]struct{} {
@@ -109,10 +109,10 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 
 	traceName := gadgets.TraceName(trace.ObjectMeta.Namespace, trace.ObjectMeta.Name)
 
-	maxRows := MAX_ROWS_DEFAULT
-	intervalSeconds := INTERVAL_DEFAULT
-	sortBy := SORT_BY_DEFAULT
-	allFiles := ALL_FILES_DEFAULT
+	maxRows := MaxRowsDefault
+	intervalSeconds := IntervalDefault
+	sortBy := SortByDefault
+	allFiles := AllFilesDefault
 
 	if trace.Spec.Parameters != nil {
 		params := trace.Spec.Parameters

--- a/pkg/gadgets/filetop/types/types.go
+++ b/pkg/gadgets/filetop/types/types.go
@@ -78,18 +78,18 @@ type Stats struct {
 	WriteBytes uint64 `json:"wbytes,omitempty"`
 	Pid        uint32 `json:"pid,omitempty"`
 	Tid        uint32 `json:"tid,omitempty"`
-	MountNsId  uint64 `json:"mountnsid,omitempty"`
+	MountNsID  uint64 `json:"mountnsid,omitempty"`
 	Filename   string `json:"filename,omitempty"`
 	Comm       string `json:"comm,omitempty"`
 	FileType   byte   `json:"file_type,omitempty"`
 }
 
-func SortStats(stats []Stats, sort_by SortBy) {
+func SortStats(stats []Stats, sortBy SortBy) {
 	sort.Slice(stats, func(i, j int) bool {
 		a := stats[i]
 		b := stats[j]
 
-		switch sort_by {
+		switch sortBy {
 		case READS:
 			return a.Reads > b.Reads
 		case WRITES:

--- a/pkg/gadgets/fsslower/gadget.go
+++ b/pkg/gadgets/fsslower/gadget.go
@@ -55,7 +55,7 @@ The following parameters are supported:
 - filesystem: Which filesystem to trace [%s]
 - minlatency: Min latency to trace, in ms. (default %d)`
 
-	return fmt.Sprintf(t, strings.Join(validFilesystems, ", "), types.MIN_LATENCY_DEFAULT)
+	return fmt.Sprintf(t, strings.Join(validFilesystems, ", "), types.MinLatencyDefault)
 }
 
 func (f *TraceFactory) OutputModesSupported() map[string]struct{} {
@@ -126,7 +126,7 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 		return
 	}
 
-	minLatency := types.MIN_LATENCY_DEFAULT
+	minLatency := types.MinLatencyDefault
 
 	val, ok := params["minlatency"]
 	if ok {

--- a/pkg/gadgets/fsslower/tracer/core/tracer.go
+++ b/pkg/gadgets/fsslower/tracer/core/tracer.go
@@ -138,20 +138,20 @@ func (t *Tracer) start() error {
 
 	spec, err := loadFsslower()
 	if err != nil {
-		return fmt.Errorf("Failed to load ebpf program: %w", err)
+		return fmt.Errorf("failed to load ebpf program: %w", err)
 	}
 
-	filter_by_mnt_ns := false
+	filterByMntNs := false
 
 	if t.config.MountnsMap != "" {
-		filter_by_mnt_ns = true
+		filterByMntNs = true
 		m := spec.Maps["mount_ns_set"]
 		m.Pinning = ebpf.PinByName
 		m.Name = filepath.Base(t.config.MountnsMap)
 	}
 
 	consts := map[string]interface{}{
-		"filter_by_mnt_ns": filter_by_mnt_ns,
+		"filter_by_mnt_ns": filterByMntNs,
 		"min_lat_ns":       uint64(t.config.MinLatency * 1000 * 1000),
 	}
 
@@ -166,7 +166,7 @@ func (t *Tracer) start() error {
 	}
 
 	if err := spec.LoadAndAssign(&t.objs, &opts); err != nil {
-		return fmt.Errorf("Failed to load ebpf program: %w", err)
+		return fmt.Errorf("failed to load ebpf program: %w", err)
 	}
 
 	// choose a configuration based on the filesystem type passed
@@ -253,7 +253,7 @@ func (t *Tracer) run() {
 				Type: eventtypes.NORMAL,
 				Node: t.node,
 			},
-			MountNsId: uint64(eventC.mntns_id),
+			MountNsID: uint64(eventC.mntns_id),
 			Comm:      C.GoString(&eventC.task[0]),
 			Pid:       uint32(eventC.pid),
 			Op:        ops[int(eventC.op)],
@@ -263,7 +263,7 @@ func (t *Tracer) run() {
 			File:      C.GoString(&eventC.file[0]),
 		}
 
-		container := t.resolver.LookupContainerByMntns(event.MountNsId)
+		container := t.resolver.LookupContainerByMntns(event.MountNsID)
 		if container != nil {
 			event.Container = container.Name
 			event.Pod = container.Podname

--- a/pkg/gadgets/fsslower/types/types.go
+++ b/pkg/gadgets/fsslower/types/types.go
@@ -19,13 +19,13 @@ import (
 )
 
 const (
-	MIN_LATENCY_DEFAULT = uint(10)
+	MinLatencyDefault = uint(10)
 )
 
 type Event struct {
 	eventtypes.Event
 
-	MountNsId uint64 `json:"mountnsid,omitempty"`
+	MountNsID uint64 `json:"mountnsid,omitempty"`
 	Comm      string `json:"comm,omitempty"`
 	Pid       uint32 `json:"pid,omitempty"`
 	Op        string `json:"op,omitempty"`

--- a/pkg/gadgets/helpers.go
+++ b/pkg/gadgets/helpers.go
@@ -24,12 +24,12 @@ import (
 )
 
 const (
-	PIN_PATH         = "/sys/fs/bpf/gadget"
-	MNTMAP_PREFIX    = "mntnsset_"
-	CGROUPMAP_PREFIX = "cgroupidset_"
+	PinPath         = "/sys/fs/bpf/gadget"
+	MountMapPrefix  = "mntnsset_"
+	CGroupMapPrefix = "cgroupidset_"
 
 	// The Trace custom resource is preferably in the "gadget" namespace
-	TRACE_DEFAULT_NAMESPACE = "gadget"
+	TraceDefaultNamespace = "gadget"
 )
 
 func TraceName(namespace, name string) string {
@@ -41,7 +41,7 @@ func TraceNameFromNamespacedName(n types.NamespacedName) string {
 }
 
 func TracePinPath(namespace, name string) string {
-	return fmt.Sprintf("%s/%s%s", PIN_PATH, MNTMAP_PREFIX, TraceName(namespace, name))
+	return fmt.Sprintf("%s/%s%s", PinPath, MountMapPrefix, TraceName(namespace, name))
 }
 
 func TracePinPathFromNamespacedName(n types.NamespacedName) string {

--- a/pkg/gadgets/mountsnoop/tracer/core/tracer.go
+++ b/pkg/gadgets/mountsnoop/tracer/core/tracer.go
@@ -40,7 +40,7 @@ import (
 
 //go:generate sh -c "GOOS=$(go env GOHOSTOS) GOARCH=$(go env GOHOSTARCH) go run github.com/cilium/ebpf/cmd/bpf2go -target bpfel -cc clang mountsnoop ./bpf/mountsnoop.bpf.c -- -I./bpf/ -I../../../../ -target bpf -D__TARGET_ARCH_x86"
 
-const PERF_BUFFER_PAGES = 64
+const PerfBufferPages = 64
 
 type Tracer struct {
 	config        *tracer.Config
@@ -90,20 +90,20 @@ func (t *Tracer) start() error {
 	var err error
 	spec, err := loadMountsnoop()
 	if err != nil {
-		return fmt.Errorf("Failed to load ebpf program: %w", err)
+		return fmt.Errorf("failed to load ebpf program: %w", err)
 	}
 
-	filter_by_mnt_ns := false
+	filterByMntNs := false
 
 	if t.config.MountnsMap != "" {
-		filter_by_mnt_ns = true
+		filterByMntNs = true
 		m := spec.Maps["mount_ns_set"]
 		m.Pinning = ebpf.PinByName
 		m.Name = filepath.Base(t.config.MountnsMap)
 	}
 
 	consts := map[string]interface{}{
-		"filter_by_mnt_ns": filter_by_mnt_ns,
+		"filter_by_mnt_ns": filterByMntNs,
 	}
 
 	if err := spec.RewriteConstants(consts); err != nil {
@@ -117,32 +117,32 @@ func (t *Tracer) start() error {
 	}
 
 	if err := spec.LoadAndAssign(&t.objs, &opts); err != nil {
-		return fmt.Errorf("Failed to load ebpf program: %w", err)
+		return fmt.Errorf("failed to load ebpf program: %w", err)
 	}
 
 	t.mountEnterLink, err = link.Tracepoint("syscalls", "sys_enter_mount", t.objs.MountEntry)
 	if err != nil {
-		return fmt.Errorf("Error opening tracepoint: %w", err)
+		return fmt.Errorf("error opening tracepoint: %w", err)
 	}
 
 	t.mountExitLink, err = link.Tracepoint("syscalls", "sys_exit_mount", t.objs.MountExit)
 	if err != nil {
-		return fmt.Errorf("Error opening tracepoint: %w", err)
+		return fmt.Errorf("error opening tracepoint: %w", err)
 	}
 
 	t.umountEnterLink, err = link.Tracepoint("syscalls", "sys_enter_umount", t.objs.UmountEntry)
 	if err != nil {
-		return fmt.Errorf("Error opening tracepoint: %w", err)
+		return fmt.Errorf("error opening tracepoint: %w", err)
 	}
 
 	t.umountExitLink, err = link.Tracepoint("syscalls", "sys_exit_umount", t.objs.UmountExit)
 	if err != nil {
-		return fmt.Errorf("Error opening tracepoint: %w", err)
+		return fmt.Errorf("error opening tracepoint: %w", err)
 	}
 
-	t.reader, err = perf.NewReader(t.objs.mountsnoopMaps.Events, PERF_BUFFER_PAGES*os.Getpagesize())
+	t.reader, err = perf.NewReader(t.objs.mountsnoopMaps.Events, PerfBufferPages*os.Getpagesize())
 	if err != nil {
-		return fmt.Errorf("Error creating perf ring buffer: %w", err)
+		return fmt.Errorf("error creating perf ring buffer: %w", err)
 	}
 
 	go t.run()
@@ -177,7 +177,7 @@ func (t *Tracer) run() {
 				Type: eventtypes.NORMAL,
 				Node: t.node,
 			},
-			MountNsId: uint64(eventC.mount_ns_id),
+			MountNsID: uint64(eventC.mount_ns_id),
 			Pid:       uint32(eventC.pid),
 			Tid:       uint32(eventC.tid),
 			Comm:      C.GoString(&eventC.comm[0]),
@@ -200,7 +200,7 @@ func (t *Tracer) run() {
 
 		event.Flags = tracer.DecodeFlags(uint64(eventC.flags))
 
-		container := t.resolver.LookupContainerByMntns(event.MountNsId)
+		container := t.resolver.LookupContainerByMntns(event.MountNsID)
 		if container != nil {
 			event.Container = container.Name
 			event.Pod = container.Podname

--- a/pkg/gadgets/mountsnoop/types/types.go
+++ b/pkg/gadgets/mountsnoop/types/types.go
@@ -21,7 +21,7 @@ import (
 type Event struct {
 	eventtypes.Event
 
-	MountNsId uint64   `json:"mntnsid,omitempty"`
+	MountNsID uint64   `json:"mntnsid,omitempty"`
 	Pid       uint32   `json:"pid,omitempty"`
 	Tid       uint32   `json:"tid,omitempty"`
 	Comm      string   `json:"comm,omitempty"`

--- a/pkg/gadgets/networkpolicy/advisor/advisor.go
+++ b/pkg/gadgets/networkpolicy/advisor/advisor.go
@@ -82,7 +82,7 @@ func (a *NetworkPolicyAdvisor) LoadBuffer(buf []byte) error {
 		line++
 		err = json.Unmarshal([]byte(text), &event)
 		if err != nil {
-			return fmt.Errorf("cannot parse line %d: %s", line, err)
+			return fmt.Errorf("cannot parse line %d: %w", line, err)
 		}
 		events = append(events, event)
 	}

--- a/pkg/gadgets/oomkill/types/types.go
+++ b/pkg/gadgets/oomkill/types/types.go
@@ -26,7 +26,7 @@ type Event struct {
 	KilledPid     uint32 `json:"kpid,omitempty"`
 	KilledComm    string `json:"kcomm,omitempty"`
 	Pages         uint64 `json:"pages,omitempty"`
-	MountNsId     uint64 `json:"mountnsid,omitempty"`
+	MountNsID     uint64 `json:"mountnsid,omitempty"`
 }
 
 func Base(ev eventtypes.Event) Event {

--- a/pkg/gadgets/opensnoop/tracer/core/tracer.go
+++ b/pkg/gadgets/opensnoop/tracer/core/tracer.go
@@ -86,20 +86,20 @@ func (t *Tracer) Stop() {
 func (t *Tracer) start() error {
 	spec, err := loadOpensnoop()
 	if err != nil {
-		return fmt.Errorf("Failed to load ebpf program: %w", err)
+		return fmt.Errorf("failed to load ebpf program: %w", err)
 	}
 
-	filter_by_mnt_ns := false
+	filterByMntNs := false
 
 	if t.config.MountnsMap != "" {
-		filter_by_mnt_ns = true
+		filterByMntNs = true
 		m := spec.Maps["mount_ns_set"]
 		m.Pinning = ebpf.PinByName
 		m.Name = filepath.Base(t.config.MountnsMap)
 	}
 
 	consts := map[string]interface{}{
-		"filter_by_mnt_ns": filter_by_mnt_ns,
+		"filter_by_mnt_ns": filterByMntNs,
 	}
 
 	if err := spec.RewriteConstants(consts); err != nil {
@@ -113,36 +113,36 @@ func (t *Tracer) start() error {
 	}
 
 	if err := spec.LoadAndAssign(&t.objs, &opts); err != nil {
-		return fmt.Errorf("Failed to load ebpf program: %w", err)
+		return fmt.Errorf("failed to load ebpf program: %w", err)
 	}
 
 	openEnter, err := link.Tracepoint("syscalls", "sys_enter_open", t.objs.TracepointSyscallsSysEnterOpen)
 	if err != nil {
-		return fmt.Errorf("Error opening tracepoint: %w", err)
+		return fmt.Errorf("error opening tracepoint: %w", err)
 	}
 	t.openEnterLink = openEnter
 
 	openAtEnter, err := link.Tracepoint("syscalls", "sys_enter_openat", t.objs.TracepointSyscallsSysEnterOpenat)
 	if err != nil {
-		return fmt.Errorf("Error opening tracepoint: %w", err)
+		return fmt.Errorf("error opening tracepoint: %w", err)
 	}
 	t.openAtEnterLink = openAtEnter
 
 	openExit, err := link.Tracepoint("syscalls", "sys_exit_open", t.objs.TracepointSyscallsSysExitOpen)
 	if err != nil {
-		return fmt.Errorf("Error opening tracepoint: %w", err)
+		return fmt.Errorf("error opening tracepoint: %w", err)
 	}
 	t.openExitLink = openExit
 
 	openAtExit, err := link.Tracepoint("syscalls", "sys_exit_openat", t.objs.TracepointSyscallsSysExitOpenat)
 	if err != nil {
-		return fmt.Errorf("Error opening tracepoint: %w", err)
+		return fmt.Errorf("error opening tracepoint: %w", err)
 	}
 	t.openAtExitLink = openAtExit
 
 	reader, err := perf.NewReader(t.objs.opensnoopMaps.Events, 4096)
 	if err != nil {
-		return fmt.Errorf("Error creating perf ring buffer: %w", err)
+		return fmt.Errorf("error creating perf ring buffer: %w", err)
 	}
 	t.reader = reader
 
@@ -188,9 +188,9 @@ func (t *Tracer) run() {
 				Type: eventtypes.NORMAL,
 				Node: t.node,
 			},
-			MountNsId: uint64(eventC.mntns_id),
+			MountNsID: uint64(eventC.mntns_id),
 			Pid:       uint32(eventC.pid),
-			Uid:       uint32(eventC.uid),
+			UID:       uint32(eventC.uid),
 			Comm:      C.GoString(&eventC.comm[0]),
 			Ret:       ret,
 			Fd:        fd,
@@ -198,7 +198,7 @@ func (t *Tracer) run() {
 			Path:      C.GoString(&eventC.fname[0]),
 		}
 
-		container := t.resolver.LookupContainerByMntns(event.MountNsId)
+		container := t.resolver.LookupContainerByMntns(event.MountNsID)
 		if container != nil {
 			event.Container = container.Name
 			event.Pod = container.Podname

--- a/pkg/gadgets/opensnoop/types/types.go
+++ b/pkg/gadgets/opensnoop/types/types.go
@@ -21,9 +21,9 @@ import (
 type Event struct {
 	eventtypes.Event
 
-	MountNsId uint64 `json:"mountnsid,omitempty"`
+	MountNsID uint64 `json:"mountnsid,omitempty"`
 	Pid       uint32 `json:"pid,omitempty"`
-	Uid       uint32 `json:"uid,omitempty"`
+	UID       uint32 `json:"uid,omitempty"`
 	Comm      string `json:"pcomm,omitempty"`
 	Fd        int    `json:"fd,omitempty"`
 	Ret       int    `json:"ret,omitempty"`

--- a/pkg/gadgets/process-collector/tracer/tracer.go
+++ b/pkg/gadgets/process-collector/tracer/tracer.go
@@ -29,7 +29,7 @@ import (
 )
 
 const (
-	BPF_ITER_NAME = "dump_task"
+	BPFIterName = "dump_task"
 )
 
 func RunCollector(resolver gadgets.Resolver, node, mntnsmap string) ([]processcollectortypes.Event, error) {
@@ -37,8 +37,8 @@ func RunCollector(resolver gadgets.Resolver, node, mntnsmap string) ([]processco
 	if mntnsmap == "" {
 		prog = ebpfProg
 	} else {
-		if filepath.Dir(mntnsmap) != gadgets.PIN_PATH {
-			return nil, fmt.Errorf("error while checking pin path: only paths in %s are supported", gadgets.PIN_PATH)
+		if filepath.Dir(mntnsmap) != gadgets.PinPath {
+			return nil, fmt.Errorf("error while checking pin path: only paths in %s are supported", gadgets.PinPath)
 		}
 
 		prog = ebpfProgWithFilter
@@ -56,7 +56,7 @@ func RunCollector(resolver gadgets.Resolver, node, mntnsmap string) ([]processco
 	coll, err := ebpf.NewCollectionWithOptions(spec,
 		ebpf.CollectionOptions{
 			Maps: ebpf.MapOptions{
-				PinPath: gadgets.PIN_PATH,
+				PinPath: gadgets.PinPath,
 			},
 		},
 	)
@@ -64,9 +64,9 @@ func RunCollector(resolver gadgets.Resolver, node, mntnsmap string) ([]processco
 		return nil, fmt.Errorf("failed to create BPF collection: %w", err)
 	}
 
-	dumpTask, ok := coll.Programs[BPF_ITER_NAME]
+	dumpTask, ok := coll.Programs[BPFIterName]
 	if !ok {
-		return nil, fmt.Errorf("failed to find BPF iterator %q", BPF_ITER_NAME)
+		return nil, fmt.Errorf("failed to find BPF iterator %q", BPFIterName)
 	}
 	dumpTaskIter, err := link.AttachIter(link.IterOptions{
 		Program: dumpTask,
@@ -109,10 +109,10 @@ func RunCollector(resolver gadgets.Resolver, node, mntnsmap string) ([]processco
 				Pod:       container.Podname,
 				Container: container.Name,
 			},
-			Tgid:    tgid,
-			Pid:     pid,
-			Command: command,
-			MntNsId: mntnsid,
+			Tgid:      tgid,
+			Pid:       pid,
+			Command:   command,
+			MountNsID: mntnsid,
 		})
 	}
 

--- a/pkg/gadgets/process-collector/types/process-collector.go
+++ b/pkg/gadgets/process-collector/types/process-collector.go
@@ -20,8 +20,8 @@ import (
 
 type Event struct {
 	eventtypes.Event
-	Tgid    int    `json:"tgid"`
-	Pid     int    `json:"pid"`
-	Command string `json:"comm"`
-	MntNsId uint64 `json:"mntns"`
+	Tgid      int    `json:"tgid"`
+	Pid       int    `json:"pid"`
+	Command   string `json:"comm"`
+	MountNsID uint64 `json:"mntns"`
 }

--- a/pkg/gadgets/seccomp/gadget.go
+++ b/pkg/gadgets/seccomp/gadget.go
@@ -406,7 +406,7 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 			*gadgets.ContainerSelectorFromContainerFilter(trace.Spec.Filter),
 			func(event pubsub.PubSubEvent) {
 				// Ignore container creation events.
-				if event.Type != pubsub.EVENT_TYPE_REMOVE_CONTAINER {
+				if event.Type != pubsub.EventTypeRemoveContainer {
 					return
 				}
 				t.containerTerminated(traceCopy, event)

--- a/pkg/gadgets/seccomp/tracer/tracer.go
+++ b/pkg/gadgets/seccomp/tracer/tracer.go
@@ -28,8 +28,8 @@ import (
 import "C"
 
 const (
-	BPF_PROG_NAME = "tracepoint__raw_syscalls__sys_enter"
-	BPF_MAP_NAME  = "syscalls_per_mntns"
+	BPFProgName = "tracepoint__raw_syscalls__sys_enter"
+	BPFMapName  = "syscalls_per_mntns"
 )
 
 type Tracer struct {
@@ -46,24 +46,24 @@ type Tracer struct {
 func NewTracer() (*Tracer, error) {
 	spec, err := ebpf.LoadCollectionSpecFromReader(bytes.NewReader(ebpfProg))
 	if err != nil {
-		return nil, fmt.Errorf("failed to load asset: %s", err)
+		return nil, fmt.Errorf("failed to load asset: %w", err)
 	}
 
 	coll, err := ebpf.NewCollection(spec)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create BPF collection: %s", err)
+		return nil, fmt.Errorf("failed to create BPF collection: %w", err)
 	}
 
 	t := &Tracer{
 		collection: coll,
-		seccompMap: coll.Maps[BPF_MAP_NAME],
+		seccompMap: coll.Maps[BPFMapName],
 	}
 
 	t.seccompMap.Update(uint64(0), [C.SYSCALLS_MAP_VALUE_SIZE]byte{}, ebpf.UpdateAny)
 
-	tracepointProg, ok := coll.Programs[BPF_PROG_NAME]
+	tracepointProg, ok := coll.Programs[BPFProgName]
 	if !ok {
-		return nil, fmt.Errorf("failed to find BPF program %q", BPF_PROG_NAME)
+		return nil, fmt.Errorf("failed to find BPF program %q", BPFProgName)
 	}
 
 	t.progLink, err = link.AttachRawTracepoint(link.RawTracepointOptions{
@@ -71,7 +71,7 @@ func NewTracer() (*Tracer, error) {
 		Program: tracepointProg,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to open tracepoint: %s", err)
+		return nil, fmt.Errorf("failed to open tracepoint: %w", err)
 	}
 
 	return t, nil

--- a/pkg/gadgets/sigsnoop/types/types.go
+++ b/pkg/gadgets/sigsnoop/types/types.go
@@ -26,7 +26,7 @@ type Event struct {
 	Signal    string `json:"signal,omitempty"`
 	Retval    int    `json:"ret,omitempty"`
 	Comm      string `json:"comm,omitempty"`
-	MountNsId uint64 `json:"mountnsid,omitempty"`
+	MountNsID uint64 `json:"mountnsid,omitempty"`
 }
 
 func Base(ev eventtypes.Event) Event {

--- a/pkg/gadgets/snisnoop/gadget.go
+++ b/pkg/gadgets/snisnoop/gadget.go
@@ -220,9 +220,9 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 
 	containerEventCallback := func(event pubsub.PubSubEvent) {
 		switch event.Type {
-		case pubsub.EVENT_TYPE_ADD_CONTAINER:
+		case pubsub.EventTypeAddContainer:
 			attachContainerFunc(&event.Container)
-		case pubsub.EVENT_TYPE_REMOVE_CONTAINER:
+		case pubsub.EventTypeRemoveContainer:
 			detachContainerFunc(&event.Container)
 		}
 	}

--- a/pkg/gadgets/snisnoop/tracer/tracer.go
+++ b/pkg/gadgets/snisnoop/tracer/tracer.go
@@ -36,9 +36,9 @@ import (
 import "C"
 
 const (
-	BPF_PROG_NAME = "bpf_prog1"
-	BPF_MAP_NAME  = "events"
-	SO_ATTACH_BPF = 50
+	BPFProgName     = "bpf_prog1"
+	BPFMapName      = "events"
+	BPFSocketAttach = 50
 )
 
 type link struct {
@@ -100,14 +100,14 @@ func (t *Tracer) Attach(
 		return fmt.Errorf("failed to create BPF collection: %w", err)
 	}
 
-	rd, err := perf.NewReader(coll.Maps[BPF_MAP_NAME], os.Getpagesize())
+	rd, err := perf.NewReader(coll.Maps[BPFMapName], os.Getpagesize())
 	if err != nil {
 		return fmt.Errorf("failed to get a perf reader: %w", err)
 	}
 
-	prog, ok := coll.Programs[BPF_PROG_NAME]
+	prog, ok := coll.Programs[BPFProgName]
 	if !ok {
-		return fmt.Errorf("failed to find BPF program %q", BPF_PROG_NAME)
+		return fmt.Errorf("failed to find BPF program %q", BPFProgName)
 	}
 
 	sockFd, err := rawsock.OpenRawSock(pid)
@@ -115,7 +115,7 @@ func (t *Tracer) Attach(
 		return fmt.Errorf("failed to open raw socket: %w", err)
 	}
 
-	if err := syscall.SetsockoptInt(sockFd, syscall.SOL_SOCKET, SO_ATTACH_BPF, prog.FD()); err != nil {
+	if err := syscall.SetsockoptInt(sockFd, syscall.SOL_SOCKET, BPFSocketAttach, prog.FD()); err != nil {
 		return fmt.Errorf("failed to attach BPF program: %w", err)
 	}
 

--- a/pkg/gadgets/tcpconnect/types/types.go
+++ b/pkg/gadgets/tcpconnect/types/types.go
@@ -21,9 +21,9 @@ import (
 type Event struct {
 	eventtypes.Event
 
-	MountNsId uint64 `json:"mountnsid,omitempty"`
+	MountNsID uint64 `json:"mountnsid,omitempty"`
 	Pid       uint32 `json:"pid,omitempty"`
-	Uid       uint32 `json:"uid,omitempty"`
+	UID       uint32 `json:"uid,omitempty"`
 	Comm      string `json:"comm,omitempty"`
 	IPVersion int    `json:"ipversion,omitempty"`
 	Saddr     string `json:"saddr,omitempty"`

--- a/pkg/gadgets/traceloop/gadget.go
+++ b/pkg/gadgets/traceloop/gadget.go
@@ -138,12 +138,12 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 
 func (t *Trace) stop() error {
 	if !t.started {
-		return errors.New("Not started")
+		return errors.New("not started")
 	}
 
 	err := t.cmd.Process.Signal(syscall.SIGINT)
 	if err != nil {
-		return fmt.Errorf("Failed to send SIGINT to process: %w", err)
+		return fmt.Errorf("failed to send SIGINT to process: %w", err)
 	}
 
 	timeout := time.After(2 * time.Second)

--- a/pkg/gadgettracermanager/common.go
+++ b/pkg/gadgettracermanager/common.go
@@ -18,15 +18,15 @@ package gadgettracermanager
 import "C"
 
 const (
-	NAME_MAX_LENGTH         = C.NAME_MAX_LENGTH
-	NAME_MAX_CHARACTERS     = NAME_MAX_LENGTH - 1
-	MAX_CONTAINERS_PER_NODE = C.MAX_CONTAINERS_PER_NODE
+	NameMaxLength        = C.NAME_MAX_LENGTH
+	NameMaxCharacters    = NameMaxLength - 1
+	MaxContainersPerNode = C.MAX_CONTAINERS_PER_NODE
 )
 
 type container = C.struct_container
 
-func copyToC(dest *[NAME_MAX_LENGTH]C.char, source string) {
-	for i := 0; i < len(source) && i < NAME_MAX_CHARACTERS; i++ {
+func copyToC(dest *[NameMaxLength]C.char, source string) {
+	for i := 0; i < len(source) && i < NameMaxCharacters; i++ {
 		dest[i] = C.char(source[i])
 	}
 }

--- a/pkg/gadgettracermanager/containers-map/tracer.go
+++ b/pkg/gadgettracermanager/containers-map/tracer.go
@@ -22,7 +22,7 @@ import (
 )
 
 const (
-	BPF_MAP_NAME = "containers"
+	BPFMapName = "containers"
 )
 
 func CreateContainersMap(pinPath string) (*ebpf.Map, error) {
@@ -39,5 +39,5 @@ func CreateContainersMap(pinPath string) (*ebpf.Map, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to create BPF collection: %w", err)
 	}
-	return coll.Maps[BPF_MAP_NAME], nil
+	return coll.Maps[BPFMapName], nil
 }

--- a/pkg/gadgettracermanager/containerutils/containerd/containerd.go
+++ b/pkg/gadgettracermanager/containerutils/containerd/containerd.go
@@ -27,8 +27,8 @@ import (
 )
 
 const (
-	DEFAULT_SOCKET_PATH = "/run/containerd/containerd.sock"
-	DEFAULT_TIMEOUT     = 2 * time.Second
+	DefaultSocketPath = "/run/containerd/containerd.sock"
+	DefaultTimeout    = 2 * time.Second
 )
 
 type ContainerdClient struct {
@@ -41,7 +41,7 @@ func NewContainerdClient(path string) (*ContainerdClient, error) {
 		path,
 		grpc.WithInsecure(),
 		grpc.WithDialer(func(addr string, timeout time.Duration) (net.Conn, error) {
-			return net.DialTimeout("unix", path, DEFAULT_TIMEOUT)
+			return net.DialTimeout("unix", path, DefaultTimeout)
 		}),
 	)
 	if err != nil {
@@ -63,9 +63,9 @@ func (c *ContainerdClient) Close() error {
 	return nil
 }
 
-func (c *ContainerdClient) PidFromContainerId(containerID string) (int, error) {
+func (c *ContainerdClient) PidFromContainerID(containerID string) (int, error) {
 	if !strings.HasPrefix(containerID, "containerd://") {
-		return -1, fmt.Errorf("Invalid CRI %s, it should be containerd", containerID)
+		return -1, fmt.Errorf("invalid CRI %s, it should be containerd", containerID)
 	}
 
 	containerID = strings.TrimPrefix(containerID, "containerd://")

--- a/pkg/gadgettracermanager/containerutils/crio/crio.go
+++ b/pkg/gadgettracermanager/containerutils/crio/crio.go
@@ -28,8 +28,8 @@ import (
 )
 
 const (
-	DEFAULT_SOCKET_PATH = "/run/crio/crio.sock"
-	DEFAULT_TIMEOUT     = 2 * time.Second
+	DefaultSocketPath = "/run/crio/crio.sock"
+	DefaultTimeout    = 2 * time.Second
 )
 
 type CrioClient struct {
@@ -42,7 +42,7 @@ func NewCrioClient(path string) (*CrioClient, error) {
 		path,
 		grpc.WithInsecure(),
 		grpc.WithDialer(func(addr string, timeout time.Duration) (net.Conn, error) {
-			return net.DialTimeout("unix", path, DEFAULT_TIMEOUT)
+			return net.DialTimeout("unix", path, DefaultTimeout)
 		}),
 	)
 	if err != nil {
@@ -101,9 +101,9 @@ func parseExtraInfo(extraInfo map[string]string) (int, error) {
 	return infoContent.Pid, nil
 }
 
-func (c *CrioClient) PidFromContainerId(containerID string) (int, error) {
+func (c *CrioClient) PidFromContainerID(containerID string) (int, error) {
 	if !strings.HasPrefix(containerID, "cri-o://") {
-		return -1, fmt.Errorf("Invalid CRI %s, it should be cri-o", containerID)
+		return -1, fmt.Errorf("invalid CRI %s, it should be cri-o", containerID)
 	}
 
 	containerID = strings.TrimPrefix(containerID, "cri-o://")

--- a/pkg/gadgettracermanager/k8s/k8s.go
+++ b/pkg/gadgettracermanager/k8s/k8s.go
@@ -56,7 +56,7 @@ func NewK8sClient(nodeName string) (*K8sClient, error) {
 
 	node, err := clientset.CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("Failed to get node %s", err)
+		return nil, fmt.Errorf("failed to get node %w", err)
 	}
 
 	// get a CRI client to talk to the CRI handling pods in this node
@@ -78,20 +78,20 @@ func newCRIClient(node *v1.Node) (containerutils.CRIClient, error) {
 	criVersion := node.Status.NodeInfo.ContainerRuntimeVersion
 	list := strings.Split(criVersion, "://")
 	if len(list) < 1 {
-		return nil, fmt.Errorf("Impossible to get CRI type from %s", criVersion)
+		return nil, fmt.Errorf("impossible to get CRI type from %s", criVersion)
 	}
 
 	criType := list[0]
 
 	switch criType {
 	case "docker":
-		return docker.NewDockerClient(docker.DEFAULT_SOCKET_PATH)
+		return docker.NewDockerClient(docker.DefaultSocketPath)
 	case "containerd":
-		return containerd.NewContainerdClient(containerd.DEFAULT_SOCKET_PATH)
+		return containerd.NewContainerdClient(containerd.DefaultSocketPath)
 	case "cri-o":
-		return crio.NewCrioClient(crio.DEFAULT_SOCKET_PATH)
+		return crio.NewCrioClient(crio.DefaultSocketPath)
 	default:
-		return nil, fmt.Errorf("Unknown '%s' cri", criType)
+		return nil, fmt.Errorf("unknown '%s' cri", criType)
 	}
 }
 
@@ -129,7 +129,7 @@ func (k *K8sClient) PodToContainers(pod *v1.Pod) []pb.ContainerDefinition {
 			continue
 		}
 
-		pid, err := k.criClient.PidFromContainerId(s.ContainerID)
+		pid, err := k.criClient.PidFromContainerID(s.ContainerID)
 		if err != nil {
 			log.Warnf("Skip pod %s/%s: cannot find pid: %v", pod.GetNamespace(), pod.GetName(), err)
 			continue

--- a/pkg/gadgettracermanager/k8s/podinformer.go
+++ b/pkg/gadgettracermanager/k8s/podinformer.go
@@ -20,7 +20,7 @@
 package k8s
 
 import (
-	"fmt"
+	"errors"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -146,7 +146,7 @@ func (p *PodInformer) Run(threadiness int, stopCh chan struct{}) {
 
 	// Wait for all involved caches to be synced, before processing items from the queue is started
 	if !cache.WaitForCacheSync(stopCh, p.informer.HasSynced) {
-		runtime.HandleError(fmt.Errorf("Timed out waiting for caches to sync"))
+		runtime.HandleError(errors.New("timed out waiting for caches to sync"))
 		return
 	}
 

--- a/pkg/gadgettracermanager/pubsub/pubsub.go
+++ b/pkg/gadgettracermanager/pubsub/pubsub.go
@@ -25,8 +25,8 @@ type EventType int
 type FuncNotify func(event PubSubEvent)
 
 const (
-	EVENT_TYPE_ADD_CONTAINER EventType = iota
-	EVENT_TYPE_REMOVE_CONTAINER
+	EventTypeAddContainer EventType = iota
+	EventTypeRemoveContainer
 )
 
 type PubSubEvent struct {

--- a/pkg/gadgettracermanager/pubsub/pubsub_test.go
+++ b/pkg/gadgettracermanager/pubsub/pubsub_test.go
@@ -38,13 +38,13 @@ func TestPubSub(t *testing.T) {
 
 	p.Subscribe(key, callback, nil)
 
-	p.Publish(EVENT_TYPE_REMOVE_CONTAINER, pb.ContainerDefinition{Id: "container1"})
+	p.Publish(EventTypeRemoveContainer, pb.ContainerDefinition{Id: "container1"})
 	_, ok := <-done
 	if !ok {
 		t.Fatalf("Failed to receive event from callback")
 	}
 
-	if event.Type != EVENT_TYPE_REMOVE_CONTAINER {
+	if event.Type != EventTypeRemoveContainer {
 		t.Fatalf("Failed to receive correct event of type EVENT_TYPE_REMOVE_CONTAINER")
 	}
 	if event.Container.Id != "container1" {
@@ -52,7 +52,7 @@ func TestPubSub(t *testing.T) {
 	}
 
 	p.Unsubscribe(key)
-	p.Publish(EVENT_TYPE_REMOVE_CONTAINER, pb.ContainerDefinition{Id: "container2"})
+	p.Publish(EventTypeRemoveContainer, pb.ContainerDefinition{Id: "container2"})
 	if counter != 1 {
 		t.Fatalf("Callback called too many times")
 	}

--- a/pkg/gadgettracermanager/stream/stream.go
+++ b/pkg/gadgettracermanager/stream/stream.go
@@ -20,8 +20,8 @@ import (
 )
 
 const (
-	HISTORY_SIZE     = 100
-	SUB_CHANNEL_SIZE = 250
+	HistorySize    = 100
+	SubChannelSize = 250
 )
 
 type TimestampedLine struct {
@@ -30,7 +30,6 @@ type TimestampedLine struct {
 	EventLost bool
 }
 
-// GadgetStream
 type GadgetStream struct {
 	mu sync.RWMutex
 
@@ -56,7 +55,7 @@ func (g *GadgetStream) Subscribe() chan TimestampedLine {
 		return nil
 	}
 
-	ch := make(chan TimestampedLine, SUB_CHANNEL_SIZE)
+	ch := make(chan TimestampedLine, SubChannelSize)
 	for _, l := range g.previousLines {
 		ch <- l
 	}
@@ -93,7 +92,7 @@ func (g *GadgetStream) Publish(line string) {
 		Timestamp: time.Now(),
 	}
 
-	if len(g.previousLines) == HISTORY_SIZE {
+	if len(g.previousLines) == HistorySize {
 		// Force new array allocation to avoid an ever growing underlying array
 		// TODO: check possible performance issue
 		g.previousLines = append([]TimestampedLine{}, g.previousLines[1:]...)

--- a/pkg/k8sutil/client.go
+++ b/pkg/k8sutil/client.go
@@ -15,6 +15,7 @@
 package k8sutil
 
 import (
+	"errors"
 	"path/filepath"
 
 	"k8s.io/cli-runtime/pkg/genericclioptions"
@@ -34,7 +35,7 @@ func NewClientset(kubeconfigPath string) (*kubernetes.Clientset, error) {
 	} else {
 		// kubeconfig from a pod Service Account token
 		config, err = rest.InClusterConfig()
-		if err == rest.ErrNotInCluster {
+		if errors.Is(err, rest.ErrNotInCluster) {
 			// kubeconfig from $HOME/.kube/config
 			if home := homedir.HomeDir(); home != "" {
 				config, err = clientcmd.BuildConfigFromFlags("", filepath.Join(home, ".kube", "config"))

--- a/pkg/local-gadget-manager/local-gadget-manager.go
+++ b/pkg/local-gadget-manager/local-gadget-manager.go
@@ -174,7 +174,7 @@ func (l *LocalGadgetManager) Operation(name, opname string) error {
 	if opname != "" {
 		gadgetOperation, ok := tracer.factory.Operations()[opname]
 		if !ok {
-			return fmt.Errorf("Unknown operation %q", opname)
+			return fmt.Errorf("unknown operation %q", opname)
 		}
 		tracerNamespacedName := tracer.traceResource.ObjectMeta.Namespace +
 			"/" + tracer.traceResource.ObjectMeta.Name


### PR DESCRIPTION
# Add go linters stylecheck, staticcheck and errorlint

The aim of this PR is to uniform the code style and speed up PR reviews. To do so, this PR adds three Go linters: stylecheck, staticcheck and errorlint to automate the work.

Regarding `errorlint`, check https://github.com/polyfloyd/go-errorlint for further details. There are three main checks:
- Use `%w` to format errors in `fmt.Errorf()`
- Comparison of errors is done using `errors.Is()`
- Type assertions of errors is done using `errors.As()`

Regarding `stylecheck` and `staticcheck`, check https://staticcheck.io/docs/checks/ for further details. Some examples of checks:
- ALL_CAPS should not be used in Go names; use CamelCase instead
- Underscores should not be used in Go names
- Error strings should not be capitalized
- Error strings should not end with punctuation or a newline
- Keywords like ID and JSON on variables and function names should be in uppercase, e.g. var `tracerId` should be `tracerID`.

## Warning

Only two errors were not fixed and were skipped by adding exceptions. They will be managed in separate PRs, see issues #540 and #541.