### PR TITLE
Retitle usage guides in the docs (plus some minor updates)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Inspektor Gadget is a collection of tools (or gadgets) to debug and inspect Kube
 
 Inspektor Gadget tools are known as gadgets. You can deploy one, two or many gadgets.
 
-Exploring the following documentation will best help you learn which tools can help you in your investigations.
+Explore the following documentation to find out which tools can help you in your investigations.
 
 - `advise`:
 	- [`network-policy`](docs/guides/advise/network-policy.md)

--- a/docs/gadgets/_index.md
+++ b/docs/gadgets/_index.md
@@ -1,6 +1,6 @@
 ---
-title: Gadget specs
+title: CR Usage Reference
 description: >
-  Reference documentation for the existing gadgets.
+  Syntax reference for using the Trace custom resource with each gadget.
 weight: 30
 ---

--- a/docs/guides/_index.md
+++ b/docs/guides/_index.md
@@ -1,8 +1,8 @@
 ---
 title: Guides
 description: >
-  Quick guides showing the capability and use cases of gadgets.
+  This section provides an overview of the gadgets included in Inspektor
+  Gadget and guidance on how to use each.
 weight: 30
 ---
 
-This section provides an overview of the gadgets included in Inspektor Gadget and guidance on how to use each.

--- a/docs/guides/advise/network-policy.md
+++ b/docs/guides/advise/network-policy.md
@@ -1,5 +1,5 @@
 ---
-title: 'The "network-policy" gadget'
+title: 'Using `advise network-policy`'
 weight: 10
 ---
 

--- a/docs/guides/advise/seccomp-profile.md
+++ b/docs/guides/advise/seccomp-profile.md
@@ -1,5 +1,5 @@
 ---
-title: 'The "seccomp" gadget'
+title: 'Using `advise seccomp-profile`'
 weight: 10
 ---
 

--- a/docs/guides/audit/seccomp.md
+++ b/docs/guides/audit/seccomp.md
@@ -1,5 +1,5 @@
 ---
-title: 'The "audit seccomp" gadget'
+title: 'Using `audit seccomp`'
 weight: 10
 ---
 

--- a/docs/guides/profile/block-io.md
+++ b/docs/guides/profile/block-io.md
@@ -1,5 +1,5 @@
 ---
-title: 'The "biolatency" gadget'
+title: 'Using `profile block-io`'
 weight: 10
 ---
 

--- a/docs/guides/profile/cpu.md
+++ b/docs/guides/profile/cpu.md
@@ -1,5 +1,5 @@
 ---
-title: 'The "profile" gadget'
+title: 'Using `profile cpu`'
 weight: 10
 ---
 

--- a/docs/guides/snapshot/process.md
+++ b/docs/guides/snapshot/process.md
@@ -1,5 +1,5 @@
 ---
-title: 'The "process-collector" gadget'
+title: 'Using `snapshot process`'
 weight: 10
 ---
 

--- a/docs/guides/snapshot/socket.md
+++ b/docs/guides/snapshot/socket.md
@@ -1,5 +1,5 @@
 ---
-title: 'The "socket-collector" gadget'
+title: 'Using `snapshot socket`'
 weight: 10
 ---
 

--- a/docs/guides/top/block-io.md
+++ b/docs/guides/top/block-io.md
@@ -1,5 +1,5 @@
 ---
-title: 'The "top block-io" gadget'
+title: 'Using `top block-io`'
 weight: 10
 ---
 

--- a/docs/guides/top/file.md
+++ b/docs/guides/top/file.md
@@ -1,5 +1,5 @@
 ---
-title: 'The "top file" gadget'
+title: 'Using `top file`'
 weight: 10
 ---
 

--- a/docs/guides/top/tcp.md
+++ b/docs/guides/top/tcp.md
@@ -1,5 +1,5 @@
 ---
-title: 'The "top tcp" gadget'
+title: 'Using `top tcp`'
 weight: 10
 ---
 

--- a/docs/guides/trace/bind.md
+++ b/docs/guides/trace/bind.md
@@ -1,5 +1,5 @@
 ---
-title: 'The "trace bind" gadget'
+title: 'Using `trace bind`'
 weight: 10
 ---
 

--- a/docs/guides/trace/capabilities.md
+++ b/docs/guides/trace/capabilities.md
@@ -1,5 +1,5 @@
 ---
