### PR TITLE
kubectl-gadget: Add missing capabilities needed in ARO

### DIFF
--- a/cmd/kubectl-gadget/deploy.go
+++ b/cmd/kubectl-gadget/deploy.go
@@ -295,6 +295,9 @@ spec:
               # Needed by BCC python-based gadgets to load the kheaders module:
               # https://github.com/iovisor/bcc/blob/v0.24.0/src/cc/frontends/clang/kbuild_helper.cc#L158
               - SYS_MODULE
+
+              # Needed by gadgets that open a raw sock like dns and snisnoop
+              - NET_RAW
         volumeMounts:
         - name: host
           mountPath: /host

--- a/cmd/kubectl-gadget/deploy.go
+++ b/cmd/kubectl-gadget/deploy.go
@@ -291,6 +291,10 @@ spec:
               # Needed for gadgets that don't dumb the memory rlimit.
               # (Currently only applies to BCC python-based gadgets)
               - IPC_LOCK
+
+              # Needed by BCC python-based gadgets to load the kheaders module:
+              # https://github.com/iovisor/bcc/blob/v0.24.0/src/cc/frontends/clang/kbuild_helper.cc#L158
+              - SYS_MODULE
         volumeMounts:
         - name: host
           mountPath: /host


### PR DESCRIPTION
- BCC python-based tools were failing to start because the container was missing the sys_mod capability. 
It seems it was only happening in ARO because that system don't have the kernel headers available.
- NET_RAW: Needed by gadgets that open a raw sock like dns and snisnoop

Fixes https://github.com/kinvolk/inspektor-gadget/issues/570
Fixes https://github.com/kinvolk/inspektor-gadget/issues/568
Fixes https://github.com/kinvolk/inspektor-gadget/issues/572
Fixes https://github.com/kinvolk/inspektor-gadget/issues/569
