### PR TITLE
pkg/gadget/-*collector: Mark trace as completed when no container matches.

### DIFF
--- a/pkg/gadgets/process-collector/gadget.go
+++ b/pkg/gadgets/process-collector/gadget.go
@@ -73,6 +73,7 @@ func (t *Trace) Collect(trace *gadgetv1alpha1.Trace) {
 
 	if len(events) == 0 {
 		trace.Status.OperationWarning = "No container matches the requested filter"
+		trace.Status.State = "Completed"
 		return
 	}
 

--- a/pkg/gadgets/socket-collector/gadget.go
+++ b/pkg/gadgets/socket-collector/gadget.go
@@ -77,6 +77,7 @@ func (t *Trace) Collect(trace *gadgetv1alpha1.Trace) {
 	filteredContainers := t.resolver.GetContainersBySelector(selector)
 	if len(filteredContainers) == 0 {
 		trace.Status.OperationWarning = "No container matches the requested filter"
+		trace.Status.State = "Completed"
 		return
 	}
 


### PR DESCRIPTION
There was a problem in the CLI where the collect operation would timeout.
Particularly, if there was, e.g., 3 nodes but target namespace only has one pod
on a given node.
Then the traces created for the nodes without trace would make the CLI code
timeout because they would never reach Completed state.