### PR TITLE
Fix bad json event and provide more information when unmarshal fails

### DIFF
--- a/cmd/kubectl-gadget/audit/seccomp.go
+++ b/cmd/kubectl-gadget/audit/seccomp.go
@@ -68,7 +68,7 @@ func transformAuditSeccompLine(line string) string {
 	var e types.Event
 
 	if err := json.Unmarshal([]byte(line), &e); err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %s", utils.WrapInErrUnmarshalOutput(err))
+		fmt.Fprintf(os.Stderr, "Error: %s", utils.WrapInErrUnmarshalOutput(err, line))
 		return ""
 	}
 

--- a/cmd/kubectl-gadget/top/block-io.go
+++ b/cmd/kubectl-gadget/top/block-io.go
@@ -109,7 +109,7 @@ func blockIOCallback(line string, node string) {
 	var event types.Event
 
 	if err := json.Unmarshal([]byte(line), &event); err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %s", utils.WrapInErrUnmarshalOutput(err))
+		fmt.Fprintf(os.Stderr, "Error: %s", utils.WrapInErrUnmarshalOutput(err, line))
 		return
 	}
 

--- a/cmd/kubectl-gadget/top/file.go
+++ b/cmd/kubectl-gadget/top/file.go
@@ -118,7 +118,7 @@ func fileCallback(line string, node string) {
 	var event types.Event
 
 	if err := json.Unmarshal([]byte(line), &event); err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %s", utils.WrapInErrUnmarshalOutput(err))
+		fmt.Fprintf(os.Stderr, "Error: %s", utils.WrapInErrUnmarshalOutput(err, line))
 		return
 	}
 

--- a/cmd/kubectl-gadget/top/tcp.go
+++ b/cmd/kubectl-gadget/top/tcp.go
@@ -139,7 +139,7 @@ func tcpCallback(line string, node string) {
 	var event types.Event
 
 	if err := json.Unmarshal([]byte(line), &event); err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %s", utils.WrapInErrUnmarshalOutput(err))
+		fmt.Fprintf(os.Stderr, "Error: %s", utils.WrapInErrUnmarshalOutput(err, line))
 		return
 	}
 

--- a/cmd/kubectl-gadget/trace/bind.go
+++ b/cmd/kubectl-gadget/trace/bind.go
@@ -108,7 +108,7 @@ func bindsnoopTransformLine(line string) string {
 	var e types.Event
 
 	if err := json.Unmarshal([]byte(line), &e); err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %s", utils.WrapInErrUnmarshalOutput(err))
+		fmt.Fprintf(os.Stderr, "Error: %s", utils.WrapInErrUnmarshalOutput(err, line))
 		return ""
 	}
 

--- a/cmd/kubectl-gadget/trace/capabilities.go
+++ b/cmd/kubectl-gadget/trace/capabilities.go
@@ -69,7 +69,7 @@ func capabilitiesTransformLine(line string) string {
 	var e types.Event
 
 	if err := json.Unmarshal([]byte(line), &e); err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %s", utils.WrapInErrUnmarshalOutput(err))
+		fmt.Fprintf(os.Stderr, "Error: %s", utils.WrapInErrUnmarshalOutput(err, line))
 		return ""
 	}
 