-title: 'The "capabilities" gadget'
+title: 'Using `trace capabilities`'
 weight: 10
 ---
 

--- a/docs/guides/trace/dns.md
+++ b/docs/guides/trace/dns.md
@@ -1,5 +1,5 @@
 ---
-title: 'The "dns" gadget'
+title: 'Using `trace dns`'
 weight: 10
 ---
 

--- a/docs/guides/trace/exec.md
+++ b/docs/guides/trace/exec.md
@@ -1,5 +1,5 @@
 ---
-title: 'The "trace exec" gadget'
+title: 'Using `trace exec`'
 weight: 10
 ---
 

--- a/docs/guides/trace/fsslower.md
+++ b/docs/guides/trace/fsslower.md
@@ -1,5 +1,5 @@
 ---
-title: 'The "fsslower" gadget'
+title: 'Using `trace fsslower`'
 weight: 10
 ---
 

--- a/docs/guides/trace/mount.md
+++ b/docs/guides/trace/mount.md
@@ -1,5 +1,5 @@
 ---
-title: 'The "trace mount" gadget'
+title: 'Using `trace mount`'
 weight: 10
 ---
 

--- a/docs/guides/trace/oomkill.md
+++ b/docs/guides/trace/oomkill.md
@@ -1,5 +1,5 @@
 ---
-title: 'The "oomkill" gadget'
+title: 'Using `trace oomkill`'
 weight: 10
 ---
 

--- a/docs/guides/trace/open.md
+++ b/docs/guides/trace/open.md
@@ -1,5 +1,5 @@
 ---
-title: 'The "trace open" gadget'
+title: 'Using `trace open`'
 weight: 10
 ---
 

--- a/docs/guides/trace/signal.md
+++ b/docs/guides/trace/signal.md
@@ -1,5 +1,5 @@
 ---
-title: 'The "trace signal" gadget'
+title: 'Using `trace signal`'
 weight: 10
 ---
 

--- a/docs/guides/trace/tcp.md
+++ b/docs/guides/trace/tcp.md
@@ -1,5 +1,5 @@
 ---
-title: 'The "trace tcp" gadget'
+title: 'Using `trace tcp`'
 weight: 10
 ---
 

--- a/docs/guides/trace/tcpconnect.md
+++ b/docs/guides/trace/tcpconnect.md
@@ -1,5 +1,5 @@
 ---
-title: 'The "tcpconnect" gadget'
+title: 'Using `trace tcpconnect`'
 weight: 10
 ---
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -2,7 +2,7 @@
 title: Installation
 weight: 10
 description: >
-  How to install.
+  How to install Inspektor Gadget
 ---
 
 <!-- toc -->
@@ -18,7 +18,7 @@ description: >
     + [Minikube](#minikube)
 <!-- /toc -->
 
-Inspektor Gadget is composed by a `kubectl` plugin executed in the user's
+Inspektor Gadget is composed of a `kubectl` plugin executed in the user's
 system and a DaemonSet deployed in the cluster.
 
 ## Installing kubectl gadget
@@ -49,7 +49,10 @@ $ curl -sL https://github.com/kinvolk/inspektor-gadget/releases/download/v0.2.0/
 $ kubectl gadget version
 ```
 
-### Compile from the sources
+### Compile from source
+
+To build Inspektor Gadget from source, you'll need to have a Golang version
+1.16 or higher installed.
 
 ```bash
 $ git clone https://github.com/kinvolk/inspektor-gadget.git

--- a/docs/local-gadget.md
+++ b/docs/local-gadget.md
@@ -5,7 +5,7 @@ description: >
   How to use the local-gadget tool.
 ---
 
-Inspektor Gadget can also be used without Kubernetes to trace containers with the local-gadget tool.
+Inspektor Gadget can also be used without Kubernetes to trace containers with the `local-gadget` tool.
 
 ## Examples
 


### PR DESCRIPTION
# Retitle usage guides

Some of our usage guides were still using the old CLI names, and even those that weren't were using a weird title format (The "audit seccomp" gadget).  This change updates all titles to the new names, and changes the title template, e.g. Using `audit seccomp`

Also, it moves the "Gadget specs" title to "CR Usage Reference", as those specs are not about how to use the gadget, but rather what the custom resources take as parameters and so on.

There are also some other minor fixes that I ran across when reviewing the docs.