### PR TITLE
cmd/kubectl-gadget: Increase livenessProbe initial delay

### DIFF
--- a/cmd/kubectl-gadget/deploy.go
+++ b/cmd/kubectl-gadget/deploy.go
@@ -187,6 +187,7 @@ spec:
       hostNetwork: true
       containers:
       - name: gadget
+        terminationMessagePolicy: FallbackToLogsOnError
         image: {{.Image}}
         imagePullPolicy: {{.ImagePullPolicy}}
         command: [ "/entrypoint.sh" ]
@@ -197,7 +198,7 @@ spec:
                 - "/cleanup.sh"
 {{if .LivenessProbe}}
         livenessProbe:
-          initialDelaySeconds: 10
+          initialDelaySeconds: 60
           periodSeconds: 5
           exec:
             command:

--- a/gadget-container/entrypoint.sh
+++ b/gadget-container/entrypoint.sh
@@ -98,7 +98,10 @@ if [ "$ID" = "rhcos" ] && [ ! -d "/usr/src/kernels/$KERNEL" ]; then
     RPM=kernel-devel-$KERNEL.rpm
 
     mkdir -p $RPMDIR/usr/src/kernels/
-    curl -fsSLo $RPMDIR/$RPM $REPO/$RPM || true
+    # Ensure the whole operation does not take more than 40 seconds. This value
+    # needs to be lower than the liveness-probe initial delay. Otherwise, there
+    # is the risk the gadget pod gets restarted while downloading this package.
+    curl --max-time 40 -fsSLo $RPMDIR/$RPM $REPO/$RPM || rm -f $RPMDIR/$RPM
 
     if test -f $RPMDIR/$RPM; then
       cd $RPMDIR && rpm2cpio $RPM | cpio --quiet -i


### PR DESCRIPTION
# Increase livenessProbe initial delay

This PR limits the maximum time the download of the kernel headers can last to 40 seconds (the default value was 2 min) and increases the `initialDelaySeconds` to 60 seconds so that the gadget pod will never be restarted while it is downloading the headers.

In addition, this PR sets the `terminationMessagePolicy` to "FallbackToLogsOnError" in order to have more information when gadget pod exited with an error:

Ref: [Customizing the termination message](https://kubernetes.io/docs/tasks/debug-application-cluster/determine-reason-pod-failure/#customizing-the-termination-message)
> By setting the terminationMessagePolicy to "FallbackToLogsOnError", you can tell Kubernetes to use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller.
What's next
>

## How to use

Deploy IG in ARO.

## Testing done

I modified the `entrypoint.sh` script to wait just for 1 second and fail if the `curl` command fails (I removed the `|| true`):

```
curl --max-time 1 -fsSLo $RPMDIR/$RPM $REPO/$RPM
```

After doing this, I test the container image and it keeps restarting continuously. Then, I checked the container status:

```
$ kubectl describe pod -n gadget <gadget-pod>
...
 Last State:   Terminated
      Reason:     Error
      Message:    OS detected: Red Hat Enterprise Linux CoreOS 48.84.202110270303-0 (Ootpa)
Kernel detected: 4.18.0-305.19.1.el8_4.x86_64
bcc detected: 0.24.0-1
Gadget image: docker.io/blanquicet/gadget:jose-increase-liveness-init-delay
Deployment options:
INSPEKTOR_GADGET_OPTION_FALLBACK_POD_INFORMER=true
INSPEKTOR_GADGET_OPTION_TOOLS_MODE=auto
INSPEKTOR_GADGET_OPTION_HOOK_MODE=auto
Inspektor Gadget version: v0.4.2-286-g3c80ace65da3-dirty
CRI-O detected.
Fetching kernel-devel from CentOS Vault Mirror...
curl: (28) Operation timed out after 1001 milliseconds with 9561607 out of 1073741824 bytes received

      Exit Code:    28
      Started:      Thu, 10 Mar 2022 16:32:27 +0100
      Finished:     Thu, 10 Mar 2022 16:32:28 +0100
...
```

While before this PR, it was just:

```
    Last State:     Terminated
      Reason:       Error
      Exit Code:    143
      Started:      Thu, 10 Mar 2022 15:49:20 +0100
      Finished:     Thu, 10 Mar 2022 15:49:44 +0100
```