--- a/cmd/kubectl-gadget/trace/dns.go
+++ b/cmd/kubectl-gadget/trace/dns.go
@@ -91,7 +91,7 @@ func init() {
 func transformLine(line string) string {
 	event := &dnstypes.Event{}
 	if err := json.Unmarshal([]byte(line), event); err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %s", utils.WrapInErrUnmarshalOutput(err))
+		fmt.Fprintf(os.Stderr, "Error: %s", utils.WrapInErrUnmarshalOutput(err, line))
 		return ""
 	}
 

--- a/cmd/kubectl-gadget/trace/exec.go
+++ b/cmd/kubectl-gadget/trace/exec.go
@@ -69,7 +69,7 @@ func execsnoopTransformLine(line string) string {
 	var e types.Event
 
 	if err := json.Unmarshal([]byte(line), &e); err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %s", utils.WrapInErrUnmarshalOutput(err))
+		fmt.Fprintf(os.Stderr, "Error: %s", utils.WrapInErrUnmarshalOutput(err, line))
 		return ""
 	}
 

--- a/cmd/kubectl-gadget/trace/fsslower.go
+++ b/cmd/kubectl-gadget/trace/fsslower.go
@@ -111,7 +111,7 @@ func fsslowerTransformLine(line string) string {
 	var e types.Event
 
 	if err := json.Unmarshal([]byte(line), &e); err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %s", utils.WrapInErrUnmarshalOutput(err))
+		fmt.Fprintf(os.Stderr, "Error: %s", utils.WrapInErrUnmarshalOutput(err, line))
 		return ""
 	}
 

--- a/cmd/kubectl-gadget/trace/mount.go
+++ b/cmd/kubectl-gadget/trace/mount.go
@@ -83,7 +83,7 @@ func mountsnoopTransformLine(line string) string {
 	var e types.Event
 
 	if err := json.Unmarshal([]byte(line), &e); err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %s", utils.WrapInErrUnmarshalOutput(err))
+		fmt.Fprintf(os.Stderr, "Error: %s", utils.WrapInErrUnmarshalOutput(err, line))
 		return ""
 	}
 

--- a/cmd/kubectl-gadget/trace/oomkill.go
+++ b/cmd/kubectl-gadget/trace/oomkill.go
@@ -69,7 +69,7 @@ func oomkillTransformLine(line string) string {
 	var e types.Event
 
 	if err := json.Unmarshal([]byte(line), &e); err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %s", utils.WrapInErrUnmarshalOutput(err))
+		fmt.Fprintf(os.Stderr, "Error: %s", utils.WrapInErrUnmarshalOutput(err, line))
 		return ""
 	}
 

--- a/cmd/kubectl-gadget/trace/open.go
+++ b/cmd/kubectl-gadget/trace/open.go
@@ -69,7 +69,7 @@ func opensnoopTransformLine(line string) string {
 	var e types.Event
 
 	if err := json.Unmarshal([]byte(line), &e); err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %s", utils.WrapInErrUnmarshalOutput(err))
+		fmt.Fprintf(os.Stderr, "Error: %s", utils.WrapInErrUnmarshalOutput(err, line))
 		return ""
 	}
 

--- a/cmd/kubectl-gadget/trace/signal.go
+++ b/cmd/kubectl-gadget/trace/signal.go
@@ -101,7 +101,7 @@ func sigsnoopTransformLine(line string) string {
 	var e types.Event
 
 	if err := json.Unmarshal([]byte(line), &e); err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %s", utils.WrapInErrUnmarshalOutput(err))
+		fmt.Fprintf(os.Stderr, "Error: %s", utils.WrapInErrUnmarshalOutput(err, line))
 		return ""
 	}
 

--- a/cmd/kubectl-gadget/trace/sni.go
+++ b/cmd/kubectl-gadget/trace/sni.go
@@ -86,7 +86,7 @@ func init() {
 func snisnoopTransformLine(line string) string {
 	event := &snitypes.Event{}
 	if err := json.Unmarshal([]byte(line), event); err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %s", utils.WrapInErrUnmarshalOutput(err))
+		fmt.Fprintf(os.Stderr, "Error: %s", utils.WrapInErrUnmarshalOutput(err, line))
 	}
 
 	podMsgSuffix := ""

--- a/cmd/kubectl-gadget/trace/tcp.go
+++ b/cmd/kubectl-gadget/trace/tcp.go
@@ -84,7 +84,7 @@ func tcptracerTransformLine(line string) string {
 	var e types.Event
 
 	if err := json.Unmarshal([]byte(line), &e); err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %s", utils.WrapInErrUnmarshalOutput(err))
+		fmt.Fprintf(os.Stderr, "Error: %s", utils.WrapInErrUnmarshalOutput(err, line))
 		return ""
 	}
 

--- a/cmd/kubectl-gadget/trace/tcpconnect.go
+++ b/cmd/kubectl-gadget/trace/tcpconnect.go
@@ -69,7 +69,7 @@ func tcpconnectTransformLine(line string) string {
 	var e types.Event
 
 	if err := json.Unmarshal([]byte(line), &e); err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %s", utils.WrapInErrUnmarshalOutput(err))
+		fmt.Fprintf(os.Stderr, "Error: %s", utils.WrapInErrUnmarshalOutput(err, line))
 		return ""
 	}
 

--- a/cmd/kubectl-gadget/utils/errors.go
+++ b/cmd/kubectl-gadget/utils/errors.go
@@ -83,8 +83,8 @@ func WrapInErrInvalidArg(arg string, err error) error {
 
 // JSON parsing
 
-func WrapInErrUnmarshalOutput(err error) error {
-	return fmt.Errorf("failed to unmarshal output: %w", err)
+func WrapInErrUnmarshalOutput(err error, output string) error {
+	return fmt.Errorf("failed to unmarshal output: %w\n%s", err, output)
 }
 
 func WrapInErrMarshalOutput(err error) error {

--- a/cmd/kubectl-gadget/utils/table.go
+++ b/cmd/kubectl-gadget/utils/table.go
@@ -99,7 +99,7 @@ func (t *TableFormater) GetTransformFunc() func(string) string {
 
 		err := json.Unmarshal([]byte(line), &event)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error: %s", WrapInErrUnmarshalOutput(err))
+			fmt.Fprintf(os.Stderr, "Error: %s", WrapInErrUnmarshalOutput(err, line))
 			return ""
 		}
 


### PR DESCRIPTION
- Fix bad json sent to client in gadget tracer manager
- Add extra information to WrapInErrUnmarshalOutput() on the client 
