### PR TITLE
ci: Run integration tests on ARO

### DIFF
--- a/.github/actions/run-integration-tests/action.yml
+++ b/.github/actions/run-integration-tests/action.yml
@@ -1,0 +1,62 @@
+name: "Run integration tests"
+description: "Run Inspektor Gadget integration tests"
+
+inputs:
+  registry:
+    description: 'Server address of registry where integration tests container image will be pushed'
+    required: false
+  username:
+    description: 'Username used to log against the registry'
+    required: false
+  password:
+    description: 'Password or access token used to log against the registry'
+    required: false
+
+runs:
+  using: "composite"
+  steps:
+    - name: Set IMAGE_TAG
+      shell: bash
+      run: |
+        TMP1=${GITHUB_REF#*/}
+        TMP2=${TMP1#*/}
+        IMAGE_TAG=${TMP2//\//-}
+        if [ "$IMAGE_TAG" = "main" ]; then
+            IMAGE_TAG="latest"
+        fi
+        echo IMAGE_TAG=$IMAGE_TAG >> $GITHUB_ENV
+    - name: Get kubectl-gadget-linux-amd64.tar.gz from artifact.
+      uses: actions/download-artifact@v2
+      with:
+        name: kubectl-gadget-linux-amd64-tar-gz
+        path: /home/runner/work/inspektor-gadget/
+    - name: Integration tests
+      shell: bash
+      run: |
+        echo "Using IMAGE_TAG=$IMAGE_TAG"
+
+        tar zxvf /home/runner/work/inspektor-gadget/kubectl-gadget-linux-amd64.tar.gz
+        mv kubectl-gadget kubectl-gadget-linux-amd64
+
+        TESTS_DOCKER_ARGS="-e KUBECONFIG=/root/.kube/config -v /home/runner/.kube:/root/.kube -v /home/runner/work/_temp/.minikube:/home/runner/work/_temp/.minikube" \
+            make -C integration build test
+
+        sed -i "s/latest/$IMAGE_TAG/g" integration/gadget-integration-tests-job.yaml
+    - name: Add integration asset as artifact.
+      if: startsWith(github.ref, 'refs/tags/v')
+      uses: actions/upload-artifact@master
+      with:
+        name: integration-asset
+        path: /home/runner/work/inspektor-gadget/inspektor-gadget/integration/gadget-integration-tests-job.yaml
+    - name: Login to Container Registry
+      if: startsWith(github.ref, 'refs/tags/v')
+      uses: docker/login-action@v1
+      with:
+        registry: ${{ inputs.registry }}
+        username: ${{ inputs.username }}
+        password: ${{ inputs.password }}
+    - name: Push Integration Test Image
+      shell: bash
+      if: startsWith(github.ref, 'refs/tags/v')
+      run: |
+        make -C integration push

--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -321,67 +321,92 @@ jobs:
 
         make local-gadget-tests
 
+  check-secrets:
+    name: Check repo secrets
+    # level: 0
+    runs-on: ubuntu-latest
+    outputs:
+      aro: ${{ steps.set_output.outputs.aro }}
+    steps:
+      # Secrets cannot be used as if condition, use job output as workaround.
+      # https://github.com/actions/runner/issues/520
+      - id: set_output
+        run: |
+          if [[ "${{ secrets.OPENSHIFT_SERVER }}" != "" && \
+                "${{ secrets.OPENSHIFT_USER }}" != "" && \
+                "${{ secrets.OPENSHIFT_PASSWORD }}" != "" ]]; \
+          then
+            echo "Secrets to use an ARO cluster were configured in the repo"
+            echo "::set-output name=aro::true"
+          else
+            echo "Secrets to use an ARO cluster were not configured in the repo"
+            echo "::set-output name=aro::false"
+          fi
+
+  # Integration tests for ARO are separated from others distributions because it
+  # is a pre-created cluster. It implies that we need to use a concurrency group
+  # to ensure that only one test-integration-aro job runs at a time so that we
+  # never try to use IG on that unique ARO cluster from different workflow runs.
+  test-integration-aro:
+    name: Integration tests on ARO
+    # level: 1
+    needs: [check-secrets, test-unit, build-kubectl-gadget, build-local-gadget, build-docker-image]
+    # Run this job only if an ARO cluster is available on repo secrets. See
+    # docs/ci.md for further details.
+    if: needs.check-secrets.outputs.aro == 'true'
+    runs-on: ubuntu-latest
+    concurrency:
+      group: no-simultaneous-test-integration-aro
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v1
+    - name: Authenticate and set ARO cluster context
+      # NOTE: This action generates the Kubernetes config file in the current
+      # directory. Therefore, it must be run after checking out code otherwise
+      # the file will be cleaned up.
+      uses: redhat-actions/oc-login@v1
+      with:
+        # API Server URL
+        openshift_server_url: ${{ secrets.OPENSHIFT_SERVER }}
+        # Credentials (TODO: Use a functional Service Account, see issue #574)
+        openshift_username: ${{ secrets.OPENSHIFT_USER }}
+        openshift_password: ${{ secrets.OPENSHIFT_PASSWORD }}
+    - name: Run integration tests
+      uses: ./.github/actions/run-integration-tests
+      env:
+        KUBERNETES_DISTRIBUTION: "aro"
+      with:
+        registry: ${{ secrets.CONTAINER_REGISTRY }}
+        username: ${{ secrets.CONTAINER_REGISTRY_USERNAME }}
+        password: ${{ secrets.CONTAINER_REGISTRY_PASSWORD }}
+
   test-integration:
     name: Integration tests
     # level: 1
     needs: [test-unit, build-kubectl-gadget, build-local-gadget, build-docker-image]
     runs-on: ubuntu-latest
     steps:
+    - name: Check out code
+      uses: actions/checkout@v1
     - name: Setup Minikube
       uses: manusa/actions-setup-minikube@v2.4.3
       with:
         minikube version: 'v1.25.2'
         kubernetes version: 'v1.23.0'
         github token: ${{ secrets.GITHUB_TOKEN }}
-    - name: Set IMAGE_TAG
-      run: |
-        TMP1=${GITHUB_REF#*/}
-        TMP2=${TMP1#*/}
-        IMAGE_TAG=${TMP2//\//-}
-        if [ "$IMAGE_TAG" = "main" ]; then
-            IMAGE_TAG="latest"
-        fi
-        echo IMAGE_TAG=$IMAGE_TAG >> $GITHUB_ENV
-    - name: Check out code
-      uses: actions/checkout@v1
-    - name: Get kubectl-gadget-linux-amd64.tar.gz from artifact.
-      uses: actions/download-artifact@v2
-      with:
-        name: kubectl-gadget-linux-amd64-tar-gz
-        path: /home/runner/work/inspektor-gadget/
-    - name: Integration tests
-      run: |
-        echo "Using IMAGE_TAG=$IMAGE_TAG"
-
-        tar zxvf /home/runner/work/inspektor-gadget/kubectl-gadget-linux-amd64.tar.gz
-        mv kubectl-gadget kubectl-gadget-linux-amd64
-
-        TESTS_DOCKER_ARGS="-e KUBECONFIG=/root/.kube/config -v /home/runner/.kube:/root/.kube -v /home/runner/work/_temp/.minikube:/home/runner/work/_temp/.minikube" \
-            make -C integration build test
-
-        sed -i "s/latest/$IMAGE_TAG/g" integration/gadget-integration-tests-job.yaml
-    - name: Add integration asset as artifact.
-      if: startsWith(github.ref, 'refs/tags/v')
-      uses: actions/upload-artifact@master
-      with:
-        name: integration-asset
-        path: /home/runner/work/inspektor-gadget/inspektor-gadget/integration/gadget-integration-tests-job.yaml
-    - name: Login to Container Registry
-      if: startsWith(github.ref, 'refs/tags/v')
-      uses: docker/login-action@v1
+    - name: Run integration tests
+      uses: ./.github/actions/run-integration-tests
+      env:
+        KUBERNETES_DISTRIBUTION: "minikube-github"
       with:
         registry: ${{ secrets.CONTAINER_REGISTRY }}
         username: ${{ secrets.CONTAINER_REGISTRY_USERNAME }}
         password: ${{ secrets.CONTAINER_REGISTRY_PASSWORD }}
-    - name: Push Integration Test Image
-      if: startsWith(github.ref, 'refs/tags/v')
-      run: |
-        make -C integration push
 
   release:
     name: Release
     # level: 2
-    needs: [documentation-checks, lint, test-integration, test-local-gadget]
+    needs: [documentation-checks, lint, test-integration, test-integration-aro, test-local-gadget]
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
     steps:

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -62,19 +62,10 @@ section for a faster development cycle.
 
 ## Workflows
 
-### Github Actions
+### Continuous Integration
 
-This repo uses Github actions as CI. It compiles and uploads the Inspektor Gadget
-executable and gadget container image. It also runs unit and some integration tests.
-A fork of this project should enable them in the repo settings page and add the
-following
-[secrets](https://help.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets#creating-encrypted-secrets-for-a-repository)
-to be able to use them:
-
-
-- `CONTAINER_REPO`: The container repository to use. Example: docker.io/kinvolk/gadget
-- `CONTAINER_REGISTRY`: The registry containing the repo above. Leave empty for Docker Hub. Example: ghcr.io, foo.azurecr.io, gcr.io
-- `CONTAINER_REGISTRY_USERNAME` & `CONTAINER_REGISTRY_PASSWORD`: Authentication information for the the repo above.
+This repo uses GitHub Actions as CI. Please check dedicated [CI
+documentation](ci.md) for details.
 
 ### Development environment on minikube
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,0 +1,158 @@
+---
+title: About Continuous Integration
+weight: 20
+description: >
+  Inspektor Gadget continuous integration workflow
+---
+
+This repository uses GitHub Actions to create a custom Continuous Integration
+(CI) workflow named `Inspektor Gadget CI`. This workflow compiles and uploads
+the Inspektor Gadget CLI, local-gadget and gadget container image and runs their
+unit and integration tests. In addition, it verifies that the documentation is
+up-to-date and runs a static code analysis using Golang linters.
+
+A fork of this project should enable GitHub Actions in the repo settings page
+and add the proper
+[secrets](https://help.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets#creating-encrypted-secrets-for-a-repository)
+to be able to use this workflow. The following sections describes what
+secrets needs to be added to enable all the CI tests.
+
+## Container repository
+
+To run the integration tests, it is necessary to have the gadget container image
+available on a container repository so that it can be installed in the
+Kubernetes cluster where the tests will run.
+
+After adding the following secrets, the workflow is already configured to use
+them to login to the container registry and push the generated images:
+
+- `CONTAINER_REPO`: The container repository to use. Example:
+  docker.io/kinvolk/gadget
+- `CONTAINER_REGISTRY`: The registry containing the repo above. Leave empty for
+  Docker Hub. Example: ghcr.io, foo.azurecr.io, gcr.io
+- `CONTAINER_REGISTRY_USERNAME` & `CONTAINER_REGISTRY_PASSWORD`: Authentication
+  information for the the registry above.
+
+Notice that either the provided container repository allows anonymous pull or
+the cluster used to run the integration tests is properly configured to be able
+to pull images from it.
+
+## Run integration tests on an ARO cluster
+
+Optionally, we can add the secrets described in this section so that the
+integration tests will also run on a pre-created [Azure Red Hat OpenShift
+(ARO)](https://docs.microsoft.com/en-us/azure/openshift/intro-openshift)
+cluster. Consider that the Inspektor Gadget workflow will still success even if
+no ARO cluster is provided through these secrets.
+
+### Create a cluster
+
+These are the steps to create an ARO cluster using the [Azure
+CLI](https://docs.microsoft.com/en-us/cli/azure/):
+
+```bash
+$ export SUBSCRIPTION=<mySubscription>
+$ export RESOURCEGROUP=<myResourceName>
+$ export LOCATION=<myLocation>
+$ export CLUSTER=<myCluster>
+$ export VNET=<myVNET>
+$ export MASTSUB=<myMASTSUB>
+$ export WORKSUB=<myWORKSUB>
+
+# Set subscription so that we don't need to specify it at every command
+$ az account set --subscription $SUBSCRIPTION
+
+# Register resource providers
+$ az provider register -n Microsoft.RedHatOpenShift --wait
+$ az provider register -n Microsoft.Compute --wait
+$ az provider register -n Microsoft.Storage --wait
+$ az provider register -n Microsoft.Authorization --wait
+
+# Create resource group
+$ az group create --name $RESOURCEGROUP --location $LOCATION
+
+# Create virtual network and two empty subnets for the master and the worker nodes.
+$ az network vnet create --resource-group $RESOURCEGROUP --name $VNET --address-prefixes 10.0.0.0/22
+$ az network vnet subnet create --resource-group $RESOURCEGROUP --vnet-name $VNET --name $MASTSUB --address-prefixes 10.0.0.0/23 --service-endpoints Microsoft.ContainerRegistry
+$ az network vnet subnet create --resource-group $RESOURCEGROUP --vnet-name $VNET --name $WORKSUB --address-prefixes 10.0.2.0/23 --service-endpoints Microsoft.ContainerRegistry
+$ az network vnet subnet update --name $MASTSUB --resource-group $RESOURCEGROUP --vnet-name $VNET --disable-private-link-service-network-policies true
+
+# Create the cluster (Minimum 3 worker nodes must be used)
+$ az aro create --resource-group $RESOURCEGROUP --name $CLUSTER --vnet $VNET --master-subnet $MASTSUB --worker-count 3 --worker-subnet $WORKSUB
+```
+
+Considerations:
+- After executing the `az aro create` command, it normally takes about 35
+  minutes to create a cluster.
+- For the sack of simplicity, we are not providing a [Red Hat pull
+  secret](https://docs.microsoft.com/en-us/azure/openshift/tutorial-create-cluster#get-a-red-hat-pull-secret-optional)
+  during the cluster creation, so our cluster will not include samples or
+  operators from Red Hat or certified partners. However, it is not a requirement
+  to run the Inspektor Gadget integration tests on it.
+- Creating an ARO cluster requires specific permissions, check [the
+  documentation](https://docs.microsoft.com/en-us/azure/openshift/tutorial-create-cluster#verify-your-permissions)
+  to be sure you have them.
+
+### Delete a cluster
+
+If we need to delete our cluster, it is enough to execute:
+```bash
+$ az group delete --name $RESOURCEGROUP
+```
+
+Take into account that it will remove the entire resource group and all
+resources inside it.
+
+Further details about creating an ARO cluster can be found in the [Azure Red Hat
+OpenShift
+documentation](https://docs.microsoft.com/en-us/azure/openshift/tutorial-create-cluster).
+
+### Connect to a cluster
+
+Fist of all, to be able to connect to our cluster, we need the following
+information:
+
+```bash
+# API Server URL
+$ az aro show --subscription $SUBSCRIPTION -g $RESOURCEGROUP -n $CLUSTER --query apiserverProfile.url
+https://api.server.example.io:1234
+
+# Credentials
+$ az aro list-credentials --subscription $SUBSCRIPTION -g $RESOURCEGROUP -n $CLUSTER
+{
+  "kubeadminPassword": "myPassword",
+  "kubeadminUsername": "myUsername"
+}
+```
+
+#### From GitHub actions
+
+The `test-integration` job is already configured to authenticate and set the
+kubeconf context to the ARO cluster configured in the GitHub repository. So all
+we need to do is to add the following actions secrets:
+
+- `OPENSHIFT_SERVER`: The API server URL: `https://api.server.example.io:1234`.
+- `OPENSHIFT_USER`: The `kubeadminUsername` from the JSON output of the
+  `list-credentials` command.
+- `OPENSHIFT_PASSWORD`: The `kubeadminPassword` from the JSON output of the
+  `list-credentials` command.
+
+Further details about connect to an ARO cluster from GitHub actions can be found
+in the [Azure Red Hat OpenShift
+documentation](https://docs.microsoft.com/en-us/azure/openshift/tutorial-connect-cluster#connect-using-the-openshift-cli)
+and the [redhat-actions/oc-login
+documentation](https://github.com/redhat-actions/oc-login).
+
+#### From a host
+
+For debugging, it might be necessary to connect to the cluster from a host. We
+can do it by using the `oc` tool:
+
+```bash
+$ oc login $apiServer -u $kubeadminUsername -p $kubeadminPassword
+```
+
+Notice that it configures the kubectl configuration with a new context.
+
+Please take into account that any change done on this cluster could cause issues
+with the integration tests running on GitHub actions at that moment.

--- a/integration/Dockerfile
+++ b/integration/Dockerfile
@@ -14,6 +14,10 @@ RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s
 RUN chmod +x ./kubectl
 RUN mv ./kubectl /usr/local/bin
 
+# Specify the -k8s-distro flag only if KUBERNETES_DISTRIBUTION was set through --build-arg
+ARG KUBERNETES_DISTRIBUTION
+ENV ARG_KUBERNETES_DISTRIBUTION=${KUBERNETES_DISTRIBUTION:+-k8s-distro\ $KUBERNETES_DISTRIBUTION}
+
 COPY bin/kubectl-gadget /bin/kubectl-gadget
 COPY --from=build_base /build/gadget-integration.test /bin/gadget-integration.test
-CMD ["/bin/sh", "-c", "gadget-integration.test -integration -test.timeout 20m"]
+CMD ["/bin/sh", "-c", "gadget-integration.test -integration -test.timeout 20m $ARG_KUBERNETES_DISTRIBUTION"]

--- a/integration/Makefile
+++ b/integration/Makefile
@@ -3,11 +3,14 @@ IMAGE_TAG ?= $(shell ./tools/image-tag branch)
 
 TESTS_DOCKER_ARGS ?= "-e KUBECONFIG=/opt/kubeconfig/config -v $(HOME)/.kube:/opt/kubeconfig"
 
+KUBERNETES_DISTRIBUTION ?= ""
+
 .PHONY: build
 build:
 	mkdir -p bin
 	cp ../kubectl-gadget-linux-amd64 bin/kubectl-gadget
-	docker build -t $(CONTAINER_REPO)test:$(IMAGE_TAG) -f Dockerfile .
+	docker build -t $(CONTAINER_REPO)test:$(IMAGE_TAG) -f Dockerfile \
+		--build-arg KUBERNETES_DISTRIBUTION=$(KUBERNETES_DISTRIBUTION) .
 	rm -f bin/kubectl-gadget
 
 .PHONY: push

--- a/integration/command.go
+++ b/integration/command.go
@@ -112,9 +112,11 @@ var deploySPO *command = &command{
 	expectedRegexp: "pod/security-profiles-operator-.*-.* condition met",
 }
 
-var waitUntilInspektorGadgetPodsInitialized *command = &command{
-	name: "Wait until Inspektor Gadget is initialised",
-	cmd:  "sleep 15",
+func waitUntilInspektorGadgetPodsInitialized(initialDelay int) *command {
+	return &command{
+		name: "Wait until Inspektor Gadget is initialised",
+		cmd:  fmt.Sprintf("sleep %d", initialDelay),
+	}
 }
 
 var cleanupInspektorGadget *command = &command{

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -223,7 +223,7 @@ func TestBiolatency(t *testing.T) {
 	commands := []*command{
 		{
 			name:           "Run biolatency gadget",
-			cmd:            "id=$($KUBECTL_GADGET profile block-io start --node $(kubectl get node --no-headers | cut -d' ' -f1)); sleep 15; $KUBECTL_GADGET profile block-io stop $id",
+			cmd:            "id=$($KUBECTL_GADGET profile block-io start --node $(kubectl get node --no-headers | cut -d' ' -f1 | head -1)); sleep 15; $KUBECTL_GADGET profile block-io stop $id",
 			expectedRegexp: `usecs\s+:\s+count\s+distribution`,
 		},
 	}
@@ -659,7 +659,7 @@ func TestTcptop(t *testing.T) {
 
 	tcptopCmd := &command{
 		name:           "Start tcptop gadget",
-		cmd:            fmt.Sprintf("$KUBECTL_GADGET top tcp --node $(kubectl get node --no-headers | cut -d' ' -f1) -n %s -p test-pod", ns),
+		cmd:            fmt.Sprintf("$KUBECTL_GADGET top tcp -n %s", ns),
 		expectedRegexp: `wget`,
 		startAndStop:   true,
 	}


### PR DESCRIPTION
# Run integration tests on ARO

This PR modifies the CI to also run the integration tests on a pre-created [Azure Red Hat OpenShift (ARO) cluster](https://docs.microsoft.com/en-us/azure/openshift/intro-openshift).

## Implementation details

- It is a pre-created ARO cluster because its creation takes about 35 minutes: [documentation](https://docs.microsoft.com/en-us/azure/openshift/tutorial-create-cluster#create-the-cluster).
- Integration tests on ARO was added to the `test-integration` job with the minikube (already existing) using a [build matrix](https://docs.github.com/en/actions/using-jobs/using-a-build-matrix-for-your-jobs). Notice it was configured with `fail-fast: false` to continue running on other Kubernetes distributions so that one can understand if it is a distro-specific issue or not.
- The [concurrency feature](https://docs.github.com/en/actions/using-jobs/using-concurrency) was used to ensure only one test-integration job runs at a time to avoid trying to deploy IG multiple times on the same Kubernetes cluster. It is specifically needed for ARO because it is a pre-created cluster, see _Improvements_ section.
- Authentication credentials are not associated with any user but the ones generated with [az](https://docs.microsoft.com/en-us/azure/openshift/tutorial-connect-cluster), see _Improvements_ section though. Notice that this information was stored in the repo secrets. See [REAMDE](https://github.com/kinvolk/inspektor-gadget/blob/jose/ci-aro/.github/workflows/README.md) file this PR adds.
- The kernel headers for the RedHat CoreOS are downloaded as one of the first steps when the gadget pod is started. It means that even if the pod is in `Ready` state, it is not yet able to run gadgets because it is downloading the kernel headers. As a workaround, I increased the initial delay after the pod is ready and before starting running the gadgets, see _Improvements_ section below.
- Not all the gadgets are working on ARO so they are being temporary skipped, see the _Improvements_ section though. So far, we are only sure that **SocketCollector** and **ProcessCollector** will never work on ARO because they require a kernel version newer than 5.10 and ARO uses 4.18.

## Improvements (In future PRs)

- [ ] Use a functional Service Account instead of admin credentials: https://github.com/kinvolk/inspektor-gadget/issues/574
- [x] By using the [concurrency feature](https://docs.github.com/en/actions/using-jobs/using-concurrency), when there are two workflows running in parallel, the entire `test-integration` job on one of them remains blocked waiting for the other one to finish. It means that the overall CI process is now taking longer while the test-integration job could run in parallel in different workflows when they are using the minikube-github: https://github.com/kinvolk/inspektor-gadget/issues/575  
- [ ] Improve the deploy command to return just when the pod is ready to run gadgets: https://github.com/kinvolk/inspektor-gadget/issues/123
- [ ] Make all gadgets work:
  - **Biolatency**: See issue https://github.com/kinvolk/inspektor-gadget/issues/572
  - **Dns** and **Snisnoop**: See issue https://github.com/kinvolk/inspektor-gadget/issues/569
  - **Capabilities**, **Fsslower**, **Tcptracer**: See issues https://github.com/kinvolk/inspektor-gadget/issues/570, https://github.com/kinvolk/inspektor-gadget/issues/571, https://github.com/kinvolk/inspektor-gadget/issues/568.
  - **Biotop**: See issue https://github.com/kinvolk/inspektor-gadget/issues/589.
  - **Audit-seccomp**: See issue https://github.com/kinvolk/inspektor-gadget/issues/631.

## TODO (This PR)

- [x] Create issues for improvements and not working gadgets. Then, specify then in the code, see [comments]( https://github.com/kinvolk/inspektor-gadget/pull/561#pullrequestreview-910500319).

## How to use it

This PR adds also the [docs/ci.md](https://github.com/kinvolk/inspektor-gadget/blob/jose/ci-aro/docs/ci.md) describing how to create an ARO cluster so that the `Inspektor Gadget CI` workflow will run the integration tests on it.