### PR TITLE
Remove libbpf-tools from container image

### DIFF
--- a/gadget.Dockerfile
+++ b/gadget.Dockerfile
@@ -2,7 +2,7 @@
 
 # BCC built from the gadget branch in the kinvolk/bcc fork.
 # See BCC section in docs/CONTRIBUTING.md for further details.
-ARG BCC="quay.io/kinvolk/bcc:8b46a61f618fb74ec647250f71be33ce74763d75-focal-release"
+ARG BCC="quay.io/kinvolk/bcc:64a64b4ba0a719fb6b79a4705f29ad5e1fa1e47d-focal-release"
 ARG OS_TAG=20.04
 
 FROM ${BCC} as bcc
@@ -39,11 +39,10 @@ COPY ./ /gadget
 RUN cd /gadget/gadget-container && make gadget-container-deps
 
 # Execute BTFGen
-COPY --from=bcc /objs /objs
 RUN set -ex; \
 	if [ "$ENABLE_BTFGEN" = true ]; then \
 		cd /btf-tools && \
-		LIBBPFTOOLS=/objs BTFHUB=/tmp/btfhub INSPEKTOR_GADGET=/gadget ./btfgen.sh; \
+		BTFHUB=/tmp/btfhub INSPEKTOR_GADGET=/gadget ./btfgen.sh; \
 	fi
 
 # Builder: traceloop
@@ -66,7 +65,7 @@ RUN set -ex; \
 	apt-get install -y --no-install-recommends \
 		ca-certificates curl jq wget xz-utils binutils rpm2cpio cpio && \
 		rmdir /usr/src && ln -sf /host/usr/src /usr/src && \
-		rm /etc/localtime && ln -sf /host/etc/localtime /etc/localtime
+		rm -f /etc/localtime && ln -sf /host/etc/localtime /etc/localtime
 
 COPY gadget-container/entrypoint.sh gadget-container/cleanup.sh /
 

--- a/tools/btfgen.sh
+++ b/tools/btfgen.sh
@@ -3,16 +3,10 @@
 set -e
 set -x
 
-LIBBPFTOOLS="${LIBBPFTOOLS:-$(pwd)/../bcc/libbpf-tools/.output/}"
 BTFHUB="${BTFHUB:-$(pwd)/../btfhub/}"
 INSPEKTOR_GADGET=${INSPEKTOR_GADGET:-$(pwd)}
 ARCH=x86_64
 OUTPUT=/tmp/btfs
-
-if [ ! -d "${LIBBPFTOOLS}" ]; then
-    echo "error: libbpftools folder not found"
-    exit 1
-fi
 
 if [ ! -d "${BTFHUB}" ]; then
     echo "error: btfhub folder not found"


### PR DESCRIPTION
Those are not needed anymore as we implemented such tools directly
in Inspektor Gadget. This changes reduces the container image size by about 60MB. 

