### PR TITLE
Review some commands short descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Available Commands:
   help        Help about any command
   profile     Profile different subsystems
   snapshot    Take a snapshot of a subsystem and print it
-  top         Gather, sort and print events according to a given criteria
+  top         Gather, sort and periodically report events according to a given criteria
   trace       Trace and print system events
   traceloop   Get strace-like logs of a pod from the past
   undeploy    Undeploy Inspektor Gadget from cluster
@@ -106,7 +106,7 @@ Usage:
   kubectl-gadget audit [command]
 
 Available Commands:
-  seccomp     Trace syscalls that seccomp sent to the audit log
+  seccomp     Audit syscalls according to the seccomp profile
 
 ...
 $ kubectl gadget profile --help
@@ -132,15 +132,15 @@ Available Commands:
 
 ...
 $ kubectl gadget top --help
-Gather, sort and print events according to a given criteria
+Gather, sort and periodically report events according to a given criteria
 
 Usage:
   kubectl-gadget top [command]
 
 Available Commands:
-  block-io    Trace block devices I/O
-  file        Trace reads and writes by file
-  tcp         Trace TCP connection
+  block-io    Periodically report block device I/O activity
+  file        Periodically report read/write activity by file
+  tcp         Periodically report TCP activity
 
 ...
 $ kubectl gadget trace --help

--- a/cmd/kubectl-gadget/audit/seccomp.go
+++ b/cmd/kubectl-gadget/audit/seccomp.go
@@ -29,7 +29,7 @@ import (
 
 var auditSeccompCmd = &cobra.Command{
 	Use:   "seccomp",
-	Short: "Trace syscalls that seccomp sent to the audit log",
+	Short: "Audit syscalls according to the seccomp profile",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// print header
 		switch params.OutputMode {

--- a/cmd/kubectl-gadget/top/block-io.go
+++ b/cmd/kubectl-gadget/top/block-io.go
@@ -36,7 +36,7 @@ var blockIOSortBy types.SortBy
 
 var blockIOCmd = &cobra.Command{
 	Use:   fmt.Sprintf("block-io [interval=%d]", types.IntervalDefault),
-	Short: "Trace block devices I/O",
+	Short: "Periodically report block device I/O activity",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var err error
 

--- a/cmd/kubectl-gadget/top/file.go
+++ b/cmd/kubectl-gadget/top/file.go
@@ -39,7 +39,7 @@ var (
 
 var fileCmd = &cobra.Command{
 	Use:   "file [interval]",
-	Short: "Trace reads and writes by file",
+	Short: "Periodically report read/write activity by file",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var err error
 

--- a/cmd/kubectl-gadget/top/tcp.go
+++ b/cmd/kubectl-gadget/top/tcp.go
@@ -41,7 +41,7 @@ var (
 
 var tcpCmd = &cobra.Command{
 	Use:   fmt.Sprintf("tcp [interval=%d]", types.IntervalDefault),
-	Short: "Trace TCP connection",
+	Short: "Periodically report TCP activity",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var err error
 

--- a/cmd/kubectl-gadget/top/top.go
+++ b/cmd/kubectl-gadget/top/top.go
@@ -35,7 +35,7 @@ var (
 
 var TopCmd = &cobra.Command{
 	Use:   "top",
-	Short: "Gather, sort and print events according to a given criteria",
+	Short: "Gather, sort and periodically report events according to a given criteria",
 }
 
 func addTopCommand(command *cobra.Command, defaultMaxRows int, sortBySlice []string) {


### PR DESCRIPTION
Commands from a given category should have similar verbiage, matching
what they are doing and not what other categories do. i.e. the commands
in `top` should say that they periodically print their data, and `audit`
should say that it audits the given subsystem.