### PR TITLE
pkg/gadgets: Uniform perf buffer memory size for all gadgets

### DIFF
--- a/pkg/gadgets/bindsnoop/tracer/core/tracer.go
+++ b/pkg/gadgets/bindsnoop/tracer/core/tracer.go
@@ -177,7 +177,7 @@ func (t *Tracer) start() error {
 		return fmt.Errorf("error opening ipv6 kprobe: %w", err)
 	}
 
-	t.reader, err = perf.NewReader(t.objs.bindsnoopMaps.Events, os.Getpagesize())
+	t.reader, err = perf.NewReader(t.objs.bindsnoopMaps.Events, gadgets.PerfBufferPages*os.Getpagesize())
 	if err != nil {
 		return fmt.Errorf("error creating perf ring buffer: %w", err)
 	}

--- a/pkg/gadgets/dns/tracer/tracer.go
+++ b/pkg/gadgets/dns/tracer/tracer.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cilium/ebpf/perf"
 	"golang.org/x/sys/unix"
 
+	"github.com/kinvolk/inspektor-gadget/pkg/gadgets"
 	"github.com/kinvolk/inspektor-gadget/pkg/gadgets/dns/types"
 	"github.com/kinvolk/inspektor-gadget/pkg/rawsock"
 	eventtypes "github.com/kinvolk/inspektor-gadget/pkg/types"
@@ -93,7 +94,7 @@ func (t *Tracer) Attach(
 		return fmt.Errorf("failed to create BPF collection: %w", err)
 	}
 
-	rd, err := perf.NewReader(coll.Maps[BPFMapName], os.Getpagesize())
+	rd, err := perf.NewReader(coll.Maps[BPFMapName], gadgets.PerfBufferPages*os.Getpagesize())
 	if err != nil {
 		return fmt.Errorf("failed to get a perf reader: %w", err)
 	}

