### PR TITLE
Add general usage page, improve guides navigation and content

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,8 +116,8 @@ Usage:
   kubectl-gadget profile [command]
 
 Available Commands:
-  block-io    Generate a histogram with the distribution of block device I/O latency
-  cpu         Profile CPU usage by sampling stack traces
+  block-io    Analyze block I/O performance through a latency distribution
+  cpu         Analyze CPU performance by sampling stack traces
 
 ...
 $ kubectl gadget snapshot --help
@@ -128,7 +128,7 @@ Usage:
 
 Available Commands:
   process     Gather information about running processes
-  socket      Gather information about network sockets
+  socket      Gather information about TCP and UDP sockets
 
 ...
 $ kubectl gadget top --help

--- a/cmd/kubectl-gadget/profile/block-io.go
+++ b/cmd/kubectl-gadget/profile/block-io.go
@@ -34,7 +34,7 @@ var biolatencyTraceConfig = &utils.TraceConfig{
 
 var biolatencyCmd = &cobra.Command{
 	Use:   "block-io",
-	Short: "Generate a histogram with the distribution of block device I/O latency",
+	Short: "Analyze block I/O performance through a latency distribution",
 }
 
 var biolatencyStartCmd = &cobra.Command{

--- a/cmd/kubectl-gadget/profile/cpu.go
+++ b/cmd/kubectl-gadget/profile/cpu.go
@@ -27,7 +27,7 @@ var (
 
 var profileCmd = &cobra.Command{
 	Use:   "cpu",
-	Short: "Profile CPU usage by sampling stack traces",
+	Short: "Analyze CPU performance by sampling stack traces",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		specificFlag := "-f -d "
 

--- a/cmd/kubectl-gadget/snapshot/socket.go
+++ b/cmd/kubectl-gadget/snapshot/socket.go
@@ -36,7 +36,7 @@ var (
 
 var socketCollectorCmd = &cobra.Command{
 	Use:   "socket",
-	Short: "Gather information about network sockets",
+	Short: "Gather information about TCP and UDP sockets",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		callback := func(results []gadgetv1alpha1.Trace) error {
 			allSockets := []socketcollectortypes.Event{}

--- a/docs/guides/advise/network-policy.md
+++ b/docs/guides/advise/network-policy.md
@@ -5,7 +5,7 @@ description: >
   Generate network policies based on recorded network activity.
 ---
 
-network-policy monitors the network activity in the specified namespaces and
+The network-policy advisor monitors the network activity in the specified namespaces and
 records the list of new TCP connections in a file. This file can then be used to
 generate Kubernetes network policies.
 

--- a/docs/guides/advise/network-policy.md
+++ b/docs/guides/advise/network-policy.md
@@ -1,6 +1,8 @@
 ---
 title: 'Using advise network-policy'
-weight: 10
+weight: 20
+description: >
+  Generate network policies based on recorded network activity.
 ---
 
 network-policy monitors the network activity in the specified namespaces and

--- a/docs/guides/advise/seccomp-profile.md
+++ b/docs/guides/advise/seccomp-profile.md
@@ -1,6 +1,8 @@
 ---
 title: 'Using advise seccomp-profile'
-weight: 10
+weight: 20
+description: >
+  Generate seccomp profiles based on recorded syscalls activity.
 ---
 
 The Seccomp Policy Advisor gadget records syscalls that are issued in a

--- a/docs/guides/advise/seccomp-profile.md
+++ b/docs/guides/advise/seccomp-profile.md
@@ -5,9 +5,9 @@ description: >
   Generate seccomp profiles based on recorded syscalls activity.
 ---
 
-The Seccomp Policy Advisor gadget records syscalls that are issued in a
+The seccomp profile advisor gadget records syscalls that are issued in a
 specified pod, and then uses this information to generate the corresponding
-seccomp policy. It can integrate with the [Kubernetes Security Profile
+seccomp profile. It can integrate with the [Kubernetes Security Profile
 Operator](https://github.com/kubernetes-sigs/security-profiles-operator),
 directly generating the necessary `seccompprofile` resource.
 
@@ -34,7 +34,10 @@ $ kubectl gadget advise seccomp-profile start -n seccomp-demo -p hello-python
 jMzhur2dQjZJxDCI
 ```
 
-After that, we need to interact with the workload, to get it to generate
+The string we receive is the identifier that we will use to refer to the
+running operation when we want to stop it.
+
+While the advisor is running, we need to interact with the workload, to get it to generate
 system calls. In our example, it's a simple webservice, and we can interact
 with it by forwarding the service port and then querying the service
 
@@ -53,7 +56,8 @@ $ kill %1
 ```
 
 Once we have captured the syscalls, we can ask the gadget to generate the
-corresponding profile:
+corresponding profile, by stopping the operation with the identifier we had
+received before.
 
 ```bash
 $ kubectl gadget advise seccomp-profile stop jMzhur2dQjZJxDCI

--- a/docs/guides/audit/seccomp.md
+++ b/docs/guides/audit/seccomp.md
@@ -5,9 +5,9 @@ description: >
   Trace syscalls that seccomp sent to the audit log.
 ---
 
-The Audit Seccomp gadget provides a stream of events with syscalls that had
+The audit seccomp gadget provides a stream of events with syscalls that had
 their seccomp filters generating an audit log. An audit log can be generated in
-one of those two conditions:
+one of these two conditions:
 
 * The Seccomp profile has the flag `SECCOMP_FILTER_FLAG_LOG` (currently
   [unsupported by runc](https://github.com/opencontainers/runc/pull/3390)) and

--- a/docs/guides/audit/seccomp.md
+++ b/docs/guides/audit/seccomp.md
@@ -1,6 +1,8 @@
 ---
 title: 'Using audit seccomp'
-weight: 10
+weight: 20
+description: >
+  Trace syscalls that seccomp sent to the audit log.
 ---
 
 The Audit Seccomp gadget provides a stream of events with syscalls that had

--- a/docs/guides/general-usage.md
+++ b/docs/guides/general-usage.md
@@ -1,0 +1,140 @@
+---
+title: 'General Usage'
+weight: 10
+description: 'An overview of the flags shared across gadgets'
+---
+
+Inspektor Gadget comes with a wide array of gadgets that allow us to
+inspect what's going on in our clusters. The flags and parameters that we
+can pass to each specific gadget may differ, but there are some that are
+supported across all gadgets.
+
+## Selecting Containers
+
+There are several ways to choose the pods or containers to consider:
+
+ * `--node string`, show only data from pods running in that node
+ * `-n string`, `--namespace string`, show data from pods in that namespace
+ * `-A`, `--all-namespaces`, show data from pods in all namespaces
+ * `-p string`, `--podname string`, show only data from pods with that name
+ * `-c string`, `--containername string`, show only data from containers with that name
+ * `-l string`, `--selector string`: show only data that matches the given
+   label or selector. Only `=` is currently supported (e.g. `key1=value1,key2=value2`).
+
+We can use one or more of these parameters to choose which pods or
+containers will be inspected by our gadgets.
+For example:
+
+```
+$ kubectl gadget trace exec -n demo -l app=myapp
+```
+
+Will run the `exec` tracer for all pods in the `demo` namespace that have
+the `app=myapp` label.
+
+```
+$ kubectl gadget snapshot socket -A -p nginx
+```
+
+Will get the `socket` snapshot for all pods with name `nginx`, regardless
+of which namespace they are in.
+
+## Handling Output
+
+The `-o` or `--output` flag lets us decide the format for the output the
+gadget will generate. The default `columns` output shows some of the
+information gathered, arranged in text columns on the console.
+
+This can be overridden with either `json` or `custom-columns`.
+
+### JSON Output
+
+Passing `-o json` will print all the information gathered in JSON format.
+
+For example:
+```
+$ kubectl gadget trace tcp -A -o json | jq
+{
+  "type": "normal",
+  "node": "minikube",
+  "namespace": "kube-system",
+  "pod": "coredns-66bff467f8-8ftjm",
+  "container": "coredns",
+  "pid": 2688,
+  "comm": "coredns",
+  "ipversion": 4,
+  "saddr": "127.0.0.1",
+  "daddr": "127.0.0.1",
+  "sport": 46010,
+  "dport": 8080,
+  "operation": "connect"
+}
+```
+
+### Custom Columns
+
+Using `-o custom-columns=column1,column2` we can choose which columns to
+print. We can use the JSON output to know the names of all the available
+columns for a given gadget.
+
+For example, when tracing which processes were killed because of the node
+running out of memory, we can choose to only print the PID and command of
+the killed process:
+
+```
+kubectl gadget trace oomkill -A -o custom-columns=kpid,kcomm
+KPID   KCOMM
+15182  tail
+```
+
+## Run for a specific amount of time
+
+Many gadgets will run forever, printing the gathered output until we press
+Ctrl-C to stop them. If we want to run a gadget only for a window of time,
+we can use the `--timeout int` flag, passing the number of seconds during which
+we want to run the gadget.
+
+For example, we can trace files that get opened by pods in the `gadget`
+namespace during a window of 5 seconds, like this:
+
+```
+$ kubectl gadget trace open -n gadget --timeout 5
+NODE             NAMESPACE        POD              CONTAINER        PID    COMM             FD  ERR PATH
+minikube         gadget           gadget-vhcj7     gadget           1303299 gadgettracerman  3     0 /etc/ld.so.cache
+minikube         gadget           gadget-vhcj7     gadget           1303299 gadgettracerman  3     0 /lib/x86_64-linux-gnu/libpthread.so.0
+minikube         gadget           gadget-vhcj7     gadget           1303299 gadgettracerman  3     0 /lib/x86_64-linux-gnu/libseccomp.so.2
+minikube         gadget           gadget-vhcj7     gadget           1303299 gadgettracerman  3     0 /lib/x86_64-linux-gnu/libc.so.6
+minikube         gadget           gadget-vhcj7     gadget           1303299 gadgettracerman  3     0 /sys/kernel/mm/transparent_hugepage/hpage_pmd_size
+minikube         gadget           gadget-vhcj7     gadget           1303299 gadgettracerman  6     0 /usr/bin/gadgettracermanager
+minikube         gadget           gadget-vhcj7     gadget           1303299 gadgettracerman  6     0 /etc/localtime
+```
+
+## Kubernetes CLI Runtime options
+
+The Inspektor Gadget `kubectl` plugin uses the [kubernetes
+cli-runtime](https://github.com/kubernetes/cli-runtime) helpers. This adds
+support for many CLI options that are common to many Kubernetes tools,
+which let us specify how to connect to the cluster, which kubeconfig to
+use, and so on.
+
+```
+  --as string                      Username to impersonate for the operation
+  --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
+  --cache-dir string               Default cache directory (default "/home/marga/.kube/cache")
+  --certificate-authority string   Path to a cert file for the certificate authority
+  --client-certificate string      Path to a client certificate file for TLS
+  --client-key string              Path to a client key file for TLS
+  --cluster string                 The name of the kubeconfig cluster to use
+  --context string                 The name of the kubeconfig context to use
+  --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
+  --kubeconfig string              Path to the kubeconfig file to use for CLI requests.
+  --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
+, --server string                  The address and port of the Kubernetes API server
+  --tls-server-name string         Server name to use for server certificate validation. If it is not provided, the hostname used to contact the server is used
+  --token string                   Bearer token for authentication to the API server
+  --user string                    The name of the kubeconfig user to use
+```
+
+If none of these options are specified, Inspektor Gadget will connect to the
+cluster configured in the default kubeconfig location, with the default
+connection options.

--- a/docs/guides/profile/block-io.md
+++ b/docs/guides/profile/block-io.md
@@ -1,6 +1,8 @@
 ---
 title: 'Using profile block-io'
-weight: 10
+weight: 20
+description: >
+  Analyze block I/O performance through a latency distribution.
 ---
 
 The biolatency gadget traces the block device I/O (disk I/O), and records the

--- a/docs/guides/profile/block-io.md
+++ b/docs/guides/profile/block-io.md
@@ -5,12 +5,15 @@ description: >
   Analyze block I/O performance through a latency distribution.
 ---
 
-The biolatency gadget traces the block device I/O (disk I/O), and records the
-distribution of I/O latency (time), to then print this as a histogram when
-the gadget is stopped. Notice that the latency of the disk I/O is measured
-from the issue to the device to its completion, so it does not include
-time queued in the kernel. It means that the histogram reflects only the
-performance of the device and not the latency suffered by an application.
+The profile block-io gadget gathers information about the usage of the
+block device I/O (disk I/O), generating a histogram distribution of I/O
+latency (time), when the gadget is stopped.
+
+Notice that the latency of the disk I/O is measured from when the call is
+issued to the device until its completion, it does not include time spent
+in the kernel queue. This means that the histogram reflects only the
+performance of the device and not the effective latency suffered by the
+applications.
 
 The histogram shows the number of I/O operations (`count` column) that lie in
 the latency range `interval-start` -> `interval-end` (`usecs` column), which,
@@ -24,7 +27,7 @@ the `--io` flag that will generate a given number of workers to spin on the
 way, we will generate disk I/O that we will analyse using the biolatency
 gadget.
 
-Firstly, let's use the biolatency gadget to see the I/O latency in our
+Firstly, let's use the profile block-io gadget to see the I/O latency in our
 testing node with its normal load work:
 
 ```bash
@@ -77,7 +80,7 @@ NAME        READY   STATUS    RESTARTS   AGE   IP           NODE          NOMINA
 stress-io   1/1     Running   0          2s    10.244.1.7   worker-node   <none>           <none>
 ```
 
-Using the biolatency gadget, we can generate another histogram to analyse the
+Using the profile block-io gadget, we can generate another histogram to analyse the
 disk I/O with this load:
 
 ```bash

--- a/docs/guides/profile/cpu.md
+++ b/docs/guides/profile/cpu.md
@@ -1,6 +1,8 @@
 ---
 title: 'Using profile cpu'
-weight: 10
+weight: 20
+description: >
+  Analyze CPU performance by sampling stack traces.
 ---
 
 The profile gadget takes samples of the stack traces.

--- a/docs/guides/profile/cpu.md
+++ b/docs/guides/profile/cpu.md
@@ -5,7 +5,7 @@ description: >
   Analyze CPU performance by sampling stack traces.
 ---
 
-The profile gadget takes samples of the stack traces.
+The profile cpu gadget takes samples of the stack traces.
 
 Here we deploy a small demo pod "random":
 
@@ -14,7 +14,7 @@ $ kubectl run --restart=Never --image=busybox random -- sh -c 'cat /dev/urandom 
 pod/random created
 ```
 
-Using the profile gadget, we can see the list of stack traces.
+Using the profile cpu gadget, we can see the list of stack traces.
 The following command filters only for pods named "random", execute the command
 and interrupt it after ~30 seconds. The `-K` option is passed to show only the
 kernel stack traces.

--- a/docs/guides/snapshot/process.md
+++ b/docs/guides/snapshot/process.md
@@ -5,7 +5,7 @@ description: >
   Gather information about running processes.
 ---
 
-The process-collector gadget gathers information about running processes.
+The snapshot process gadget gathers information about running processes.
 
 Let's start this demo by creating a namespace:
 

--- a/docs/guides/snapshot/process.md
+++ b/docs/guides/snapshot/process.md
@@ -1,6 +1,8 @@
 ---
 title: 'Using snapshot process'
-weight: 10
+weight: 20
+description: >
+  Gather information about running processes.
 ---
 
 The process-collector gadget gathers information about running processes.

--- a/docs/guides/snapshot/socket.md
+++ b/docs/guides/snapshot/socket.md
@@ -5,7 +5,7 @@ description: >
   Gather information about TCP and UDP sockets.
 ---
 
-socket-collector gathers information about TCP and UDP sockets.
+The snapshot socket gadget gathers information about TCP and UDP sockets.
 
 We will start this demo by using nginx to create a web server on port 80:
 
@@ -25,7 +25,7 @@ NAME        READY   STATUS    RESTARTS   AGE
 nginx-app   1/1     Running   0          46s
 ```
 
-We will now use Inspektor Gadget to retrieve the TCP/UDP sockets information
+We will now use the snapshot socket gadget to retrieve the TCP/UDP sockets information
 of the nginx-app pod. Notice we are filtering by namespace but we could have
 done it also using the podname or labels:
 
@@ -47,7 +47,7 @@ $ kubectl exec -n test-socketcollector nginx-app -- /bin/bash -c "sed -i 's/list
 [...] signal process started
 ```
 
-Check with Inspektor Gadget what are the sockets now:
+Now, we can check again with the snapshot socket gadget what the active socket is:
 
 ```bash
 $ kubectl gadget snapshot socket -n test-socketcollector

--- a/docs/guides/snapshot/socket.md
+++ b/docs/guides/snapshot/socket.md
@@ -1,6 +1,8 @@
 ---
 title: 'Using snapshot socket'
-weight: 10
+weight: 20
+description: >
+  Gather information about TCP and UDP sockets.
 ---
 
 socket-collector gathers information about TCP and UDP sockets.

--- a/docs/guides/top/block-io.md
+++ b/docs/guides/top/block-io.md
@@ -5,7 +5,8 @@ description: >
   Periodically report block device I/O activity.
 ---
 
-The `top block-io` gadget is used to trace block devices I/O.
+The top block-io gadget is used to visualize the containers generating
+the most block device input/output.
 
 ## How to use it?
 

--- a/docs/guides/top/block-io.md
+++ b/docs/guides/top/block-io.md
@@ -1,6 +1,8 @@
 ---
 title: 'Using top block-io'
-weight: 10
+weight: 20
+description: >
+  Periodically report block device I/O activity.
 ---
 
 The `top block-io` gadget is used to trace block devices I/O.

--- a/docs/guides/top/file.md
+++ b/docs/guides/top/file.md
@@ -5,12 +5,12 @@ description: >
   Periodically report read/write activity by file.
 ---
 
-`top file` shows reads and writes by file, with container details.
+The top file gadget is used to visualize reads and writes by file, with container details.
 
-This guide will deploy an example workload that perform some disk I/O
-activity to show how to use filetop.
+This guide will deploy an example workload that performs some disk I/O
+activity to show how to use `top file`.
 
-Before starting our workload, let's start filetop to be sure it captures
+Before starting our workload, let's start our top file gadget to be sure it captures
 all the events from the beginning:
 
 ```bash
@@ -30,9 +30,9 @@ clone the linux source code.
 $ kubectl run -it mypod --image ubuntu -- /bin/sh -c "apt-get update && apt-get install -y git && git clone https://github.com/torvalds/linux"
 ```
 
-We can see how the filetop terminal shows the files that are read and
+We can see how the `top file` terminal shows the files that are read and
 written by the pod. For instace, apt-get is reading a lot of files in
-this case.
+when updating the packages list and installing packages.
 
 ```bash
 NODE             NAMESPACE        POD              CONTAINER        PID     COMM             READS  WRITES R_Kb    W_Kb    T FILE
@@ -62,13 +62,13 @@ them remove it:
 $ kubectl delete pod mypod
 ```
 
-By default filetop prints a summary each second. It accepts a numeric argument to indicate the interval to use:
+By default the top file gadget prints a summary each second. It accepts a numeric argument to indicate the interval to use:
 
 ```bash
 $ kubectl gadget top file 5 # will print a summary each 5 seconds
 ```
 
-filetop supports the following flags to customize the output:
+This gadget also supports the following flags to customize the output:
 
 ```bash
 $ kubectl gadget top file --help

--- a/docs/guides/top/file.md
+++ b/docs/guides/top/file.md
@@ -1,6 +1,8 @@
 ---
 title: 'Using top file'
-weight: 10
+weight: 20
+description: >
+  Periodically report read/write activity by file.
 ---
 
 `top file` shows reads and writes by file, with container details.

--- a/docs/guides/top/tcp.md
+++ b/docs/guides/top/tcp.md
@@ -1,6 +1,8 @@
 ---
 title: 'Using top tcp'
-weight: 10
+weight: 20
+description: >
+  Periodically report TCP activity.
 ---
 
 The `top tcp` gadget is used to monitor TCP connections.

--- a/docs/guides/top/tcp.md
+++ b/docs/guides/top/tcp.md
@@ -5,7 +5,7 @@ description: >
   Periodically report TCP activity.
 ---
 
-The `top tcp` gadget is used to monitor TCP connections.
+The top tcp gadget is used to visualize active TCP connections.
 
 ## How to use it?
 
@@ -24,7 +24,7 @@ NODE             NAMESPACE        POD              CONTAINER        PID     COMM
 ```
 
 Indeed, it is waiting for TCP connection to occur.
-So, open *an other terminal* and keep and eye on the first one, `exec` the container and use `wget`:
+So, open *another terminal* and keep and eye on the first one, `exec` the container and use `wget`:
 
 ```bash
 $ kubectl exec -ti test-pod -- wget kinvolk.io
@@ -39,7 +39,7 @@ minikube         default          test-pod         test-pod         49447   wget
     188.114.97.3:443                                    10      0
 ```
 
-This line correspond to the TCP connection initiated by `wget`.
+This line corresponds to the TCP connection initiated by `wget`.
 
 ## Only print some information
 

--- a/docs/guides/trace/bind.md
+++ b/docs/guides/trace/bind.md
@@ -5,7 +5,7 @@ description: >
   Trace the kernel functions performing socket binding.
 ---
 
-The `bind` gadget is used to trace the kernel functions performing socket binding.
+The trace bind gadget is used to stream socket binding syscalls.
 
 ## How to use it?
 
@@ -38,17 +38,17 @@ NODE             NAMESPACE        POD              CONTAINER        PID    COMM 
 minikube         default          test-pod         test-pod         58208  nc               IP     ::               4242   .R...  0
 ```
 
-This line correspond to the socket binding operation initiated by `nc`.
+This line corresponds to the socket binding operation initiated by `nc`.
 
 ## Restricting output to certain PID, ports or succeeded and failed port bindings
 
-With the following option, you can restrain the output:
+With the following options, you can restrict the output:
 
 * `--pid` only prints events where socket binding is done by the given PID.
 * `-P/--ports` only prints events where these ports are used for socket bindings.
 * `-i/--ignore-errors` only prints events where the bind succeeded.
 
-So, this command will print all (*i.e.* succeeded and failed) attempt to bind a socket on port 4242 or 4343 by PID 42:
+So, this command will print all (*i.e.* succeeded and failed) attempts to bind a socket on port 4242 or 4343 by PID 42:
 
 ```bash
 $ kubectl gadget trace bind -i=false --pid 42 -P=4242,4343

--- a/docs/guides/trace/bind.md
+++ b/docs/guides/trace/bind.md
@@ -1,6 +1,8 @@
 ---
 title: 'Using trace bind'
-weight: 10
+weight: 20
+description: >
+  Trace the kernel functions performing socket binding.
 ---
 
 The `bind` gadget is used to trace the kernel functions performing socket binding.

--- a/docs/guides/trace/capabilities.md
+++ b/docs/guides/trace/capabilities.md
@@ -5,7 +5,7 @@ description: >
   Trace security capability checks.
 ---
 
-The capabilities gadget allows us to see what capability security checks
+The trace capabilities gadget allows us to see what capability security checks
 are triggered by applications running in Kubernetes Pods.
 
 Linux [capabilities](https://linux.die.net/man/7/capabilities) allow for a finer

--- a/docs/guides/trace/capabilities.md
+++ b/docs/guides/trace/capabilities.md
@@ -1,6 +1,8 @@
 ---
 title: 'Using trace capabilities'
-weight: 10
+weight: 20
+description: >
+  Trace security capability checks.
 ---
 
 The capabilities gadget allows us to see what capability security checks

--- a/docs/guides/trace/dns.md
+++ b/docs/guides/trace/dns.md
@@ -5,7 +5,7 @@ description: >
   Trace DNS requests.
 ---
 
-The dns gadget prints information about DNS requests performed by the different
+The trace dns gadget prints information about DNS requests performed by the different
 pods.
 
 Create a `demo` namespace:

--- a/docs/guides/trace/dns.md
+++ b/docs/guides/trace/dns.md
@@ -1,6 +1,8 @@
 ---
 title: 'Using trace dns'
-weight: 10
+weight: 20
+description: >
+  Trace DNS requests.
 ---
 
 The dns gadget prints information about DNS requests performed by the different

--- a/docs/guides/trace/exec.md
+++ b/docs/guides/trace/exec.md
@@ -1,6 +1,8 @@
 ---
 title: 'Using trace exec'
-weight: 10
+weight: 20
+description: >
+  Trace new processes.
 ---
 
 trace exec traces new processes creation.

--- a/docs/guides/trace/exec.md
+++ b/docs/guides/trace/exec.md
@@ -5,7 +5,7 @@ description: >
   Trace new processes.
 ---
 
-trace exec traces new processes creation.
+The trace exec gadget streams new processes creation events.
 
 Let's deploy an example application that will spawn few new processes:
 

--- a/docs/guides/trace/fsslower.md
+++ b/docs/guides/trace/fsslower.md
@@ -5,7 +5,8 @@ description: >
   Trace open, read, write and fsync operations slower than a threshold.
 ---
 
-fsslower traces open, read, write and fsync operations slower than a threshold.
+The trace fsslower gadget streams file operations (open, read, write and
+fsync) that are slower than a threshold.
 
 In this guide you'll deploy an example workload that performs some
 open(), read() write() and sync() calls and will trace which ones are

--- a/docs/guides/trace/fsslower.md
+++ b/docs/guides/trace/fsslower.md
@@ -1,6 +1,8 @@
 ---
 title: 'Using trace fsslower'
-weight: 10
+weight: 20
+description: >
+  Trace open, read, write and fsync operations slower than a threshold.
 ---
 
 fsslower traces open, read, write and fsync operations slower than a threshold.

--- a/docs/guides/trace/mount.md
+++ b/docs/guides/trace/mount.md
@@ -5,8 +5,8 @@ description: >
   Trace mount and umount system calls.
 ---
 
-The `trace mount` gadget is used to monitor `mount` and `umount` syscalls.
-In this guide, we will learn how to use it by running a small `kubernetes` cluster inside `minikube`.
+The trace mount gadget is used to monitor `mount` and `umount` syscalls.
+In this guide, we will learn how to use it by running a small Kubernetes cluster inside `minikube`.
 
 ## How to use it?
 
@@ -53,11 +53,11 @@ minikube         default          busybox-0        busybox-0        mount       
 
 All these lines correspond to the error we get from `mount` inside the pod.
 
-## Restrain output to certain pods
+## Restrict output to certain pods
 
-It can be useful to restrain the output to certains pods.
-For this, you can use `--selector` option.
-In a first terminal, run the following:
+It can be useful to restrict the output to certains pods. There are many
+flags that we can use for this. For example, we can use `--selector` option
+to select by label.  In a first terminal, run the following:
 
 ```bash
 $ kubectl get pods --show-labels
@@ -69,7 +69,7 @@ NODE             NAMESPACE        POD              CONTAINER        COMM        
 ```
 
 As you can see, the `--selector` option, and its `-l` shorthand awaits for pods labels as argument.
-In an *other terminal*, run these commands:
+In *another terminal*, run these commands:
 
 ```bash
 # Exec the first pod:
@@ -82,7 +82,7 @@ mount: mounting /quux on /quuz failed: No such file or directory
 command terminated with exit code 255
 ```
 
-Go back to the first terminal, you should only output related to `mount /foo /bar` as a result of using `--selector` options filtering the pods:
+Go back to the first terminal, you should only see output related to `mount /foo /bar` as a result of using `--selector` options filtering the pods:
 
 ```bash
 NODE             NAMESPACE        POD              CONTAINER        COMM             PID     TID     MNT_NS      CALL

--- a/docs/guides/trace/mount.md
+++ b/docs/guides/trace/mount.md
@@ -1,6 +1,8 @@
 ---
 title: 'Using trace mount'
-weight: 10
+weight: 20
+description: >
+  Trace mount and umount system calls.
 ---
 
 The `trace mount` gadget is used to monitor `mount` and `umount` syscalls.

--- a/docs/guides/trace/oomkill.md
+++ b/docs/guides/trace/oomkill.md
@@ -5,7 +5,7 @@ description: >
   Trace when OOM killer is triggered and kills a process.
 ---
 
-The `oomkill` gadget is used to monitor when OOM killer actually kills a process.
+The trace oomkill gadget is used to monitor when out-of-memory killer kills a process.
 
 ## How to use it?
 
@@ -24,8 +24,9 @@ $ kubectl gadget trace oomkill -n oomkill-demo
 NODE             NAMESPACE        POD              CONTAINER        KPID   KCOMM            PAGES  TPID             TCOMM
 ```
 
-Indeed, it is waiting for OOM killer to kick in and kills a process in `oomkill-demo` namespace (you can use `-A` to monitor all namespaces and then be sure to not miss any event).
-So, in *another terminal*, `exec` a container and run this command to exhaust the memory:
+The gadget is waiting for the OOM killer to get triggered and kill a process in `oomkill-demo` namespace (alternatively, we could use `-A` and get out-of-memory killer events in all namespaces).
+
+To trigger the OOM killer, in *another terminal*, `exec` a container and run this command to exhaust the memory:
 
 ```bash
 $ kubectl get pod -n oomkill-demo
@@ -42,7 +43,7 @@ NODE             NAMESPACE        POD              CONTAINER        KPID   KCOMM
 minikube         oomkill-demo     test-pod         test-container   11507  tail             32768  11507  tail
 ```
 
-The printed lined correspond to the killing of `perl` process by the OOM killer.
+The printed lined corresponds to the killing of the `perl` process by the OOM killer.
 Here is the full legend of all the fields:
 
 * `KPID`: The PID of the process killed by the OOM killer (KilledPID).
@@ -51,13 +52,13 @@ Here is the full legend of all the fields:
 * `TPID`: The PID of the process which triggered the OOM killer (TriggeredPID).
 * `TCOMM`: The command of the process which triggered the OOM killer (TriggeredCommand).
 
-So, the above line should be read like this: "Command tail, whom PID is 11507, running inside container test-container, within pod test-pod, in namespace oomkill-demo on minikube node, was killed by the OOM killer because it allocated 32768 pages. The OOM killer was triggered by tail whom pid is 11507."
+The line shown above can also be read like this: "The tail command, with PID 11507, running inside the test-container container, in the test-pod pod, in the oomkill-demo namespace, on the minikube node, was killed by the OOM killer because it allocated 32768 pages. The OOM killer was triggered by tail with PID 11507."
 
 Note that, in this case, the command which was killed by the OOM killer is the same which triggered it, **this is not always the case**.
 
 ## Only print some information
 
-You can restrain the information printed using `-o custom-columns=column0,...,columnN`.
+You can restrict the information printed using `-o custom-columns=column0,...,columnN`.
 This command will only show the PID and command of the killed process:
 
 ```bash

--- a/docs/guides/trace/oomkill.md
+++ b/docs/guides/trace/oomkill.md
@@ -1,6 +1,8 @@
 ---
 title: 'Using trace oomkill'
-weight: 10
+weight: 20
+description: >
+  Trace when OOM killer is triggered and kills a process.
 ---
 
 The `oomkill` gadget is used to monitor when OOM killer actually kills a process.

--- a/docs/guides/trace/open.md
+++ b/docs/guides/trace/open.md
@@ -5,7 +5,7 @@ description: >
   Trace open system calls.
 ---
 
-The trace open gadget watches files that programs in pods open.
+The trace open gadget streams events related to files opened inside pods.
 
 Here we deploy a small demo pod "mypod":
 
@@ -15,7 +15,7 @@ $ kubectl run --restart=Never -ti --image=busybox mypod -- sh -c 'while /bin/tru
 
 Using the trace open gadget, we can see which processes open what files.
 We can simply filter for the pod "mypod" and omit specifying the node,
-thus traceing on all nodes for pod "mypod":
+thus tracing on all nodes for a pod called "mypod":
 
 ```bash
 $ kubectl gadget trace open --podname mypod

--- a/docs/guides/trace/open.md
+++ b/docs/guides/trace/open.md
@@ -1,6 +1,8 @@
 ---
 title: 'Using trace open'
-weight: 10
+weight: 20
+description: >
+  Trace open system calls.
 ---
 
 The trace open gadget watches files that programs in pods open.

--- a/docs/guides/trace/signal.md
+++ b/docs/guides/trace/signal.md
@@ -5,7 +5,8 @@ description: >
   Trace signals received by processes.
 ---
 
-The `trace signal` gadget is used to trace signal sent system-wide.
+The trace signal gadget is used to trace system signals received by the
+pods.
 
 ## How to use it?
 
@@ -59,13 +60,13 @@ minikube         default          debian           debian           142244 pytho
 
 ## Restricting output to certain PID, signals or failed to send the signals
 
-With the following option, you can restrain the output:
+With the following option, you can restrict the output:
 
 * `--pid` only prints events where a signal is sent by the given PID.
 * `--signal` only prints events where the given signal is sent.
 * `-f/--failed-only` only prints events where signal failed to be delivered.
 
-So, this command will only print failed attempts to send `SIGKILL` by PID `42`:
+For example, this command will only print failed attempts to send `SIGKILL` by PID `42`:
 
 ```bash
 $ kubectl gadget -f --pid 42 --signal SIGKILL

--- a/docs/guides/trace/signal.md
+++ b/docs/guides/trace/signal.md
@@ -1,6 +1,8 @@
 ---
 title: 'Using trace signal'
-weight: 10
+weight: 20
+description: >
+  Trace signals received by processes.
 ---
 
 The `trace signal` gadget is used to trace signal sent system-wide.

--- a/docs/guides/trace/sni.md
+++ b/docs/guides/trace/sni.md
@@ -5,7 +5,7 @@ description: >
   Trace Server Name Indication (SNI) from TLS requests.
 ---
 
-The `trace sni` gadget is used to trace the [Server Name Indication (SNI)](https://en.wikipedia.org/wiki/Server_Name_Indication) requests sent as part of TLS handshakes.
+The trace sni gadget is used to trace the [Server Name Indication (SNI)](https://en.wikipedia.org/wiki/Server_Name_Indication) requests sent as part of TLS handshakes.
 
 ## How to use it?
 

--- a/docs/guides/trace/sni.md
+++ b/docs/guides/trace/sni.md
@@ -1,6 +1,8 @@
 ---
 title: 'Using trace sni'
-weight: 10
+weight: 20
+description: >
+  Trace Server Name Indication (SNI) from TLS requests.
 ---
 
 The `trace sni` gadget is used to trace the [Server Name Indication (SNI)](https://en.wikipedia.org/wiki/Server_Name_Indication) requests sent as part of TLS handshakes.

--- a/docs/guides/trace/tcp.md
+++ b/docs/guides/trace/tcp.md
@@ -5,7 +5,8 @@ description: >
   Trace tcp connect, accept and close.
 ---
 
-The `tcp` gadget is used to monitor tcp connections.
+The trace tcp gadget can be used to monitor tcp connections, as it shows
+connect, accept and close events related to TCP connections.
 
 ## How to use it?
 
@@ -42,7 +43,7 @@ NODE             NAMESPACE        POD              CONTAINER        T PID    COM
 minikube         <>               <>               <>               C 16266  wget             4   172.17.0.3       188.114.97.3     34878   443
 ```
 
-The printed lined correspond to TCP connection established with the socket.
+The printed lines correspond to TCP connection established with the socket.
 Here is the full legend of all the fields:
 
 * `T`: How the TCP connection was established, it can be one of the following values:
@@ -58,13 +59,13 @@ Here is the full legend of all the fields:
 * `SPORT`: The source port.
 * `DPORT`: The destination port.
 
-So, the above line should be read like this: "Command `wget`, which has PID 19981, established a TCP connection through IP version 4, using the `connect()` system call, from address 172.17.0.3 and port 16266 towards address 188.114.97.3 and port 433"
+So, the above line should be read like this: "Command `wget`, with PID 19981, established a TCP connection through IP version 4, using the `connect()` system call, from address 172.17.0.3 and port 16266 towards address 188.114.97.3 and port 433"
 
 Note that, IP 188.114.97.3 corresponds to `kinvolk.io` while port 443 is the port generally used for HTTPS.
 
 ## Only print some information
 
-You can restrain the information printed using `-o custom-columns=column0,...,columnN`.
+You can restrict the information printed using `-o custom-columns=column0,...,columnN`.
 This command will only show the PID and command:
 
 ```bash

--- a/docs/guides/trace/tcp.md
+++ b/docs/guides/trace/tcp.md
@@ -1,6 +1,8 @@
 ---
 title: 'Using trace tcp'
-weight: 10
+weight: 20
+description: >
+  Trace tcp connect, accept and close.
 ---
 
 The `tcp` gadget is used to monitor tcp connections.

--- a/docs/guides/trace/tcpconnect.md
+++ b/docs/guides/trace/tcpconnect.md
@@ -1,6 +1,8 @@
 ---
 title: 'Using trace tcpconnect'
-weight: 10
+weight: 20
+description: >
+  Trace connect system calls.
 ---
 
 The tcpconnect gadget traces TCP connect calls.

--- a/docs/guides/trace/tcpconnect.md
+++ b/docs/guides/trace/tcpconnect.md
@@ -5,12 +5,12 @@ description: >
   Trace connect system calls.
 ---
 
-The tcpconnect gadget traces TCP connect calls.
-This will help us to define a restrictive policy for outgoing connections.
+The trace tcpconnect gadget traces TCP connect calls.
+
+In this guide, we will use this gadget to define a restrictive policy for outgoing connections.
 
 Before we start a demo pod that connects to a public HTTP server, we already begin to trace
 the outgoing connections of our future pod (don't terminate it with Ctrl-C for now).
-
 
 ```bash
 $ kubectl gadget trace tcpconnect --podname mypod
@@ -23,7 +23,7 @@ $ kubectl run --restart=Never -ti --image=busybox mypod -- sh -c 'wget -q -O /de
 ok
 ```
 
-In our Inspektor Gadget terminal we can now see the logged connection:
+In our trace tcpconnect gadget terminal we can now see the logged connection:
 
 ```bash
 $ kubectl gadget trace tcpconnect --podname mypod
@@ -33,11 +33,11 @@ ip-10-0-30-247   default          mypod            mypod           9386   wget  
 ip-10-0-30-247   default          mypod            mypod           9386   wget         4  172.17.0.3       1.1.1.1          443
 ```
 
-(If the pod was started as part of a deployment, the name of the pod is not known
+If the pod was started as part of a deployment, the name of the pod is not known
 in advance since random characters will be added as suffix.
 In that case, it is still possible to trace the connections. We would just
 use `kubectl gadget trace tcpconnect --selector key=value` to filter the pods by
-labels instead of names.)
+labels instead of names.
 
 There was a HTTP redirect to HTTPS, so we need to allow both ports for our pod.
 Don't terminate it yet, we will have another look later.
@@ -86,7 +86,7 @@ ok
 
 ```
 
-Switching to the Inspektor Gadget terminal, we see the same connections again
+Switching to the gadget trace tcpconnnect terminal, we see the same connections again
 (but now with a new PID since it's a new pod):
 
 ```bash
@@ -108,7 +108,7 @@ wget: download timed out
 failed
 ```
 
-Indeed the network policy was applied and we can also see in Inspektor Gadget which
+Indeed the network policy was applied and we can also see in the gadget output which
 connection the pod wanted to make in the last line. Since connecting to port 80 failed
 there is no redirect visible to port 443:
 

--- a/docs/guides/traceloop.md
+++ b/docs/guides/traceloop.md
@@ -1,6 +1,8 @@
 ---
 title: 'Using traceloop'
-weight: 10
+weight: 30
+description: >
+  Get strace-like logs of a pod from the past.
 ---
 
 ## Start traceloop

--- a/docs/guides/traceloop.md
+++ b/docs/guides/traceloop.md
@@ -52,7 +52,7 @@ $ kubectl gadget traceloop show 10.0.30.247_default_mypod | grep -E 'write|/tmp/
 00:00.071566973 cpu#1 pid 14276 [cat] write(fd=2, buf=140723923036928 "cat: can't open '/tmp/file-3240': No such file or directory\n", count=60) = 60
 ```
 
-Thanks to the `traceloop` gadget, we can recover the result of the
+Thanks to the traceloop gadget, we can recover the result of the
 multiplication: 42. And we can understand the mistake in the shell script: the
 result was saved in `/tmp/file-1889` but we attempted to open
 `/tmp/file-3240`.


### PR DESCRIPTION
This PR includes three documentation changes:
- Add a guide documenting common parameters (pod selection, output formatting, kubernetes runtimes CLI)
- Review all guides to ensure that the gadgets are named correctly and also fix typos and so on.
- Add descriptions to all guides, for the Overview page. Which looks like this:
![image](https://user-images.githubusercontent.com/62987181/166732355-b4999f95-df38-40c8-99b1-cee8e8d9ede5.png)

Fixes: #495 