### PR TITLE
cmd/kubectl-gadget: Increase trace timeout

### DIFF
--- a/cmd/kubectl-gadget/utils/trace.go
+++ b/cmd/kubectl-gadget/utils/trace.go
@@ -47,7 +47,7 @@ const (
 	// We name it "global" as if one trace is created on several nodes, then each
 	// copy of the trace on each node will share the same id.
 	GlobalTraceID = "global-trace-id"
-	TraceTimeout  = 2 * time.Second
+	TraceTimeout  = 5 * time.Second
 )
 
 // TraceConfig is used to contain information used to manage a trace.


### PR DESCRIPTION
# Increase CLI timeout waiting for trace operations

This PR increases the time the CLI waits for a trace operation to be completed from 2 to 5 seconds. 

It is needed because, for instance, on an AKS cluster, with a CO:RE gadget (which does not need to be compiled), the start operation sometimes takes around 4 seconds:

```bash
time="2022-03-08T07:14:00Z" level=info msg="Reconcile trace gadget/bindsnoop-8znxw (gadget bindsnoop, node aks-agentpool-31885719-vmss000000)"
time="2022-03-08T07:14:00Z" level=info msg="Gadget bindsnoop operation \"start\" on gadget/bindsnoop-8znxw"
time="2022-03-08T07:14:04Z" level=info msg="Gadget completed operation. Trace status will be updated accordingly"
time="2022-03-08T07:14:04Z" level=info msg="Updating new status of trace \"gadget/bindsnoop-8znxw\": state=Started operationError=\"\" operationWarning=\"\" output=<0 characters>"
```

I am opening an issue to further investigate where exactly this time is being consumed.