### PR TITLE
Implement filters in audit-seccomp

### DIFF
--- a/pkg/gadgets/audit-seccomp/gadget.go
+++ b/pkg/gadgets/audit-seccomp/gadget.go
@@ -107,10 +107,7 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 
 	var err error
 	config := &auditseccomptracer.Config{
-		// TODO: implement filtering. See:
-		// https://github.com/kinvolk/inspektor-gadget/issues/579
-		// // MountnsMap: gadgets.TracePinPath(trace.ObjectMeta.Namespace, trace.ObjectMeta.Name),
-
+		MountnsMap:    gadgets.TracePinPath(trace.ObjectMeta.Namespace, trace.ObjectMeta.Name),
 		ContainersMap: filepath.Join(gadgets.PinPath, "containers"),
 	}
 	t.tracer, err = auditseccomptracer.NewTracer(config, eventCallback, trace.Spec.Node)

--- a/pkg/gadgets/audit-seccomp/tracer/bpf/Makefile
+++ b/pkg/gadgets/audit-seccomp/tracer/bpf/Makefile
@@ -1,5 +1,5 @@
 .PHONY: all
-all: audit-seccomp.o
+all: audit-seccomp.o audit-seccomp-with-filter.o
 
 PKG_DIR=../../../..
 
@@ -11,5 +11,9 @@ audit-seccomp.o: audit-seccomp.c
 	clang -Werror -I$(PKG_DIR) -target bpf -O2 -g -c -x c $< -o $@ \
 		-D__KERNEL__ -D__TARGET_ARCH_$(SRCARCH)
 
+audit-seccomp-with-filter.o: audit-seccomp.c
+	clang -Werror -I$(PKG_DIR) -target bpf -O2 -g -c -x c $< -o $@ \
+		-D__KERNEL__ -D__TARGET_ARCH_$(SRCARCH) -DWITH_FILTER=1
+
 clean:
-	rm -f audit-seccomp.o
+	rm -f audit-seccomp.o audit-seccomp-with-filter.o