--- a/pkg/gadgets/execsnoop/tracer/core/tracer.go
+++ b/pkg/gadgets/execsnoop/tracer/core/tracer.go
@@ -24,6 +24,7 @@ import "C"
 import (
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"unsafe"
 
@@ -125,7 +126,7 @@ func (t *Tracer) start() error {
 	}
 	t.exitLink = exit
 
-	reader, err := perf.NewReader(t.objs.execsnoopMaps.Events, 4096)
+	reader, err := perf.NewReader(t.objs.execsnoopMaps.Events, gadgets.PerfBufferPages*os.Getpagesize())
 	if err != nil {
 		return fmt.Errorf("error creating perf ring buffer: %w", err)
 	}

--- a/pkg/gadgets/fsslower/tracer/core/tracer.go
+++ b/pkg/gadgets/fsslower/tracer/core/tracer.go
@@ -24,6 +24,7 @@ import "C"
 import (
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"unsafe"
 
@@ -215,7 +216,7 @@ func (t *Tracer) start() error {
 		return fmt.Errorf("error attaching program: %w", err)
 	}
 
-	t.reader, err = perf.NewReader(t.objs.fsslowerMaps.Events, 4096)
+	t.reader, err = perf.NewReader(t.objs.fsslowerMaps.Events, gadgets.PerfBufferPages*os.Getpagesize())
 	if err != nil {
 		return fmt.Errorf("error creating perf ring buffer: %w", err)
 	}

--- a/pkg/gadgets/helpers.go
+++ b/pkg/gadgets/helpers.go
@@ -30,6 +30,8 @@ const (
 
 	// The Trace custom resource is preferably in the "gadget" namespace
 	TraceDefaultNamespace = "gadget"
+
+	PerfBufferPages = 64
 )
 
 func TraceName(namespace, name string) string {

--- a/pkg/gadgets/mountsnoop/tracer/core/tracer.go
+++ b/pkg/gadgets/mountsnoop/tracer/core/tracer.go
@@ -40,8 +40,6 @@ import (
 
 //go:generate sh -c "GOOS=$(go env GOHOSTOS) GOARCH=$(go env GOHOSTARCH) go run github.com/cilium/ebpf/cmd/bpf2go -target bpfel -cc clang mountsnoop ./bpf/mountsnoop.bpf.c -- -I./bpf/ -I../../../../ -target bpf -D__TARGET_ARCH_x86"
 
-const PerfBufferPages = 64
-
 type Tracer struct {
 	config        *tracer.Config
 	resolver      containercollection.ContainerResolver
@@ -140,7 +138,7 @@ func (t *Tracer) start() error {
 		return fmt.Errorf("error opening tracepoint: %w", err)
 	}
 
-	t.reader, err = perf.NewReader(t.objs.mountsnoopMaps.Events, PerfBufferPages*os.Getpagesize())
+	t.reader, err = perf.NewReader(t.objs.mountsnoopMaps.Events, gadgets.PerfBufferPages*os.Getpagesize())
 	if err != nil {
 		return fmt.Errorf("error creating perf ring buffer: %w", err)
 	}

--- a/pkg/gadgets/oomkill/tracer/tracer.go
+++ b/pkg/gadgets/oomkill/tracer/tracer.go
@@ -126,7 +126,7 @@ func (t *Tracer) start() error {
 	}
 	t.oomLink = kprobe
 
-	reader, err := perf.NewReader(t.objs.oomkillMaps.Events, os.Getpagesize())
+	reader, err := perf.NewReader(t.objs.oomkillMaps.Events, gadgets.PerfBufferPages*os.Getpagesize())
 	if err != nil {
 		return fmt.Errorf("error creating perf ring buffer: %w", err)
 	}

--- a/pkg/gadgets/opensnoop/tracer/core/tracer.go
+++ b/pkg/gadgets/opensnoop/tracer/core/tracer.go
@@ -24,6 +24,7 @@ import "C"
 import (
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"unsafe"
 
@@ -140,7 +141,7 @@ func (t *Tracer) start() error {
 	}
 	t.openAtExitLink = openAtExit
 
-	reader, err := perf.NewReader(t.objs.opensnoopMaps.Events, 4096)
+	reader, err := perf.NewReader(t.objs.opensnoopMaps.Events, gadgets.PerfBufferPages*os.Getpagesize())
 	if err != nil {
 		return fmt.Errorf("error creating perf ring buffer: %w", err)
 	}

--- a/pkg/gadgets/sigsnoop/tracer/core/tracer.go
+++ b/pkg/gadgets/sigsnoop/tracer/core/tracer.go
@@ -192,7 +192,7 @@ func (t *Tracer) start() error {
 		return fmt.Errorf("error opening tracepoint: %w", err)
 	}
 
-	t.reader, err = perf.NewReader(t.objs.sigsnoopMaps.Events, 64*os.Getpagesize())
+	t.reader, err = perf.NewReader(t.objs.sigsnoopMaps.Events, gadgets.PerfBufferPages*os.Getpagesize())
 	if err != nil {
 		return fmt.Errorf("error creating perf ring buffer: %w", err)
 	}

--- a/pkg/gadgets/snisnoop/tracer/tracer.go
+++ b/pkg/gadgets/snisnoop/tracer/tracer.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cilium/ebpf/perf"
 	"golang.org/x/sys/unix"
 
+	"github.com/kinvolk/inspektor-gadget/pkg/gadgets"
 	"github.com/kinvolk/inspektor-gadget/pkg/gadgets/snisnoop/types"
 	"github.com/kinvolk/inspektor-gadget/pkg/rawsock"
 	eventtypes "github.com/kinvolk/inspektor-gadget/pkg/types"
@@ -100,7 +101,7 @@ func (t *Tracer) Attach(
 		return fmt.Errorf("failed to create BPF collection: %w", err)
 	}
 
-	rd, err := perf.NewReader(coll.Maps[BPFMapName], os.Getpagesize())
+	rd, err := perf.NewReader(coll.Maps[BPFMapName], gadgets.PerfBufferPages*os.Getpagesize())
 	if err != nil {
 		return fmt.Errorf("failed to get a perf reader: %w", err)
 	}

--- a/pkg/gadgets/tcpconnect/tracer/core/tracer.go
+++ b/pkg/gadgets/tcpconnect/tracer/core/tracer.go
@@ -73,8 +73,6 @@ import (
 
 //go:generate sh -c "GOOS=$(go env GOHOSTOS) GOARCH=$(go env GOHOSTARCH) go run github.com/cilium/ebpf/cmd/bpf2go -target bpfel -cc clang tcpconnect ./bpf/tcpconnect.bpf.c -- -I./bpf/ -I../../../../ -target bpf -D__TARGET_ARCH_x86"
 
-const PerfBufferPages = 64
-
 type Tracer struct {
 	config        *tracer.Config
 	resolver      containercollection.ContainerResolver
@@ -168,7 +166,7 @@ func (t *Tracer) start() error {
 		return fmt.Errorf("error attaching program: %w", err)
 	}
 
-	reader, err := perf.NewReader(t.objs.tcpconnectMaps.Events, PerfBufferPages*os.Getpagesize())
+	reader, err := perf.NewReader(t.objs.tcpconnectMaps.Events, gadgets.PerfBufferPages*os.Getpagesize())
 	if err != nil {
 		return fmt.Errorf("error creating perf ring buffer: %w", err)
 	}


### PR DESCRIPTION
Many gadgets were using different values for the memory size of the
perf ring buffer. This commit defines a const and uses the same value
for all of them.
