### PR TITLE
Remove tools-mode flag

### DIFF
--- a/cmd/kubectl-gadget/bcck8s.go
+++ b/cmd/kubectl-gadget/bcck8s.go
@@ -32,10 +32,6 @@ import (
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// create the commands for the different gadgets. The gadgets that have CO-RE
-// support should use "/bin/gadgets/" as the path for the binary. Otherwise
-// "/usr/share/bcc/tools/" should be used.
-
 var biotopCmd = &cobra.Command{
 	Use:   "biotop",
 	Short: "Trace block device I/O",

--- a/cmd/kubectl-gadget/deploy.go
+++ b/cmd/kubectl-gadget/deploy.go
@@ -38,7 +38,6 @@ var (
 	imagePullPolicy     string
 	hookMode            string
 	livenessProbe       bool
-	toolsMode           string
 	fallbackPodInformer bool
 )
 
@@ -63,11 +62,6 @@ func init() {
 		"liveness-probe", "",
 		true,
 		"enable liveness probes")
-	deployCmd.PersistentFlags().StringVarP(
-		&toolsMode,
-		"tools-mode", "",
-		"standard",
-		"which kind of tools to use (auto, core, standard)")
 	deployCmd.PersistentFlags().BoolVarP(
 		&fallbackPodInformer,
 		"fallback-podinformer", "",
@@ -231,8 +225,6 @@ spec:
             value: {{.Version}}
           - name: INSPEKTOR_GADGET_OPTION_HOOK_MODE
             value: "{{.HookMode}}"
-          - name: INSPEKTOR_GADGET_OPTION_TOOLS_MODE
-            value: "{{.ToolsMode}}"
           - name: INSPEKTOR_GADGET_OPTION_FALLBACK_POD_INFORMER
             value: "{{.FallbackPodInformer}}"
         securityContext:
@@ -342,7 +334,6 @@ type parameters struct {
 	Version             string
 	HookMode            string
 	LivenessProbe       bool
-	ToolsMode           string
 	FallbackPodInformer bool
 }
 
@@ -353,10 +344,6 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 		hookMode != "nri" &&
 		hookMode != "fanotify" {
 		return fmt.Errorf("invalid argument %q for --hook-mode=[auto,crio,podinformer,nri,fanotify]", hookMode)
-	}
-
-	if toolsMode != "auto" && toolsMode != "core" && toolsMode != "standard" {
-		return fmt.Errorf("invalid argument %q for --tools-mode=[auto,core,standard]", toolsMode)
 	}
 
 	t, err := template.New("deploy.yaml").Parse(deployYamlTmpl)
@@ -370,7 +357,6 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 		version,
 		hookMode,
 		livenessProbe,
-		toolsMode,
 		fallbackPodInformer,
 	}
 

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -12,11 +12,28 @@ node, as well as whether or not the kernel has
 [BTF](https://www.kernel.org/doc/html/latest/bpf/btf.html) enabled (via
 `CONFIG_DEBUG_INFO_BTF=y`).
 
-The required BTF information for some well known kernel versions is
-generated with [BTFGen](https://github.com/kinvolk/btfgen) and shipped
-within the gadget container image. If there are not shipped types for
-the running kernel then they are downloaded from
-[BTFhub](https://github.com/aquasecurity/btfhub/).
+Some of the gadgets have two different implementations. The first is
+based on the [traditional BCC
+tools](https://github.com/iovisor/bcc/tree/master/tools), in this case
+they are compiled at runtime on the target machine before loading. These
+tools usually work on older kernels (~4.15) and require to have the
+kernel headers available or the `IKHEADERS` module loaded. The second
+implementation uses the modern Compile Once - Run Everywhere (CO:RE)
+approach. These tools are not compiled at runtime and it's needed to
+have BTF information. This information is collected from three different
+sources, a fallback mechanism is implemented to try another source if the
+previous one was not available.
+1. The kernel already exposes it through `/sys/kernel/btf/vmlinux`: the
+   kernel was compiled with `CONFIG_DEBUG_INFO_BTF`).
+2. It's available in the gadget container image: we ship the BTF
+   information for some well known kernel versions using
+   [BTFGen](https://github.com/kinvolk/btfgen).
+3. It's downloaded from
+   [BTFHub](https://github.com/aquasecurity/btfhub/).
+
+Inspektor Gadget always tries to use the CO:RE implementation of the
+gadget (when available), if it fails then it falls back to the
+traditional BCC-based implementation.
 
 ## Required Kernel Versions
 
@@ -26,28 +43,22 @@ and their shipped kernels, hence it's possible that some gadgets work in older
 kernels than the one mentioned here.
 
 
-| Gadget                 | Tools Mode | Required Kernel                 | BTF Required |
-|------------------------|------------|---------------------------------|--------------|
-| bindsnoop              | standard   | 4.15                            | N            |
-| bindsnoop              | core       | 5.4<sup>[1](#btfhubnote)</sup>  | Y            |
-| biolatency             | standard   | 4.15                            | N            |
-| capabilities           |            | 4.15                            | N            |
-| dns                    |            | 5.4                             | N            |
-| execsnoop              | standard   | 4.15                            | N            |
-| execsnoop              | core       | 5.4<sup>[1](#btfhubnote)</sup>  | Y            |
-| filetop                |            | 5.4<sup>[1](#btfhubnote)</sup>  | Y            |
-| fsslower               | core       | 5.4<sup>[1](#btfhubnote)</sup>  | Y            |
-| network policy advisor |            |                                 |              |
-| oomkill                | core       | 5.4<sup>[1](#btfhubnote)</sup>  | Y            |
-| opensnoop              | standard   | 4.15                            | N            |
-| opensnoop              | core       | 5.4<sup>[1](#btfhubnote)</sup>  | Y            |
-| sigsnoop               | core       | 5.4<sup>[1](#btfhubnote)</sup>  | Y            |
-| socket collector       |            | 5.10                            | Y            |
-| process collector      |            | 5.10                            | Y            |
-| tcpconnect             | standard   | 4.15                            | N            |
-| tcpconnect             | core       | 5.8                             | Y            |
-| tcptop                 | standard   | 4.15                            | N            |
-| tcptracer              | standard   | 4.15                            | N            |
-| traceloop              |            | 4.15                            | N            |
-
-<a name="btfhubnote">1</a>: By using [btfhub](https://github.com/aquasecurity/btfhub/)
+| Gadget                 | Minimum Kernel          |
+|------------------------|-------------------------|
+| bindsnoop              | 4.15 (BCC), 5.4 (CO:RE) |
+| biolatency             | 4.15                    |
+| capabilities           | 4.15                    |
+| dns                    | 5.4                     |
+| execsnoop              | 4.15 (BCC), 5.4 (CO:RE) |
+| filetop                | 5.4                     |
+| fsslower               | 5.4                     |
+| network policy advisor |                         |
+| oomkill                | 5.4                     |
+| opensnoop              | 4.15 (BCC), 5.4 (CO:RE) |
+| sigsnoop               | 5.4                     |
+| socket collector       | 5.10                    |
+| process collector      | 5.10                    |
+| tcpconnect             | 4.15 (BCC), 5.8 (CO:RE) |
+| tcptop                 | 4.15                    |
+| tcptracer              | 4.15                    |
+| traceloop              | 4.15                    |

--- a/gadget-container/entrypoint.sh
+++ b/gadget-container/entrypoint.sh
@@ -215,29 +215,6 @@ else
   fi
 fi
 
-# Choose what kind of tools based on the configuration detected
-TOOLS_MODE="$INSPEKTOR_GADGET_OPTION_TOOLS_MODE"
-
-if [ "$TOOLS_MODE" = "auto" ] || [ -z "$TOOLS_MODE" ] ; then
-  if test -f /sys/kernel/btf/vmlinux; then
-    echo "BTF is available at /sys/kernel/btf/vmlinux: Using CO-RE based tools"
-    TOOLS_MODE="core"
-  elif test -f /boot/vmlinux-$KERNEL; then
-    echo "BTF is available at /boot/vmlinux-$KERNEL: Using CO-RE based tools"
-    TOOLS_MODE="core"
-  else
-    echo "vmlinux not found. Using standard tools"
-    TOOLS_MODE="standard"
-  fi
-fi
-
-# Create symlinks for tools according to the value of TOOLS_MODE
-if [ "$TOOLS_MODE" = "core" ] ; then
-  ln -s /bin/libbpf-tools/ /bin/gadgets
-elif [ "$TOOLS_MODE" = "standard" ] ; then
-  ln -s /usr/share/bcc/tools/ /bin/gadgets
-fi
-
 echo "Starting the Gadget Tracer Manager..."
 rm -f /run/gadgettracermanager.socket
 exec /bin/gadgettracermanager -serve -hook-mode=$GADGET_TRACER_MANAGER_HOOK_MODE \


### PR DESCRIPTION
The tools-mode flag was intended to let the user choose the kind of
BCC tools to use: python-based/standard vs libbpf-based/core.

We have ported the tools to have their control plane in Golang
and we implemented a logic to automatically fallback to standard mode
when it's not possible to use CO:RE. For this reason this flag is not
useful anymore. In the future we could think about a way to specify the
tool mode (mainly for tests).

Fixes https://github.com/kinvolk/inspektor-gadget/issues/397