### PR TITLE
Remove local-gadget from the default build target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,10 @@ LDFLAGS := "-X main.version=$(VERSION) \
 
 .DEFAULT_GOAL := build
 .PHONY: build
-build: manifests generate local-gadget kubectl-gadget gadget-container
+build: manifests generate kubectl-gadget gadget-container
+
+.PHONY: all
+all: build local-gadget
 
 # make does not allow implicit rules (with '%') to be phony so let's use
 # the 'phony_explicit' dependency to make implicit rules inherit the phony


### PR DESCRIPTION
The local-gadget target in our Makefile requires having CLang and libbpf-dev installed locally, which are not considered required dependencies for building Inspektor Gadget. The default build target should only include targets that can be built with the listed tools.

This change removes local-gadget from "build", and creates an "all" target that includes local-gadget

## How to use / Testing done

Run `make` and see how it doesn't call CLang outside of docker.
Run `make all` and see how it does (or fails to, if you machine doesn't have CLang and/or libbpf-dev).
