### PR TITLE
docs: Fix install link

### DIFF
--- a/docs/_index.md
+++ b/docs/_index.md
@@ -20,6 +20,6 @@ programs are and how Inspektor Gadget uses them is briefly explained here:
 ## Further Reading
 
 * [Read more about the architecture](architecture.md)
-* [Learn how to install Inspektor Gadget](installation.md)
+* [Learn how to install Inspektor Gadget](install.md)
 * [Kernel requirements for each gadget](requirements.md)
 * [Using `Trace` resources](custom-resources.md)


### PR DESCRIPTION
Brace yourselves for some heavy contribution.

This PR fixes a [broken link](https://kinvolk.io/docs/inspektor-gadget/latest/) to the installation page, spotted while digging into inspektor-gadget.

Hope this helps.
