### PR TITLE
kubectl-gadget: Fix typo in fsslower command

### DIFF
--- a/cmd/kubectl-gadget/trace/fsslower.go
+++ b/cmd/kubectl-gadget/trace/fsslower.go
@@ -42,7 +42,7 @@ var fsslowerCmd = &cobra.Command{
 	Short: "Trace open, read, write and fsync operations slower than a threshold",
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		if fsslowerFilesystem == "" {
-			return utils.WrapInErrMissingArgs("--filesystem")
+			return utils.WrapInErrMissingArgs("--filesystem / -f")
 		}
 
 		found := false
@@ -55,7 +55,7 @@ var fsslowerCmd = &cobra.Command{
 		}
 
 		if !found {
-			return utils.WrapInErrInvalidArg("--type / -t",
+			return utils.WrapInErrInvalidArg("--filesystem / -f",
 				fmt.Errorf("%q is not a valid filesystem", fsslowerFilesystem))
 		}
 
@@ -99,7 +99,7 @@ func init() {
 		"Min latency to trace, in ms",
 	)
 	fsslowerCmd.Flags().StringVarP(
-		&fsslowerFilesystem, "type", "t", "",
+		&fsslowerFilesystem, "filesystem", "f", "",
 		fmt.Sprintf("Which filesystem to trace: [%s]", strings.Join(validFsSlowerFilesystems, ", ")),
 	)
 

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -518,7 +518,7 @@ func TestFsslower(t *testing.T) {
 
 	fsslowerCmd := &command{
 		name:           "StartFsslowerGadget",
-		cmd:            fmt.Sprintf("$KUBECTL_GADGET trace fsslower -n %s -t %s -m 0", ns, fsType),
+		cmd:            fmt.Sprintf("$KUBECTL_GADGET trace fsslower -n %s -f %s -m 0", ns, fsType),
 		expectedRegexp: fmt.Sprintf(`%s\s+test-pod\s+test-pod\s+cat`, ns),
 		startAndStop:   true,
 	}


### PR DESCRIPTION
The parameter is called "type" and not filesystem.

