### PR TITLE
Add init containers to pod informer

### DIFF
--- a/docs/examples/init-containers.yaml
+++ b/docs/examples/init-containers.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: init-containers
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod
+  namespace: init-containers
+spec:
+  containers:
+  - name: test-container
+    image: busybox
+    resources:
+      limits:
+        memory: "128Mi"
+    command: ["sleep", "5m"]
+  initContainers:
+  - name: init-one
+    image: busybox
+    command: ["sleep", "1m"]
+  - name: init-two
+    image: busybox
+    command: ["sleep", "1m"]

--- a/pkg/container-collection/options.go
+++ b/pkg/container-collection/options.go
@@ -463,7 +463,11 @@ func WithKubernetesEnrichment(nodeName string) ContainerCollectionOption {
 				for k, v := range pod.ObjectMeta.Labels {
 					labels = append(labels, &pb.Label{Key: k, Value: v})
 				}
-				for _, container := range pod.Spec.Containers {
+
+				containers := append([]v1.Container{}, pod.Spec.InitContainers...)
+				containers = append(containers, pod.Spec.Containers...)
+
+				for _, container := range containers {
 					for _, mountSource := range containerDefinition.MountSources {
 						pattern := fmt.Sprintf("pods/%s/containers/%s/", uid, container.Name)
 						if strings.Contains(mountSource, pattern) {


### PR DESCRIPTION
# Add init containers to pod informer

This PR fixes #114 by adding support for init containers to the `PodToContainers` function in `k8s.go`.

I also added `/examples/init-containers.yaml`, which I used to test the changes. Please let me know if adding this file is not necessary/desired.

## Testing
Unfortunately, I couldn't come up with a way to test this change without adding temporary logging to the function and observing the logs, please let me know if there is 👍 

As mentioned above, I used `init-containers.yaml` with apply/delete.

I used

### Before
```
time="2022-03-05T16:38:14Z" level=info msg="pubsub: ADD_CONTAINER: kube-system/gadget-vbxmd/gadget"
time="2022-03-05T16:38:14Z" level=info msg="Checked 1 containers."
time="2022-03-05T16:38:14Z" level=info msg="Returning 1 running containers."
time="2022-03-05T16:38:14Z" level=info msg="Checked 1 containers."
time="2022-03-05T16:38:14Z" level=info msg="Returning 1 running containers."
time="2022-03-05T16:38:14Z" level=info msg="Checked 1 containers."
time="2022-03-05T16:38:14Z" level=info msg="Returning 1 running containers."
time="2022-03-05T16:38:14Z" level=info msg="Checked 1 containers."
time="2022-03-05T16:38:14Z" level=info msg="Returning 1 running containers."
time="2022-03-05T16:38:14Z" level=info msg="Checked 1 containers."
time="2022-03-05T16:38:14Z" level=info msg="Returning 1 running containers."
time="2022-03-05T16:38:14Z" level=info msg="Starting trace controller manager"
time="2022-03-05T16:40:26Z" level=info msg="Checked 0 containers."
time="2022-03-05T16:40:26Z" level=info msg="Returning 0 running containers."
time="2022-03-05T16:40:26Z" level=info msg="Checked 1 containers."
time="2022-03-05T16:40:26Z" level=info msg="Returning 0 running containers."
...

### Executed: kubectl apply -f init-containers.yaml
time="2022-03-05T16:42:30Z" level=info msg="Checked 1 containers."
time="2022-03-05T16:42:30Z" level=info msg="Returning 0 running containers."
time="2022-03-05T16:42:32Z" level=info msg="pubsub: ADD_CONTAINER: init-containers/test-pod/test-container"
time="2022-03-05T16:42:32Z" level=info msg="Checked 1 containers."
time="2022-03-05T16:42:32Z" level=info msg="Returning 1 running containers."

### Executed: kubectl delete -f init-containers.yaml
time="2022-03-05T16:45:47Z" level=info msg="Checked 1 containers."
time="2022-03-05T16:45:47Z" level=info msg="Returning 1 running containers."
time="2022-03-05T16:46:17Z" level=info msg="pubsub: REMOVE_CONTAINER: init-containers/test-pod/test-container"
time="2022-03-05T16:46:17Z" level=info msg="Checked 1 containers."
time="2022-03-05T16:46:17Z" level=info msg="Returning 0 running containers."
time="2022-03-05T16:46:17Z" level=info msg="Checked 1 containers."
time="2022-03-05T16:46:17Z" level=info msg="Returning 0 running containers."
```

### After
```
time="2022-03-05T16:51:43Z" level=info msg="pubsub: ADD_CONTAINER: kube-system/gadget-clmfb/gadget"

### Executed: kubectl apply -f init-containers.yaml
time="2022-03-05T16:53:45Z" level=info msg="Checked 0 containers."
time="2022-03-05T16:53:45Z" level=info msg="Returning 0 running containers."
time="2022-03-05T16:53:45Z" level=info msg="Checked 3 containers."
time="2022-03-05T16:53:45Z" level=info msg="Returning 0 running containers."
time="2022-03-05T16:53:47Z" level=info msg="Checked 3 containers."
time="2022-03-05T16:53:47Z" level=info msg="Returning 1 running containers."
time="2022-03-05T16:53:47Z" level=warning msg="container init-containers/test-pod/init-one wasn't detected by the main hook! The fallback pod informer will add it."
time="2022-03-05T16:53:47Z" level=info msg="pubsub: ADD_CONTAINER: init-containers/test-pod/init-one"
time="2022-03-05T16:54:47Z" level=info msg="pubsub: REMOVE_CONTAINER: init-containers/test-pod/init-one"
time="2022-03-05T16:54:47Z" level=info msg="Checked 3 containers."
time="2022-03-05T16:54:47Z" level=info msg="Returning 0 running containers."
time="2022-03-05T16:54:49Z" level=info msg="Checked 3 containers."
time="2022-03-05T16:54:49Z" level=info msg="Returning 1 running containers."
time="2022-03-05T16:54:49Z" level=warning msg="container init-containers/test-pod/init-two wasn't detected by the main hook! The fallback pod informer will add it."
time="2022-03-05T16:54:49Z" level=info msg="pubsub: ADD_CONTAINER: init-containers/test-pod/init-two"
time="2022-03-05T16:55:49Z" level=info msg="pubsub: REMOVE_CONTAINER: init-containers/test-pod/init-two"
time="2022-03-05T16:55:49Z" level=info msg="Checked 3 containers."
time="2022-03-05T16:55:49Z" level=info msg="Returning 0 running containers."
time="2022-03-05T16:55:51Z" level=info msg="pubsub: ADD_CONTAINER: init-containers/test-pod/test-container"
time="2022-03-05T16:55:51Z" level=info msg="Checked 3 containers."
time="2022-03-05T16:55:51Z" level=info msg="Returning 1 running containers."


### Executed: kubectl delete -f init-containers.yaml
time="2022-03-05T16:57:10Z" level=info msg="Checked 3 containers."
time="2022-03-05T16:57:10Z" level=info msg="Returning 1 running containers."
time="2022-03-05T16:57:40Z" level=info msg="pubsub: REMOVE_CONTAINER: init-containers/test-pod/test-container"
time="2022-03-05T16:57:41Z" level=info msg="Checked 3 containers."
time="2022-03-05T16:57:41Z" level=info msg="Returning 0 running containers."
time="2022-03-05T16:57:41Z" level=info msg="Checked 3 containers."
time="2022-03-05T16:57:41Z" level=info msg="Returning 0 running containers."
```

### Logging
```go
...
        log.Infof("Checked %d containers.", len(containerStatuses))
	log.Infof("Returning %d running containers.", len(containers))
	return containers
}
```

