### PR TITLE
Provide dockerfile for only CO-RE gadgets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,6 +115,12 @@ gadget-container:
 	docker build -t $(CONTAINER_REPO):$(IMAGE_TAG) -f gadget.Dockerfile \
 		--build-arg ENABLE_BTFGEN=$(ENABLE_BTFGEN) .
 
+# gadget container core
+.PHONY: gadget-container-core
+gadget-container-core:
+	docker build -t $(CONTAINER_REPO):$(IMAGE_TAG) -f gadget.core.Dockerfile \
+		--build-arg ENABLE_BTFGEN=$(ENABLE_BTFGEN) .
+
 .PHONY: push-gadget-container
 push-gadget-container:
 	docker push $(CONTAINER_REPO):$(IMAGE_TAG)

--- a/gadget-container/entrypoint.sh
+++ b/gadget-container/entrypoint.sh
@@ -47,7 +47,7 @@ echo $INSPEKTOR_GADGET_VERSION
 # mounted, passing /sys/fs/bpf from the pseudo-host does not work.
 # See also:
 # https://github.com/kubernetes/minikube/blob/99a0c91459f17ad8c83c80fc37a9ded41e34370c/deploy/kicbase/entrypoint#L76-L81
-BPF_MOUNTPOINT_TYPE="`stat -f --format=%T /sys/fs/bpf`"
+BPF_MOUNTPOINT_TYPE="`stat -f -c %T /sys/fs/bpf`"
 if [ "$BPF_MOUNTPOINT_TYPE" != "bpf_fs" ] ; then
   echo "/sys/fs/bpf is of type $BPF_MOUNTPOINT_TYPE. Remounting."
   mount -t bpf bpf /sys/fs/bpf/

--- a/gadget.core.Dockerfile
+++ b/gadget.core.Dockerfile
@@ -1,0 +1,98 @@
+ARG BUILDER_OS_TAG=20.04
+ARG BASEIMAGE=alpine:3.14
+
+# Prepare and build gadget artifacts in a container
+FROM ubuntu:${BUILDER_OS_TAG} as builder
+
+ARG ENABLE_BTFGEN=false
+ENV ENABLE_BTFGEN=${ENABLE_BTFGEN}
+
+RUN set -ex; \
+	export DEBIAN_FRONTEND=noninteractive; \
+	apt-get update && \
+	apt-get install -y gcc make ca-certificates git clang \
+		software-properties-common libseccomp-dev && \
+	add-apt-repository -y ppa:tuxinvader/kernel-build-tools && \
+	apt-add-repository -y ppa:longsleep/golang-backports && \
+	apt-get update && \
+	apt-get install -y libbpf-dev golang-1.17 && \
+	ln -s /usr/lib/go-1.17/bin/go /bin/go
+
+# Download BTFHub files
+COPY ./tools /btf-tools
+RUN set -ex; mkdir -p /tmp/btfs && \
+	if [ "$ENABLE_BTFGEN" = true ]; then \
+		cd /btf-tools && \
+		./getbtfhub.sh; \
+	fi
+
+# Cache go modules so they won't be downloaded at each build
+COPY go.mod go.sum /gadget/
+RUN cd /gadget && go mod download
+
+# This COPY is limited by .dockerignore
+COPY ./ /gadget
+RUN cd /gadget/gadget-container && make gadget-container-deps
+
+# Execute BTFGen
+RUN set -ex; \
+	if [ "$ENABLE_BTFGEN" = true ]; then \
+		cd /btf-tools && \
+		BTFHUB=/tmp/btfhub INSPEKTOR_GADGET=/gadget ./btfgen.sh; \
+	fi
+
+# Builder: traceloop
+
+# traceloop built from:
+# https://github.com/kinvolk/traceloop/commit/95857527df8d343a054d3754dc3b77c7c8c274c7
+# See:
+# - https://github.com/kinvolk/traceloop/actions
+# - https://hub.docker.com/r/kinvolk/traceloop/tags
+
+FROM docker.io/kinvolk/traceloop:20211109004128958575 as traceloop
+
+# Main gadget image
+FROM ${BASEIMAGE}
+
+# install libseccomp according to the package manager available on the base image
+RUN set -ex; \
+	if command -v yum; then \
+		yum install -y libseccomp wget curl; \
+	elif command -v apt-get; then \
+		apt-get update && \
+		apt-get install -y seccompwget curl ; \
+	elif command -v apk; then \
+		apk add gcompat libseccomp bash wget curl ; \
+	fi && \
+	rmdir /usr/src || true && ln -sf /host/usr/src /usr/src && \
+	rm -f /etc/localtime && ln -sf /host/etc/localtime /etc/localtime
+
+COPY gadget-container/entrypoint.sh gadget-container/cleanup.sh /
+
+COPY --from=builder /gadget/gadget-container/bin/gadgettracermanager /bin/
+COPY --from=builder /gadget/gadget-container/bin/networkpolicyadvisor /bin/
+
+COPY gadget-container/gadgets/bcck8s /opt/bcck8s/
+
+COPY --from=traceloop /bin/traceloop /bin/
+
+## Hooks Begins
+
+# OCI
+COPY gadget-container/hooks/oci/prestart.sh gadget-container/hooks/oci/poststop.sh /opt/hooks/oci/
+COPY --from=builder /gadget/gadget-container/bin/ocihookgadget /opt/hooks/oci/
+
+# cri-o
+COPY gadget-container/hooks/crio/gadget-prestart.json gadget-container/hooks/crio/gadget-poststop.json /opt/hooks/crio/
+
+# nri
+COPY --from=builder /gadget/gadget-container/bin/nrigadget /opt/hooks/nri/
+COPY gadget-container/hooks/nri/conf.json /opt/hooks/nri/
+
+## Hooks Ends
+
+# BTF files
+COPY --from=builder /tmp/btfs /btfs/
+
+# Mitigate https://github.com/kubernetes/kubernetes/issues/106962.
+RUN rm -f /var/run


### PR DESCRIPTION
Inspektor Gadget has two different kind of gadgets:
1: standard gadgets. These tools come from BCC, use Python and are
   compiled in the target machine before loading. They require to ship a
   whole compiling chain (clang) and libbcc. These tools have the
   advantage that they only require the kernel headers to be installed
   and work on systems without BTF support.
2: CO-RE gadgets: These tools use Compile Once - Run Everywhere. They
   are more lighter but require BTF info to be present.

A lot of distributions are enabling BTF and tools like BTFHub and BTFGen
make it possible to run those gadgets in systems without BTF. This
commit introduces a new dockerfile that provides support only for CO-RE
gadgets. The advantages of this approach are:
- The size of the image is reduced from ~800MB to ~200MB (when using
  alpine).
- A lot of things is removed from the container reducing the attack
  surface.
- The compilation is faster.
- Other images like fedora, debian, alpine can be used as base.

--- 

NOTE: This PR only provides the docker file, it's not used by the CI nor when deploying IG. We can consider those steps later on. 