--- a/pkg/gadgets/audit-seccomp/tracer/embed-ebpf.go
+++ b/pkg/gadgets/audit-seccomp/tracer/embed-ebpf.go
@@ -23,3 +23,6 @@ import (
 
 //go:embed bpf/audit-seccomp.o
 var ebpfProg []byte
+
+//go:embed bpf/audit-seccomp-with-filter.o
+var ebpfProgWithFilter []byte

--- a/pkg/gadgets/audit-seccomp/tracer/embed-none.go
+++ b/pkg/gadgets/audit-seccomp/tracer/embed-none.go
@@ -18,3 +18,4 @@
 package tracer
 
 var ebpfProg []byte
+var ebpfProgWithFilter []byte

--- a/pkg/gadgettracermanager/gadgettracermanager.go
+++ b/pkg/gadgettracermanager/gadgettracermanager.go
@@ -18,8 +18,6 @@ import (
 	"context"
 	"crypto/rand"
 	"fmt"
-	"os"
-	"path/filepath"
 	"runtime"
 	"sync"
 
@@ -31,8 +29,8 @@ import (
 	pb "github.com/kinvolk/inspektor-gadget/pkg/gadgettracermanager/api"
 	containersmap "github.com/kinvolk/inspektor-gadget/pkg/gadgettracermanager/containers-map"
 	"github.com/kinvolk/inspektor-gadget/pkg/gadgettracermanager/pubsub"
-	"github.com/kinvolk/inspektor-gadget/pkg/gadgettracermanager/stream"
 	"github.com/kinvolk/inspektor-gadget/pkg/runcfanotify"
+	tracercollection "github.com/kinvolk/inspektor-gadget/pkg/tracer-collection"
 )
 
 import "C"
@@ -47,8 +45,8 @@ type GadgetTracerManager struct {
 	// node where this instance is running
 	nodeName string
 
-	// tracers by tracerId
-	tracers map[string]tracer
+	// tracers
+	tracerCollection *tracercollection.TracerCollection
 
 	// withBPF tells whether GadgetTracerManager can run bpf() syscall.
 	// Normally, withBPF=true but it can be disabled so unit tests can run
@@ -58,17 +56,6 @@ type GadgetTracerManager struct {
 	// containersMap is the global map at /sys/fs/bpf/gadget/containers
 	// exposing container details for each mount namespace.
 	containersMap *containersmap.ContainersMap
-}
-
-type tracer struct {
-	tracerID string
-
-	containerSelector pb.ContainerSelector
-
-	cgroupIDSetMap *ebpf.Map
-	mntnsSetMap    *ebpf.Map
-
-	gadgetStream *stream.GadgetStream
 }
 
 func (g *GadgetTracerManager) AddTracer(_ context.Context, req *pb.AddTracerRequest) (*pb.TracerID, error) {
@@ -86,60 +73,11 @@ func (g *GadgetTracerManager) AddTracer(_ context.Context, req *pb.AddTracerRequ
 	} else {
 		tracerID = req.Id
 	}
-	if _, ok := g.tracers[tracerID]; ok {
-		return nil, fmt.Errorf("tracer id %q: %w", tracerID, os.ErrExist)
+
+	if err := g.tracerCollection.AddTracer(tracerID, *req.Selector); err != nil {
+		return nil, err
 	}
 
-	// Create and pin BPF maps for this tracer.
-	var mntnsSetMap, cgroupIDSetMap *ebpf.Map
-	var err error
-	if g.withBPF {
-		cgroupIDSpec := &ebpf.MapSpec{
-			Name:       gadgets.CGroupMapPrefix + tracerID,
-			Type:       ebpf.Hash,
-			KeySize:    8,
-			ValueSize:  4,
-			MaxEntries: MaxContainersPerNode,
-			Pinning:    ebpf.PinByName,
-		}
-		cgroupIDSetMap, err = ebpf.NewMapWithOptions(cgroupIDSpec, ebpf.MapOptions{PinPath: gadgets.PinPath})
-		if err != nil {
-			return nil, fmt.Errorf("error creating cgroupid map: %w", err)
-		}
-
-		mntnsSpec := &ebpf.MapSpec{
-			Name:       gadgets.MountMapPrefix + tracerID,
-			Type:       ebpf.Hash,
-			KeySize:    8,
-			ValueSize:  4,
-			MaxEntries: MaxContainersPerNode,
-			Pinning:    ebpf.PinByName,
-		}
-		mntnsSetMap, err = ebpf.NewMapWithOptions(mntnsSpec, ebpf.MapOptions{PinPath: gadgets.PinPath})
-		if err != nil {
-			return nil, fmt.Errorf("error creating mntnsset map: %w", err)
-		}
-
-		g.ContainerRangeWithSelector(req.Selector, func(c *pb.ContainerDefinition) {
-			one := uint32(1)
-			cgroupIDC := uint64(c.CgroupId)
-			if cgroupIDC != 0 {
-				cgroupIDSetMap.Put(cgroupIDC, one)
-			}
-			mntnsC := uint64(c.Mntns)
-			if mntnsC != 0 {
-				mntnsSetMap.Put(mntnsC, one)
-			}
-		})
-	}
-
-	g.tracers[tracerID] = tracer{
-		tracerID:          tracerID,
-		containerSelector: *req.Selector,
-		cgroupIDSetMap:    cgroupIDSetMap,
-		mntnsSetMap:       mntnsSetMap,
-		gadgetStream:      stream.NewGadgetStream(),
-	}
 	return &pb.TracerID{Id: tracerID}, nil
 }
 
@@ -147,30 +85,10 @@ func (g *GadgetTracerManager) RemoveTracer(_ context.Context, tracerID *pb.Trace
 	g.mu.Lock()
 	defer g.mu.Unlock()
 
-	if tracerID.Id == "" {
-		return nil, fmt.Errorf("cannot remove tracer: Id not set")
+	if err := g.tracerCollection.RemoveTracer(tracerID.Id); err != nil {
+		return nil, err
 	}
 
-	t, ok := g.tracers[tracerID.Id]
-	if !ok {
-		return nil, fmt.Errorf("cannot remove tracer: unknown tracer %q", tracerID.Id)
-	}
-
-	if t.cgroupIDSetMap != nil {
-		t.cgroupIDSetMap.Close()
-	}
-	if t.mntnsSetMap != nil {
-		t.mntnsSetMap.Close()
-	}
-
-	t.gadgetStream.Close()
-
-	if g.withBPF {
-		os.Remove(filepath.Join(gadgets.PinPath, gadgets.CGroupMapPrefix+t.tracerID))
-		os.Remove(filepath.Join(gadgets.PinPath, gadgets.MountMapPrefix+t.tracerID))
-	}
-
-	delete(g.tracers, tracerID.Id)
 	return &pb.RemoveTracerResponse{}, nil
 }
 
@@ -181,14 +99,13 @@ func (g *GadgetTracerManager) ReceiveStream(tracerID *pb.TracerID, stream pb.Gad
 
 	g.mu.Lock()
 
-	t, ok := g.tracers[tracerID.Id]
-	if !ok {
-		g.mu.Unlock()
-		return fmt.Errorf("cannot find tracer: unknown tracer %q", tracerID.Id)
+	gadgetStream, err := g.tracerCollection.Stream(tracerID.Id)
+	if err != nil {
+		return fmt.Errorf("cannot find stream for tracer %q", tracerID.Id)
 	}
 
-	ch := t.gadgetStream.Subscribe()
-	defer t.gadgetStream.Unsubscribe(ch)
+	ch := gadgetStream.Subscribe()
+	defer gadgetStream.Unsubscribe(ch)
 
 	g.mu.Unlock()
 
@@ -213,12 +130,12 @@ func (g *GadgetTracerManager) PublishEvent(tracerID string, line string) error {
 	// g.mu.Lock()
 	// defer g.mu.Unlock()
 
-	t, ok := g.tracers[tracerID]
-	if !ok {
-		return fmt.Errorf("cannot find tracer: unknown tracer %q", tracerID)
+	stream, err := g.tracerCollection.Stream(tracerID)
+	if err != nil {
+		return fmt.Errorf("cannot find stream for tracer %q", tracerID)
 	}
 
-	t.gadgetStream.Publish(line)
+	stream.Publish(line)
 	return nil
 }
 
@@ -263,21 +180,10 @@ func (g *GadgetTracerManager) DumpState(_ context.Context, req *pb.DumpStateRequ
 	g.ContainerRange(func(c *pb.ContainerDefinition) {
 		out += fmt.Sprintf("%+v\n", c)
 	})
+
 	out += "List of tracers:\n"
-	for i, t := range g.tracers {
-		out += fmt.Sprintf("%v -> %q/%q (%s) Labels: \n",
-			i,
-			t.containerSelector.Namespace,
-			t.containerSelector.Podname,
-			t.containerSelector.Name)
-		for _, l := range t.containerSelector.Labels {
-			out += fmt.Sprintf("                  %v: %v\n", l.Key, l.Value)
-		}
-		out += "        Matches:\n"
-		g.ContainerRangeWithSelector(&t.containerSelector, func(c *pb.ContainerDefinition) {
-			out += fmt.Sprintf("        - %s/%s [Mntns=%v CgroupId=%v]\n", c.Namespace, c.Podname, c.Mntns, c.CgroupId)
-		})
-	}
+	out += g.tracerCollection.TracerDump()
+
 	out += "List of stacks:\n"
 	buf := make([]byte, 1<<20)
 	stacklen := runtime.Stack(buf, true)
@@ -289,9 +195,14 @@ func (g *GadgetTracerManager) DumpState(_ context.Context, req *pb.DumpStateRequ
 func newServer(conf *Conf) (*GadgetTracerManager, error) {
 	g := &GadgetTracerManager{
 		nodeName: conf.NodeName,
-		tracers:  make(map[string]tracer),
 		withBPF:  !conf.TestOnly,
 	}
+
+	tracerCollection, err := tracercollection.NewTracerCollection(gadgets.PinPath, gadgets.MountMapPrefix, !conf.TestOnly, &g.ContainerCollection)
+	if err != nil {
+		return nil, err
+	}
+	g.tracerCollection = tracerCollection
 
 	containerEventFuncs := []pubsub.FuncNotify{}
 
@@ -306,46 +217,7 @@ func newServer(conf *Conf) (*GadgetTracerManager, error) {
 		}
 
 		containerEventFuncs = append(containerEventFuncs, g.containersMap.ContainersMapUpdater())
-
-		containerEventFuncs = append(containerEventFuncs, func(event pubsub.PubSubEvent) {
-			switch event.Type {
-			case pubsub.EventTypeAddContainer:
-				// Skip the pause container
-				if event.Container.Name == "" {
-					return
-				}
-
-				log.Infof("pubsub: ADD_CONTAINER: %s/%s/%s", event.Container.Namespace, event.Container.Podname, event.Container.Name)
-
-				for _, t := range g.tracers {
-					if containercollection.ContainerSelectorMatches(&t.containerSelector, &event.Container) {
-						cgroupIDC := uint64(event.Container.CgroupId)
-						mntnsC := uint64(event.Container.Mntns)
-						one := uint32(1)
-						if cgroupIDC != 0 {
-							t.cgroupIDSetMap.Put(cgroupIDC, one)
-						}
-						if mntnsC != 0 {
-							t.mntnsSetMap.Put(mntnsC, one)
-						} else {
-							log.Errorf("new container with mntns=0")
-						}
-					}
-				}
-
-			case pubsub.EventTypeRemoveContainer:
-				log.Infof("pubsub: REMOVE_CONTAINER: %s/%s/%s", event.Container.Namespace, event.Container.Podname, event.Container.Name)
-
-				for _, t := range g.tracers {
-					if containercollection.ContainerSelectorMatches(&t.containerSelector, &event.Container) {
-						cgroupIDC := uint64(event.Container.CgroupId)
-						mntnsC := uint64(event.Container.Mntns)
-						t.cgroupIDSetMap.Delete(cgroupIDC)
-						t.mntnsSetMap.Delete(mntnsC)
-					}
-				}
-			}
-		})
+		containerEventFuncs = append(containerEventFuncs, g.tracerCollection.TracerMapsUpdater())
 	}
 
 	opts := []containercollection.ContainerCollectionOption{
@@ -390,7 +262,7 @@ func newServer(conf *Conf) (*GadgetTracerManager, error) {
 		opts = append(opts, containercollection.WithFallbackPodInformer(g.nodeName))
 	}
 
-	err := g.ContainerCollectionInitialize(opts...)
+	err = g.ContainerCollectionInitialize(opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/gadgettracermanager/gadgettracermanager_test.go
+++ b/pkg/gadgettracermanager/gadgettracermanager_test.go
@@ -47,8 +47,8 @@ func TestTracer(t *testing.T) {
 		}
 	}
 
-	if len(g.tracers) != 3 {
-		t.Fatalf("Error while checking tracers: len %d", len(g.tracers))
+	if g.tracerCollection.TracerCount() != 3 {
+		t.Fatalf("Error while checking tracers: len %d", g.tracerCollection.TracerCount())
 	}
 
 	// Check error on duplicate tracer
@@ -85,15 +85,13 @@ func TestTracer(t *testing.T) {
 	}
 
 	// Check content
-	if len(g.tracers) != 2 {
-		t.Fatalf("Error while checking tracers: len %d", len(g.tracers))
+	if g.tracerCollection.TracerCount() != 2 {
+		t.Fatalf("Error while checking tracers: len %d", g.tracerCollection.TracerCount())
 	}
-	_, ok := g.tracers["my_tracer_id0"]
-	if !ok {
+	if !g.tracerCollection.TracerExists("my_tracer_id0") {
 		t.Fatalf("Error while checking tracer %s: not found", "my_tracer_id0")
 	}
-	_, ok = g.tracers["my_tracer_id2"]
-	if !ok {
+	if !g.tracerCollection.TracerExists("my_tracer_id2") {
 		t.Fatalf("Error while checking tracer %s: not found", "my_tracer_id2")
 	}
 }

--- a/pkg/tracer-collection/tracer-collection.go
+++ b/pkg/tracer-collection/tracer-collection.go
@@ -1,0 +1,196 @@
+// Copyright 2022 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tracercollection
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/cilium/ebpf"
+	log "github.com/sirupsen/logrus"
+
+	containercollection "github.com/kinvolk/inspektor-gadget/pkg/container-collection"
+	pb "github.com/kinvolk/inspektor-gadget/pkg/gadgettracermanager/api"
+	"github.com/kinvolk/inspektor-gadget/pkg/gadgettracermanager/pubsub"
+	"github.com/kinvolk/inspektor-gadget/pkg/gadgettracermanager/stream"
+)
+
+const (
+	MaxContainersPerNode = 1024
+)
+
+type TracerCollection struct {
+	tracers             map[string]tracer
+	containerCollection *containercollection.ContainerCollection
+
+	withEbpf  bool
+	pinPath   string
+	mapPrefix string
+}
+
+type tracer struct {
+	tracerID string
+
+	containerSelector pb.ContainerSelector
+
+	mntnsSetMap *ebpf.Map
+
+	gadgetStream *stream.GadgetStream
+}
+
+func NewTracerCollection(pinPath, mapPrefix string, withEbpf bool, cc *containercollection.ContainerCollection) (*TracerCollection, error) {
+	return &TracerCollection{
+		tracers:             make(map[string]tracer),
+		containerCollection: cc,
+		withEbpf:            withEbpf,
+		pinPath:             pinPath,
+		mapPrefix:           mapPrefix,
+	}, nil
+}
+
+func (tc *TracerCollection) TracerMapsUpdater() pubsub.FuncNotify {
+	if !tc.withEbpf {
+		return func(event pubsub.PubSubEvent) {}
+	}
+
+	return func(event pubsub.PubSubEvent) {
+		switch event.Type {
+		case pubsub.EventTypeAddContainer:
+			// Skip the pause container
+			if event.Container.Name == "" {
+				return
+			}
+
+			for _, t := range tc.tracers {
+				if containercollection.ContainerSelectorMatches(&t.containerSelector, &event.Container) {
+					mntnsC := uint64(event.Container.Mntns)
+					one := uint32(1)
+					if mntnsC != 0 {
+						t.mntnsSetMap.Put(mntnsC, one)
+					} else {
+						log.Errorf("new container with mntns=0")
+					}
+				}
+			}
+
+		case pubsub.EventTypeRemoveContainer:
+			for _, t := range tc.tracers {
+				if containercollection.ContainerSelectorMatches(&t.containerSelector, &event.Container) {
+					mntnsC := uint64(event.Container.Mntns)
+					t.mntnsSetMap.Delete(mntnsC)
+				}
+			}
+		}
+	}
+}
+
+func (tc *TracerCollection) AddTracer(id string, containerSelector pb.ContainerSelector) error {
+	if _, ok := tc.tracers[id]; ok {
+		return fmt.Errorf("tracer id %q: %w", id, os.ErrExist)
+	}
+	var mntnsSetMap *ebpf.Map
+	if tc.withEbpf {
+		mntnsSpec := &ebpf.MapSpec{
+			Name:       tc.mapPrefix + id,
+			Type:       ebpf.Hash,
+			KeySize:    8,
+			ValueSize:  4,
+			MaxEntries: MaxContainersPerNode,
+			Pinning:    ebpf.PinByName,
+		}
+		var err error
+		mntnsSetMap, err = ebpf.NewMapWithOptions(mntnsSpec, ebpf.MapOptions{PinPath: tc.pinPath})
+		if err != nil {
+			return fmt.Errorf("error creating mntnsset map: %w", err)
+		}
+		tc.containerCollection.ContainerRangeWithSelector(&containerSelector, func(c *pb.ContainerDefinition) {
+			one := uint32(1)
+			mntnsC := uint64(c.Mntns)
+			if mntnsC != 0 {
+				mntnsSetMap.Put(mntnsC, one)
+			}
+		})
+	}
+	tc.tracers[id] = tracer{
+		tracerID:          id,
+		containerSelector: containerSelector,
+		mntnsSetMap:       mntnsSetMap,
+		gadgetStream:      stream.NewGadgetStream(),
+	}
+	return nil
+}
+
+func (tc *TracerCollection) RemoveTracer(id string) error {
+	if id == "" {
+		return fmt.Errorf("cannot remove tracer: id not set")
+	}
+
+	t, ok := tc.tracers[id]
+	if !ok {
+		return fmt.Errorf("cannot remove tracer: unknown tracer %q", id)
+	}
+
+	if t.mntnsSetMap != nil {
+		t.mntnsSetMap.Close()
+	}
+
+	t.gadgetStream.Close()
+
+	if tc.withEbpf {
+		os.Remove(filepath.Join(tc.pinPath, tc.mapPrefix+id))
+	}
+
+	delete(tc.tracers, id)
+	return nil
+}
+
+func (tc *TracerCollection) Stream(id string) (*stream.GadgetStream, error) {
+	t, ok := tc.tracers[id]
+	if !ok {
+		return nil, fmt.Errorf("unknown tracer %q", id)
+	}
+	return t.gadgetStream, nil
+}
+
+func (tc *TracerCollection) TracerCount() int {
+	return len(tc.tracers)
+}
+
+func (tc *TracerCollection) TracerDump() (out string) {
+	for i, t := range tc.tracers {
+		out += fmt.Sprintf("%v -> %q/%q (%s) Labels: \n",
+			i,
+			t.containerSelector.Namespace,
+			t.containerSelector.Podname,
+			t.containerSelector.Name)
+		for _, l := range t.containerSelector.Labels {
+			out += fmt.Sprintf("                  %v: %v\n", l.Key, l.Value)
+		}
+		out += "        Matches:\n"
+		tc.containerCollection.ContainerRangeWithSelector(&t.containerSelector, func(c *pb.ContainerDefinition) {
+			out += fmt.Sprintf("        - %s/%s [Mntns=%v CgroupId=%v]\n", c.Namespace, c.Podname, c.Mntns, c.CgroupId)
+		})
+	}
+	return
+}
+
+func (tc *TracerCollection) TracerExists(id string) bool {
+	_, ok := tc.tracers[id]
+	return ok
+}
+
+func (tc *TracerCollection) Close() {
+}


### PR DESCRIPTION
# Implement filters in audit-seccomp

This introduces a new package `tracer-collection` that will handle a set of tracers with their BPF maps such as `/sys/fs/bpf/gadget/mntnsset_trace_gadget_trace1`. It is used both in gadget-tracer-manager and local-gadget-manager.

Fixes https://github.com/kinvolk/inspektor-gadget/issues/579


## How to use with local-gadget

Prepare a seccomp profile `profile.json`:
```json
{
  "defaultAction": "SCMP_ACT_ALLOW",
  "architectures": [
    "SCMP_ARCH_X86_64"
  ],
  "syscalls": [
    {
      "action": "SCMP_ACT_LOG",
      "names": [
        "unshare"
      ]
    }
  ]
}
```

Start a container with the seccomp profile:
```
$ docker run --name demo -ti --rm --security-opt seccomp=profile.json ubuntu
```

Use the audit-seccomp gadget in local-gadget, filtering with the container name created above:
```
$ sudo ./local-gadget
» create audit-seccomp trace1 --container-selector demo
State: Started
» stream trace1 -f
```

Run the `unshare` command in the container:
```
# unshare -i
unshare: unshare failed: Operation not permitted
```

Observe the result in local-gadget:
```
{"type":"normal","node":"local","namespace":"default","pod":"demo","container":"demo","syscall":"unshare","code":"log","pid":1162251,"mountnsid":4026532756,"pcomm":"unshare"}
```

Observe that no result is printed with a different filter `--container-selector foobar`.

## How to use with kubectl-gadget

Follow the guide at https://github.com/kinvolk/inspektor-gadget/blob/main/docs/guides/audit-seccomp.md

Use some filters: 
```
kubectl gadget audit-seccomp -n default --containername container1
```

## Testing done

* [x] `make local-gadget-tests`
* [x] With kubectl-gadget