### PR TITLE
integration: Use wbitt/network-multitool for dns integration test.

### DIFF
--- a/docs/guides/dns.md
+++ b/docs/guides/dns.md
@@ -23,7 +23,7 @@ POD                            TYPE      QTYPE     NAME
 Run a pod on a different terminal and perform some DNS requests:
 
 ```bash
-$ kubectl -n demo run mypod -it --image=praqma/network-multitool -- /bin/sh
+$ kubectl -n demo run mypod -it --image=wbitt/network-multitool -- /bin/sh
 # nslookup www.microsoft.com
 # nslookup www.google.com
 # nslookup www.amazon.com

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -236,7 +236,7 @@ func TestDns(t *testing.T) {
 		dnsCmd,
 		{
 			name:           "Run pod which interacts with dns",
-			cmd:            fmt.Sprintf("kubectl run --restart=Never --image=praqma/network-multitool -n %s test-pod -- sh -c 'while true; do nslookup microsoft.com; done'", ns),
+			cmd:            fmt.Sprintf("kubectl run --restart=Never --image=wbitt/network-multitool -n %s test-pod -- sh -c 'while true; do nslookup microsoft.com; done'", ns),
 			expectedRegexp: "pod/test-pod created",
 		},
 		waitUntilTestPodReadyCommand(ns),


### PR DESCRIPTION
Hi.

This PR changed the name of docker image used for DNS integration test because:

```
========================= IMPORTANT ==============================



# Press-release: `Praqma/Network-Multitool` is now `wbitt/Network-Multitool`

## 05 Jan 2022 - Important note about name/org change:
Few years ago, I created this tool with Henrik Høegh, as `praqma/network-multitool`. Praqma was bought by another company, and now the "Praqma" brand is being dismantled. This means the network-multitool's git and docker repositories must go. Since, I was the one maintaining the docker image for all these years, it was decided by the current representatives of the company to hand it over to me so I can continue maintaining it. So, apart from a small change in the repository name, nothing has changed.

The existing/old/previous container image `praqma/network-multitool` will continue to work and will remain available for **"some time"** - may be for a couple of months - not sure though.

- Kamran Azeem <kamranazeem@gmail.com> [https://github.com/KamranAzeem](https://github.com/KamranAzeem)


## Some important URLs:
* The new official github repository for this tool is: [https://github.com/wbitt/Network-MultiTool](https://github.com/wbitt/Network-MultiTool)
* The docker repository to pull this image is now: [https://hub.docker.com/r/wbitt/network-multitool](https://hub.docker.com/r/wbitt/network-multitool)
```

Best regards.