### PR TITLE
cmd/undeploy: Remove old Inspektor Gadgets components too

### DIFF
--- a/cmd/kubectl-gadget/undeploy.go
+++ b/cmd/kubectl-gadget/undeploy.go
@@ -164,6 +164,26 @@ again:
 		)
 	}
 
+	// Let's try to remove components of IG versions before v0.5.0,
+	// just in case somebody has a newer CLI but is trying to remove
+	// an old version of Inspektor Gadget from the cluster. Given
+	// that this is a best effort work, we don't track any error.
+
+	// kube-system/gadget daemon set
+	k8sClient.AppsV1().DaemonSets("kube-system").Delete(
+		context.TODO(), "gadget", metav1.DeleteOptions{},
+	)
+
+	// gadget cluster role binding
+	k8sClient.RbacV1().ClusterRoleBindings().Delete(
+		context.TODO(), "gadget", metav1.DeleteOptions{},
+	)
+
+	// kube-system/gadget service account
+	k8sClient.CoreV1().ServiceAccounts("kube-system").Delete(
+		context.TODO(), "gadget", metav1.DeleteOptions{},
+	)
+
 	// 5. gadget namespace (it also removes daemonset, serviceaccount, rolebinding
 	// and role since they live in this namespace).
 	var list *v1.NamespaceList


### PR DESCRIPTION
It could happen that a user deploys Inspektor Gadget v0.5.0 without
first removing a previous version. This condition creates a lot of
problems because there will be two gadget daemons running (kube-system
and gadget namespaces), hence two traces controllers that will race
each other creating failures some times.

If the user has a kubectl-gadget binary >= v0.5.0 they won't be able
to remove the old Inspektor Gadget from the cluster. This commit extends
the current undeploy command to remove also components from old
versions.

It's a real problem and already hit one of our users -> https://kubernetes.slack.com/archives/CSYL75LF6/p1647025053942309?thread_ts=1644399681.035839&cid=CSYL75LF6. 