### PR TITLE
integration-tests: Print the output before making the test fail

### DIFF
--- a/integration/command.go
+++ b/integration/command.go
@@ -203,11 +203,12 @@ func (c *command) run(t *testing.T) {
 
 	t.Logf("Run command: %s\n", c.cmd)
 	err := c.command.Run()
+
+	t.Logf("Command returned:\n%s\n%s\n", c.stderr.String(), c.stdout.String())
+
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	t.Logf("Command returned:\n%s\n%s\n", c.stderr.String(), c.stdout.String())
 
 	err = c.verifyOutput()
 	if err != nil {
@@ -221,11 +222,12 @@ func (c *command) runWithoutTest() error {
 
 	c.createExecCmd()
 	err := c.command.Run()
+
+	fmt.Printf("Command returned:\n%s\n%s\n", c.stderr.String(), c.stdout.String())
+
 	if err != nil {
 		return err
 	}
-
-	fmt.Printf("Command returned:\n%s\n%s\n", c.stderr.String(), c.stdout.String())
 
 	return c.verifyOutput()
 }
@@ -275,11 +277,12 @@ func (c *command) stop(t *testing.T) {
 	// received by all the processes with such PGID, in our case, the process of
 	// /bin/sh and c.cmd.
 	err := syscall.Kill(-c.command.Process.Pid, syscall.SIGTERM)
+
+	t.Logf("Command returned:\n%s\n%s\n", c.stderr.String(), c.stdout.String())
+
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	t.Logf("Command returned:\n%s\n%s\n", c.stderr.String(), c.stdout.String())
 
 	err = c.verifyOutput()
 	if err != nil {


### PR DESCRIPTION
# Print the output before making the test fail

Printing the output no matter whether the test failed or not allows us to understand why it failed if it did.

### Before this PR
```bash
$ sudo -E go test -tags withebpf -run TestBiolatency -integration -no-deploy ./...
using random seed: 1649428227236645175
--- FAIL: TestBiolatency (15.37s)
    command.go:204: Run command: id=$($KUBECTL_GADGET biolatency start --node $(kubectl get node --no-headers | cut -d' ' -f1)); sleep 15; $KUBECTL_GADGET biolatency stop $id
    command.go:207: exit status 1
FAIL
exit status 1
FAIL    github.com/kinvolk/inspektor-gadget/integration 15.369s
```

### After this PR
```bash
$ sudo -E go test -tags withebpf -run TestBiolatency -integration -no-deploy ./...
using random seed: 1649428324109800923
--- FAIL: TestBiolatency (15.44s)
    command.go:204: Run command: id=$($KUBECTL_GADGET biolatency start --node $(kubectl get node --no-headers | cut -d' ' -f1)); sleep 15; $KUBECTL_GADGET biolatency stop $id
    command.go:207: Command returned:
        Error: unknown command "aks-agentpool-25084143-vmss000001" for "kubectl-gadget biolatency start"
        Error: missing required arguments: <trace-id>


    command.go:210: exit status 1
FAIL
exit status 1
FAIL    github.com/kinvolk/inspektor-gadget/integration 15.438s
```