### PR TITLE
Use hook-mode=auto when deploying to minikube

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -166,7 +166,7 @@ minikube-install: gadget-container kubectl-gadget
 	docker save $(CONTAINER_REPO):$(IMAGE_TAG) $(PV) | (eval $(shell $(MINIKUBE) -p minikube docker-env | grep =) && docker load)
 	# Remove all resources created by Inspektor Gadget.
 	./kubectl-gadget undeploy || true
-	./kubectl-gadget deploy --hook-mode=fanotify \
+	./kubectl-gadget deploy --hook-mode=auto \
 		--image-pull-policy=Never | \
 		sed 's/initialDelaySeconds: 10/initialDelaySeconds: '$(LIVENESS_PROBE_INITIAL_DELAY_SECONDS)'/g' | \
 		kubectl apply -f -


### PR DESCRIPTION
fanotify is already used if available, there's no reason why this should
be forced. Putting it in auto allows this rule to be used on
minikube installations that don't support fanotify (like the one used in
the cloud native bpf workshop)
