### PR TITLE
cmd/kubectl-gadget: Wait for gadget namespace to be removed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -163,7 +163,6 @@ minikube-install: gadget-container kubectl-gadget
 	docker save $(CONTAINER_REPO):$(IMAGE_TAG) $(PV) | (eval $(shell $(MINIKUBE) -p minikube docker-env | grep =) && docker load)
 	# Remove all resources created by Inspektor Gadget.
 	./kubectl-gadget undeploy || true
-	time kubectl wait --for=delete namespace gadget 2>/dev/null || true
 	./kubectl-gadget deploy --hook-mode=fanotify \
 		--image-pull-policy=Never | \
 		sed 's/initialDelaySeconds: 10/initialDelaySeconds: '$(LIVENESS_PROBE_INITIAL_DELAY_SECONDS)'/g' | \


### PR DESCRIPTION
This commit adds logic to wait until the gadget namespace is removed
before returning. This is useful to guarantee that Inspektor Gadget
is completely remove when the command returns. This behaviour is
enabled by default and can be turn off by using '--wait=false'

Fixes https://github.com/kinvolk/inspektor-gadget/issues/573