### PR TITLE
cmd/kubectl-gadget: Fix seccomp-advisor gadget help

### DIFF
--- a/cmd/kubectl-gadget/seccompadvisor.go
+++ b/cmd/kubectl-gadget/seccompadvisor.go
@@ -44,7 +44,7 @@ var seccompAdvisorStartCmd = &cobra.Command{
 }
 
 var seccompAdvisorStopCmd = &cobra.Command{
-	Use:          "stop",
+	Use:          "stop <trace-id>",
 	Short:        "Stop monitoring and report the policies",
 	RunE:         runSeccompAdvisorStop,
 	SilenceUsage: true,


### PR DESCRIPTION
# Fix seccomp-advisor gadget help

It is mandatory to specify the trace ID when stopping the seccomp-advisor gadget but it is not mentioned at all in the command help.

I followed the same notation of [biolatency](https://github.com/kinvolk/inspektor-gadget/blob/1d273dfb08b1c922c1ba158a4d301067f3d923e7/cmd/kubectl-gadget/biolatency.go#L64).

### Before this PR
```bash
$ kubectl gadget seccomp-advisor stop --help
Stop monitoring and report the policies

Usage:
  kubectl-gadget seccomp-advisor stop [flags]

Flags:
  -h, --help   help for stop

Global Flags:
  -A, --all-namespaces                 Show data from pods in all namespaces
...
```

### After this PR:
```bash
$ ./kubectl-gadget seccomp-advisor stop --help
Stop monitoring and report the policies

Usage:
  kubectl-gadget seccomp-advisor stop <trace-id> [flags]

Flags:
  -h, --help   help for stop

Global Flags:
  -A, --all-namespaces                 Show data from pods in all namespaces
...

```