### PR TITLE
ci: update minikube and kubernetes version

### DIFF
--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -366,10 +366,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Setup Minikube
-      uses: manusa/actions-setup-minikube@v2.4.2
+      uses: manusa/actions-setup-minikube@v2.4.3
       with:
-        minikube version: 'v1.9.2'
-        kubernetes version: 'v1.18.2'
+        minikube version: 'v1.25.2'
+        kubernetes version: 'v1.23.0'
         github token: ${{ secrets.GITHUB_TOKEN }}
     - name: Set IMAGE_TAG
       run: |


### PR DESCRIPTION
#383 introduces a new integration test which uses a pod with the seccompProfile field introduced in Kubernetes v1.19.
