### PR TITLE
docs: Replace --namespaces by -n for network-policy guide.

### DIFF
--- a/docs/guides/network-policy.md
+++ b/docs/guides/network-policy.md
@@ -20,7 +20,7 @@ clusterrolebinding.rbac.authorization.k8s.io/disable-psp-demo created
 In one terminal, start the network-policy gadget:
 
 ```bash
-$ kubectl gadget network-policy monitor --namespaces demo --output ./networktrace.log
+$ kubectl gadget network-policy monitor -n demo --output ./networktrace.log
 ```
 
 In another terminal, deploy [GoogleCloudPlatform/microservices-demo](https://github.com/GoogleCloudPlatform/microservices-demo/blob/master/release/kubernetes-manifests.yaml) in the demo namespace:


### PR DESCRIPTION
Hi.


I went through the network-policy guide and realized the line before this commit did not work, so I fix it to avoid people reading the doc being misguided.


Best regards.