### PR TITLE
Fix breaking typo

### DIFF
--- a/docs/guides/profile/block-io.md
+++ b/docs/guides/profile/block-io.md
@@ -1,4 +1,4 @@
---
+---
 title: 'Using profile block-io'
 weight: 10
 ---


### PR DESCRIPTION
My previous change somehow had removed one hyphen from the file format,
causing the doc renderer to choke.