### PR TITLE
Remove formatting from titles

### DIFF
--- a/docs/guides/advise/network-policy.md
+++ b/docs/guides/advise/network-policy.md
@@ -1,5 +1,5 @@
 ---
-title: 'Using `advise network-policy`'
+title: 'Using advise network-policy'
 weight: 10
 ---
 

--- a/docs/guides/advise/seccomp-profile.md
+++ b/docs/guides/advise/seccomp-profile.md
@@ -1,5 +1,5 @@
 ---
-title: 'Using `advise seccomp-profile`'
+title: 'Using advise seccomp-profile'
 weight: 10
 ---
 

--- a/docs/guides/audit/seccomp.md
+++ b/docs/guides/audit/seccomp.md
@@ -1,5 +1,5 @@
 ---
-title: 'Using `audit seccomp`'
+title: 'Using audit seccomp'
 weight: 10
 ---
 

--- a/docs/guides/profile/block-io.md
+++ b/docs/guides/profile/block-io.md
@@ -1,5 +1,5 @@
----
-title: 'Using `profile block-io`'
+--
+title: 'Using profile block-io'
 weight: 10
 ---
 

--- a/docs/guides/profile/cpu.md
+++ b/docs/guides/profile/cpu.md
@@ -1,5 +1,5 @@
 ---
-title: 'Using `profile cpu`'
+title: 'Using profile cpu'
 weight: 10
 ---
 

--- a/docs/guides/snapshot/process.md
+++ b/docs/guides/snapshot/process.md
@@ -1,5 +1,5 @@
 ---
-title: 'Using `snapshot process`'
+title: 'Using snapshot process'
 weight: 10
 ---
 

--- a/docs/guides/snapshot/socket.md
+++ b/docs/guides/snapshot/socket.md
@@ -1,5 +1,5 @@
 ---
-title: 'Using `snapshot socket`'
+title: 'Using snapshot socket'
 weight: 10
 ---
 

--- a/docs/guides/top/block-io.md
+++ b/docs/guides/top/block-io.md
@@ -1,5 +1,5 @@
 ---
-title: 'Using `top block-io`'
+title: 'Using top block-io'
 weight: 10
 ---
 

--- a/docs/guides/top/file.md
+++ b/docs/guides/top/file.md
@@ -1,5 +1,5 @@
 ---
-title: 'Using `top file`'
+title: 'Using top file'
 weight: 10
 ---
 

--- a/docs/guides/top/tcp.md
+++ b/docs/guides/top/tcp.md
@@ -1,5 +1,5 @@
 ---
-title: 'Using `top tcp`'
+title: 'Using top tcp'
 weight: 10
 ---
 

--- a/docs/guides/trace/bind.md
+++ b/docs/guides/trace/bind.md
@@ -1,5 +1,5 @@
 ---
-title: 'Using `trace bind`'
+title: 'Using trace bind'
 weight: 10
 ---
 

--- a/docs/guides/trace/capabilities.md
+++ b/docs/guides/trace/capabilities.md
@@ -1,5 +1,5 @@
 ---
-title: 'Using `trace capabilities`'
+title: 'Using trace capabilities'
 weight: 10
 ---
 

--- a/docs/guides/trace/dns.md
+++ b/docs/guides/trace/dns.md
@@ -1,5 +1,5 @@
 ---
-title: 'Using `trace dns`'
+title: 'Using trace dns'
 weight: 10
 ---
 

--- a/docs/guides/trace/exec.md
+++ b/docs/guides/trace/exec.md
@@ -1,5 +1,5 @@
 ---
-title: 'Using `trace exec`'
+title: 'Using trace exec'
 weight: 10
 ---
 

--- a/docs/guides/trace/fsslower.md
+++ b/docs/guides/trace/fsslower.md
@@ -1,5 +1,5 @@
 ---
-title: 'Using `trace fsslower`'
+title: 'Using trace fsslower'
 weight: 10
 ---
 

--- a/docs/guides/trace/mount.md
+++ b/docs/guides/trace/mount.md
@@ -1,5 +1,5 @@
 ---
-title: 'Using `trace mount`'
+title: 'Using trace mount'
 weight: 10
 ---
 

--- a/docs/guides/trace/oomkill.md
+++ b/docs/guides/trace/oomkill.md
@@ -1,5 +1,5 @@
 ---
-title: 'Using `trace oomkill`'
+title: 'Using trace oomkill'
 weight: 10
 ---
 

--- a/docs/guides/trace/open.md
+++ b/docs/guides/trace/open.md
@@ -1,5 +1,5 @@
 ---
-title: 'Using `trace open`'
+title: 'Using trace open'
 weight: 10
 ---
 

--- a/docs/guides/trace/signal.md
+++ b/docs/guides/trace/signal.md
@@ -1,5 +1,5 @@
 ---
-title: 'Using `trace signal`'
+title: 'Using trace signal'
 weight: 10
 ---
 

--- a/docs/guides/trace/tcp.md
+++ b/docs/guides/trace/tcp.md
@@ -1,5 +1,5 @@
 ---
-title: 'Using `trace tcp`'
+title: 'Using trace tcp'
 weight: 10
 ---
 

--- a/docs/guides/trace/tcpconnect.md
+++ b/docs/guides/trace/tcpconnect.md
@@ -1,5 +1,5 @@
 ---
-title: 'Using `trace tcpconnect`'
+title: 'Using trace tcpconnect'
 weight: 10
 ---
 

--- a/docs/guides/traceloop.md
+++ b/docs/guides/traceloop.md
@@ -1,5 +1,5 @@
 ---
-title: 'The "traceloop" gadget'
+title: 'Using traceloop'
 weight: 10
 ---
 


### PR DESCRIPTION
The documentation rendered that we're using doesn't support formatting in the titles of our docs. :(
