### PR TITLE
local-gadget: Support CRI-O and Containerd

### DIFF
--- a/pkg/container-utils/containerd/containerd.go
+++ b/pkg/container-utils/containerd/containerd.go
@@ -21,21 +21,21 @@ import (
 )
 
 const (
-	Name                   = "containerd"
-	DefaultRuntimeEndpoint = "/run/containerd/containerd.sock"
-	DefaultTimeout         = 2 * time.Second
+	Name              = "containerd"
+	DefaultSocketPath = "/run/containerd/containerd.sock"
+	DefaultTimeout    = 2 * time.Second
 )
 
 type ContainerdClient struct {
 	runtimeclient.CRIClient
 }
 
-func NewContainerdClient(endpoint string) (runtimeclient.ContainerRuntimeClient, error) {
-	if endpoint == "" {
-		endpoint = DefaultRuntimeEndpoint
+func NewContainerdClient(socketPath string) (runtimeclient.ContainerRuntimeClient, error) {
+	if socketPath == "" {
+		socketPath = DefaultSocketPath
 	}
 
-	criClient, err := runtimeclient.NewCRIClient(Name, endpoint, DefaultTimeout)
+	criClient, err := runtimeclient.NewCRIClient(Name, socketPath, DefaultTimeout)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/container-utils/containerd/containerd.go
+++ b/pkg/container-utils/containerd/containerd.go
@@ -31,6 +31,10 @@ type ContainerdClient struct {
 }
 
 func NewContainerdClient(endpoint string) (runtimeclient.ContainerRuntimeClient, error) {
+	if endpoint == "" {
+		endpoint = DefaultRuntimeEndpoint
+	}
+
 	criClient, err := runtimeclient.NewCRIClient(Name, endpoint, DefaultTimeout)
 	if err != nil {
 		return nil, err

--- a/pkg/container-utils/containerutils.go
+++ b/pkg/container-utils/containerutils.go
@@ -83,23 +83,28 @@ out:
 */
 import "C"
 
-var ContainerRuntimes = []string{
+var AvailableRuntimes = []string{
 	docker.Name,
 	containerd.Name,
 	crio.Name,
 }
 
-func NewContainerRuntimeClient(runtime string) (runtimeclient.ContainerRuntimeClient, error) {
-	switch runtime {
+type RuntimeConfig struct {
+	Name       string
+	SocketPath string
+}
+
+func NewContainerRuntimeClient(runtime *RuntimeConfig) (runtimeclient.ContainerRuntimeClient, error) {
+	switch runtime.Name {
 	case docker.Name:
-		return docker.NewDockerClient(docker.DefaultEngineAPISocket)
+		return docker.NewDockerClient(runtime.SocketPath)
 	case containerd.Name:
-		return containerd.NewContainerdClient(containerd.DefaultRuntimeEndpoint)
+		return containerd.NewContainerdClient(runtime.SocketPath)
 	case crio.Name:
-		return crio.NewCrioClient(crio.DefaultRuntimeEndpoint)
+		return crio.NewCrioClient(runtime.SocketPath)
 	default:
 		return nil, fmt.Errorf("unknown container runtime: %s (available %s)",
-			runtime, strings.Join(ContainerRuntimes, ", "))
+			runtime, strings.Join(AvailableRuntimes, ", "))
 	}
 }
 

--- a/pkg/container-utils/crio/crio.go
+++ b/pkg/container-utils/crio/crio.go
@@ -21,21 +21,21 @@ import (
 )
 
 const (
-	Name                   = "cri-o"
-	DefaultRuntimeEndpoint = "/run/crio/crio.sock"
-	DefaultTimeout         = 2 * time.Second
+	Name              = "cri-o"
+	DefaultSocketPath = "/run/crio/crio.sock"
+	DefaultTimeout    = 2 * time.Second
 )
 
 type CrioClient struct {
 	runtimeclient.CRIClient
 }
 
-func NewCrioClient(endpoint string) (runtimeclient.ContainerRuntimeClient, error) {
-	if endpoint == "" {
-		endpoint = DefaultRuntimeEndpoint
+func NewCrioClient(socketPath string) (runtimeclient.ContainerRuntimeClient, error) {
+	if socketPath == "" {
+		socketPath = DefaultSocketPath
 	}
 
-	criClient, err := runtimeclient.NewCRIClient(Name, endpoint, DefaultTimeout)
+	criClient, err := runtimeclient.NewCRIClient(Name, socketPath, DefaultTimeout)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/container-utils/crio/crio.go
+++ b/pkg/container-utils/crio/crio.go
@@ -31,6 +31,10 @@ type CrioClient struct {
 }
 
 func NewCrioClient(endpoint string) (runtimeclient.ContainerRuntimeClient, error) {
+	if endpoint == "" {
+		endpoint = DefaultRuntimeEndpoint
+	}
+
 	criClient, err := runtimeclient.NewCRIClient(Name, endpoint, DefaultTimeout)
 	if err != nil {
 		return nil, err

--- a/pkg/container-utils/docker/docker.go
+++ b/pkg/container-utils/docker/docker.go
@@ -17,7 +17,6 @@ package docker
 import (
 	"context"
 	"errors"
-	"net"
 	"time"
 
 	"github.com/docker/docker/client"
@@ -47,9 +46,8 @@ func NewDockerClient(apiSocket string) (runtimeclient.ContainerRuntimeClient, er
 
 	cli, err := client.NewClientWithOpts(
 		client.WithAPIVersionNegotiation(),
-		client.WithDialContext(func(ctx context.Context, network, addr string) (net.Conn, error) {
-			return net.DialTimeout("unix", apiSocket, DefaultTimeout)
-		}),
+		client.WithHost("unix://"+apiSocket),
+		client.WithTimeout(DefaultTimeout),
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/container-utils/docker/docker.go
+++ b/pkg/container-utils/docker/docker.go
@@ -24,9 +24,9 @@ import (
 )
 
 const (
-	Name                   = "docker"
-	DefaultEngineAPISocket = "/run/docker.sock"
-	DefaultTimeout         = 2 * time.Second
+	Name              = "docker"
+	DefaultSocketPath = "/run/docker.sock"
+	DefaultTimeout    = 2 * time.Second
 )
 
 // DockerClient implements the ContainerRuntimeClient interface but using the
@@ -35,18 +35,18 @@ const (
 // and Containerd. For instance, Dockershim does not provide the container pid1
 // with the ContainerStatus() call as Containerd and CRI-O do.
 type DockerClient struct {
-	client    *client.Client
-	apiSocket string
+	client     *client.Client
+	socketPath string
 }
 
-func NewDockerClient(apiSocket string) (runtimeclient.ContainerRuntimeClient, error) {
-	if apiSocket == "" {
-		apiSocket = DefaultEngineAPISocket
+func NewDockerClient(socketPath string) (runtimeclient.ContainerRuntimeClient, error) {
+	if socketPath == "" {
+		socketPath = DefaultSocketPath
 	}
 
 	cli, err := client.NewClientWithOpts(
 		client.WithAPIVersionNegotiation(),
-		client.WithHost("unix://"+apiSocket),
+		client.WithHost("unix://"+socketPath),
 		client.WithTimeout(DefaultTimeout),
 	)
 	if err != nil {
@@ -54,8 +54,8 @@ func NewDockerClient(apiSocket string) (runtimeclient.ContainerRuntimeClient, er
 	}
 
 	return &DockerClient{
-		client:    cli,
-		apiSocket: apiSocket,
+		client:     cli,
+		socketPath: socketPath,
 	}, nil
 }
 

--- a/pkg/container-utils/docker/docker.go
+++ b/pkg/container-utils/docker/docker.go
@@ -41,6 +41,10 @@ type DockerClient struct {
 }
 
 func NewDockerClient(apiSocket string) (runtimeclient.ContainerRuntimeClient, error) {
+	if apiSocket == "" {
+		apiSocket = DefaultEngineAPISocket
+	}
+
 	cli, err := client.NewClientWithOpts(
 		client.WithAPIVersionNegotiation(),
 		client.WithDialContext(func(ctx context.Context, network, addr string) (net.Conn, error) {

--- a/pkg/container-utils/runtime-client/interface.go
+++ b/pkg/container-utils/runtime-client/interface.go
@@ -23,9 +23,23 @@ import (
 	"strings"
 	"time"
 
+	log "github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
 	pb "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 )
+
+type ContainerData struct {
+	// ID is the container ID without the container runtime prefix. For
+	// instance, "cri-o://" for CRI-O.
+	ID string
+
+	// Name is the container name. In the case the container runtime response
+	// with multiples, Name contains only the first element.
+	Name string
+
+	// Running defines whether or not the container is in the running state
+	Running bool
+}
 
 // ContainerRuntimeClient defines the interface to communicate with the
 // different container runtimes.
@@ -34,6 +48,13 @@ type ContainerRuntimeClient interface {
 	// specified ID. In case of errors, it returns -1 and an error describing
 	// what happened.
 	PidFromContainerID(containerID string) (int, error)
+
+	// GetContainers returns a slice with the information of all the containers.
+	GetContainers() ([]*ContainerData, error)
+
+	// GetContainers returns the information of the container identified by the
+	// provided ID.
+	GetContainer(containerID string) (*ContainerData, error)
 
 	// Close tears down the connection with the container runtime.
 	Close() error
@@ -143,6 +164,63 @@ func (c *CRIClient) PidFromContainerID(containerID string) (int, error) {
 	}
 
 	return parseExtraInfo(res.Info)
+}
+
+func listContainers(c *CRIClient, filter *pb.ContainerFilter) ([]*pb.Container, error) {
+	request := &pb.ListContainersRequest{}
+	if filter != nil {
+		request.Filter = filter
+	}
+
+	res, err := c.client.ListContainers(context.Background(), request)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list containers with request %+v: %w",
+			request, err)
+	}
+
+	return res.GetContainers(), nil
+}
+
+func (c *CRIClient) GetContainers() ([]*ContainerData, error) {
+	containers, err := listContainers(c, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	ret := make([]*ContainerData, len(containers))
+
+	for i, container := range containers {
+		ret[i] = &ContainerData{
+			ID:      container.Id,
+			Name:    strings.TrimPrefix(container.GetMetadata().Name, "/"),
+			Running: container.GetState() == pb.ContainerState_CONTAINER_RUNNING,
+		}
+	}
+
+	return ret, nil
+}
+
+func (c *CRIClient) GetContainer(containerID string) (*ContainerData, error) {
+	containers, err := listContainers(c, &pb.ContainerFilter{
+		Id: containerID,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if len(containers) == 0 {
+		return nil, fmt.Errorf("container %q not found", containerID)
+	}
+	if len(containers) > 1 {
+		log.Warnf("CRIClient: multiple containers (%d) with ID %q. Taking the first one: %+v",
+			len(containers), containerID, containers)
+	}
+
+	return &ContainerData{
+		ID:      containers[0].Id,
+		Name:    strings.TrimPrefix(containers[0].GetMetadata().Name, "/"),
+		Running: containers[0].GetState() == pb.ContainerState_CONTAINER_RUNNING,
+	}, nil
 }
 
 func (c *CRIClient) Close() error {

--- a/pkg/container-utils/runtime-client/interface.go
+++ b/pkg/container-utils/runtime-client/interface.go
@@ -42,20 +42,20 @@ type ContainerRuntimeClient interface {
 // CRIClient implements the ContainerRuntimeClient interface using the CRI
 // plugin interface to communicate with the different container runtimes.
 type CRIClient struct {
-	Name            string
-	RuntimeEndpoint string
-	ConnTimeout     time.Duration
+	Name        string
+	SocketPath  string
+	ConnTimeout time.Duration
 
 	conn   *grpc.ClientConn
 	client pb.RuntimeServiceClient
 }
 
-func NewCRIClient(name, endpoint string, timeout time.Duration) (CRIClient, error) {
+func NewCRIClient(name, socketPath string, timeout time.Duration) (CRIClient, error) {
 	conn, err := grpc.Dial(
-		endpoint,
+		socketPath,
 		grpc.WithInsecure(),
 		grpc.WithDialer(func(addr string, timeout time.Duration) (net.Conn, error) {
-			return net.DialTimeout("unix", endpoint, timeout)
+			return net.DialTimeout("unix", socketPath, timeout)
 		}),
 	)
 	if err != nil {
@@ -63,11 +63,11 @@ func NewCRIClient(name, endpoint string, timeout time.Duration) (CRIClient, erro
 	}
 
 	return CRIClient{
-		Name:            name,
-		RuntimeEndpoint: endpoint,
-		ConnTimeout:     timeout,
-		conn:            conn,
-		client:          pb.NewRuntimeServiceClient(conn),
+		Name:        name,
+		SocketPath:  socketPath,
+		ConnTimeout: timeout,
+		conn:        conn,
+		client:      pb.NewRuntimeServiceClient(conn),
 	}, nil
 }
 

--- a/pkg/gadgettracermanager/k8s/k8s.go
+++ b/pkg/gadgettracermanager/k8s/k8s.go
@@ -60,7 +60,10 @@ func NewK8sClient(nodeName string) (*K8sClient, error) {
 	// Get a runtime client to talk to the container runtime handling pods in
 	// this node. TODO: when to close it?
 	list := strings.SplitN(node.Status.NodeInfo.ContainerRuntimeVersion, "://", 2)
-	runtimeClient, err := containerutils.NewContainerRuntimeClient(list[0])
+	runtimeClient, err := containerutils.NewContainerRuntimeClient(
+		&containerutils.RuntimeConfig{
+			Name: list[0],
+		})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/local-gadget-manager/local-gadget-manager.go
+++ b/pkg/local-gadget-manager/local-gadget-manager.go
@@ -21,6 +21,7 @@ import (
 
 	gadgetv1alpha1 "github.com/kinvolk/inspektor-gadget/pkg/apis/gadget/v1alpha1"
 	containercollection "github.com/kinvolk/inspektor-gadget/pkg/container-collection"
+	containerutils "github.com/kinvolk/inspektor-gadget/pkg/container-utils"
 	gadgetcollection "github.com/kinvolk/inspektor-gadget/pkg/gadget-collection"
 	"github.com/kinvolk/inspektor-gadget/pkg/gadgets"
 	pb "github.com/kinvolk/inspektor-gadget/pkg/gadgettracermanager/api"
@@ -316,7 +317,7 @@ func ensureBPFMount() error {
 	return nil
 }
 
-func NewManager() (*LocalGadgetManager, error) {
+func NewManager(runtimes []*containerutils.RuntimeConfig) (*LocalGadgetManager, error) {
 	l := &LocalGadgetManager{
 		traceFactories: gadgetcollection.TraceFactoriesForLocalGadget(),
 		traceResources: make(map[string]*gadgetv1alpha1.Trace),
@@ -348,7 +349,7 @@ func NewManager() (*LocalGadgetManager, error) {
 		containercollection.WithPubSub(containerEventFuncs...),
 		containercollection.WithCgroupEnrichment(),
 		containercollection.WithLinuxNamespaceEnrichment(),
-		containercollection.WithDockerEnrichment(),
+		containercollection.WithMultipleContainerRuntimesEnrichment(runtimes),
 		containercollection.WithRuncFanotify(),
 	)
 	if err != nil {

--- a/pkg/local-gadget-manager/local-gadget-manager_test.go
+++ b/pkg/local-gadget-manager/local-gadget-manager_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/client"
 
+	containerutils "github.com/kinvolk/inspektor-gadget/pkg/container-utils"
 	dnstypes "github.com/kinvolk/inspektor-gadget/pkg/gadgets/dns/types"
 	eventtypes "github.com/kinvolk/inspektor-gadget/pkg/types"
 )
@@ -43,7 +44,7 @@ func TestBasic(t *testing.T) {
 	if !*rootTest {
 		t.Skip("skipping test requiring root.")
 	}
-	localGadgetManager, err := NewManager()
+	localGadgetManager, err := NewManager(nil)
 	if err != nil {
 		t.Fatalf("Failed to start local gadget manager: %s", err)
 	}
@@ -162,7 +163,7 @@ func TestSeccomp(t *testing.T) {
 	if !*rootTest {
 		t.Skip("skipping test requiring root.")
 	}
-	localGadgetManager, err := NewManager()
+	localGadgetManager, err := NewManager([]*containerutils.RuntimeConfig{{Name: "docker"}})
 	if err != nil {
 		t.Fatalf("Failed to start local gadget manager: %s", err)
 	}
@@ -208,7 +209,7 @@ func TestAuditSeccomp(t *testing.T) {
 	if !*rootTest {
 		t.Skip("skipping test requiring root.")
 	}
-	localGadgetManager, err := NewManager()
+	localGadgetManager, err := NewManager([]*containerutils.RuntimeConfig{{Name: "docker"}})
 	if err != nil {
 		t.Fatalf("Failed to start local gadget manager: %s", err)
 	}
@@ -255,7 +256,7 @@ func TestDNS(t *testing.T) {
 	if !*rootTest {
 		t.Skip("skipping test requiring root.")
 	}
-	localGadgetManager, err := NewManager()
+	localGadgetManager, err := NewManager([]*containerutils.RuntimeConfig{{Name: "docker"}})
 	if err != nil {
 		t.Fatalf("Failed to start local gadget manager: %s", err)
 	}
@@ -366,7 +367,7 @@ func TestCollector(t *testing.T) {
 	if !*rootTest {
 		t.Skip("skipping test requiring root.")
 	}
-	localGadgetManager, err := NewManager()
+	localGadgetManager, err := NewManager([]*containerutils.RuntimeConfig{{Name: "docker"}})
 	if err != nil {
 		t.Fatalf("Failed to start local gadget manager: %s", err)
 	}


### PR DESCRIPTION
# local-gadget: Support CRI-O and Containerd

Currently, `local-gadget` only supports containers managed by Docker regardless they were created by Kubernetes or directly using the Docker CLI. To have such visibility, `local-gadget` communicates directly with the Docker Engine API and not the CRI (Docker-shim). 

This PR extends `local-gadget` to support CRI-O and Containerd CRIs. Notice that using the CRIs, the rogue containers (ie, not managed by Kubernetes) are not visible. It means that the containers created with `ctr` (Containerd CLI) are not yet visible by `local-gadget` (Work for a future PR).

With this PR, the `local-gadget` will try to collect the containers from Docker Engine API, CRI-O and Containerd CRIs by default. But it can be restricted, e.g. `--runtime=docker`. The Unix socket path for each runtime is also configurable:

```
$ ./local-gadget --help
Collection of gadgets for containers

...

Flags:
      --containerd-socketpath string   Containerd CRI Unix socket path (default "/run/containerd/containerd.sock")
      --crio-socketpath string         CRI-O CRI Unix socket path (default "/run/crio/crio.sock")
      --docker-socketpath string       Docker Engine API Unix socket path (default "/run/docker.sock")
  -h, --help                           help for local-gadget
  -r, --runtimes string                Container runtimes to be used separated by comma. Supported values are: docker, containerd, cri-o (default "docker,containerd,cri-o")
  -v, --verbose                        Print debug information
```

## Testing done

- [x] No regression tests with Docker
- [x] Tests with Containerd: Tested on Azure
- [x] Tests with CRI-O
- [x] Tested in a system running Kubernetes with Containerd as runtime and Docker installed: I was able to see the containers created through Kubernetes and the ones created through `docker run ...`.

## TODO in future PRs

- [ ] Support rogue containers (ie, not managed by Kubernetes) managed by Containerd
- [ ] Improve integration tests to test also Containerd and CRI-O