### PR TITLE
Check for fanotify support before selecting it

### DIFF
--- a/gadget-container/gadgettracermanager/main.go
+++ b/gadget-container/gadgettracermanager/main.go
@@ -261,7 +261,7 @@ func main() {
 		})
 
 		if err != nil {
-			log.Fatalf("failed to create server %v", err)
+			log.Fatalf("failed to create Gadget Tracer Manager server: %v", err)
 		}
 
 		pb.RegisterGadgetTracerManagerServer(grpcServer, tracerManager)

--- a/pkg/gadgettracermanager/gadgettracermanager.go
+++ b/pkg/gadgettracermanager/gadgettracermanager.go
@@ -230,6 +230,7 @@ func newServer(conf *Conf) (*GadgetTracerManager, error) {
 		opts = append(opts, containercollection.WithKubernetesEnrichment(g.nodeName))
 	}
 
+	podInformerUsed := false
 	switch conf.HookMode {
 	case "none":
 		// Nothing to do: grpc calls will be enough
@@ -246,10 +247,12 @@ func newServer(conf *Conf) (*GadgetTracerManager, error) {
 		} else {
 			log.Infof("GadgetTracerManager: hook mode: podinformer (auto)")
 			opts = append(opts, containercollection.WithPodInformer(g.nodeName))
+			podInformerUsed = true
 		}
 	case "podinformer":
 		log.Infof("GadgetTracerManager: hook mode: podinformer")
 		opts = append(opts, containercollection.WithPodInformer(g.nodeName))
+		podInformerUsed = true
 	case "fanotify":
 		log.Infof("GadgetTracerManager: hook mode: fanotify")
 		opts = append(opts, containercollection.WithRuncFanotify())
@@ -258,7 +261,7 @@ func newServer(conf *Conf) (*GadgetTracerManager, error) {
 		return nil, fmt.Errorf("invalid hook mode: %s", conf.HookMode)
 	}
 
-	if conf.FallbackPodInformer && conf.HookMode != "podinformer" {
+	if conf.FallbackPodInformer && !podInformerUsed {
 		log.Infof("GadgetTracerManager: enabling fallback podinformer")
 		opts = append(opts, containercollection.WithFallbackPodInformer(g.nodeName))
 	}


### PR DESCRIPTION
When using the hook-mode auto, we were only checking that runc was present, but not that they system had fanotify  capabilities. In systems without `CONFIG_FANOTIFY` enabled, this would cause the Gadget Tracer Manager to fail to start.

This change checks that `fanotify_init` returns successfully before selecting it when in hook mode auto.

It also improves the error message when starting the tracer manager fails, and avoids adding the fallback podinformer when the auto hook mode selected podinformer, thus avoiding unnecessary warning messages.

## How to use / Testing done

I deployed the modified container to a minikube instance using the kvm driver (which was failing to start before, as explained in #612), and verified that it correctly selected the podinformer and -after fixing the fallback selection- didn't log warnings.

I then deployed against a minikube instance using the docker driver, and hook mode auto, and in this case it selected fanotify with podinformer as the fallback.

Fixes #612 