### PR TITLE
SNI: Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Available Commands:
   oomkill      Trace when OOM killer is triggered and kills a process
   open         Trace open system calls
   signal       Trace signals received by processes
-  sni          Trace Server Name Indicator requests
+  sni          Trace Server Name Indication (SNI) from TLS requests
   tcp          Trace tcp connect, accept and close
   tcpconnect   Trace connect system calls
 

--- a/cmd/kubectl-gadget/trace/sni.go
+++ b/cmd/kubectl-gadget/trace/sni.go
@@ -37,7 +37,7 @@ var colSnisnoopLens = map[string]int{
 
 var snisnoopCmd = &cobra.Command{
 	Use:   "sni",
-	Short: "Trace Server Name Indicator requests",
+	Short: "Trace Server Name Indication (SNI) from TLS requests",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		transform := snisnoopTransformLine
 


### PR DESCRIPTION
It's "Server Name Indication" instead of "Server Name Indicator"

