### PR TITLE
profile: Rework block-io CLI

### DIFF
--- a/cmd/kubectl-gadget/profile/block-io.go
+++ b/cmd/kubectl-gadget/profile/block-io.go
@@ -17,6 +17,10 @@ package profile
 import (
 	"errors"
 	"fmt"
+	"os"
+	"os/signal"
+	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -33,53 +37,26 @@ var biolatencyTraceConfig = &utils.TraceConfig{
 }
 
 var biolatencyCmd = &cobra.Command{
-	Use:   "block-io",
-	Short: "Analyze block I/O performance through a latency distribution",
-}
-
-var biolatencyStartCmd = &cobra.Command{
-	Use:          "start",
-	Short:        "Start monitor the block device I/O (disk I/O) and record the distribution of I/O latency (time)",
-	RunE:         runBiolatencyStart,
+	Use:          "block-io",
+	Short:        "Analyze block I/O performance through a latency distribution",
 	Args:         cobra.NoArgs,
 	SilenceUsage: true,
-	PreRunE: func(cmd *cobra.Command, args []string) error {
-		// Biolatency does not support filtering so we need to avoid adding
-		// the default namespace configured in the kubeconfig file.
-		if params.Namespace != "" && !params.NamespaceOverridden {
-			params.Namespace = ""
-		}
-		return nil
-	},
-}
-
-var biolatencyStopCmd = &cobra.Command{
-	Use:          "stop <trace-id>",
-	Short:        "Stop monitoring and generate a report (a histogram graph) with the distribution of block device I/O latency",
-	RunE:         runBiolatencyStop,
-	SilenceUsage: true,
-}
-
-var biolatencyListCmd = &cobra.Command{
-	Use:          "list",
-	Short:        "List the currently running biolatency traces",
-	RunE:         runBiolatencyList,
-	Args:         cobra.NoArgs,
-	SilenceUsage: true,
+	RunE:         runBiolatency,
 }
 
 func init() {
-	biolatencyCmd.AddCommand(biolatencyStartCmd)
-	biolatencyCmd.AddCommand(biolatencyStopCmd)
-	biolatencyCmd.AddCommand(biolatencyListCmd)
-
 	ProfilerCmd.AddCommand(biolatencyCmd)
 
-	// Common flags are meaningless for list and stop sub-commands
-	utils.AddCommonFlags(biolatencyStartCmd, &params)
+	utils.AddCommonFlags(biolatencyCmd, &params)
 }
 
-func runBiolatencyStart(cmd *cobra.Command, args []string) error {
+func runBiolatency(cmd *cobra.Command, args []string) error {
+	// Biolatency does not support filtering so we need to avoid adding
+	// the default namespace configured in the kubeconfig file.
+	if params.Namespace != "" && !params.NamespaceOverridden {
+		params.Namespace = ""
+	}
+
 	if params.Node == "" {
 		return utils.WrapInErrMissingArgs("--node")
 	}
@@ -90,18 +67,24 @@ func runBiolatencyStart(cmd *cobra.Command, args []string) error {
 		return utils.WrapInErrRunGadget(err)
 	}
 
-	fmt.Printf("%s\n", traceID)
+	defer utils.DeleteTrace(traceID)
 
-	return nil
-}
-
-func runBiolatencyStop(cmd *cobra.Command, args []string) error {
-	if len(args) != 1 {
-		return utils.WrapInErrMissingArgs("<trace-id>")
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, os.Interrupt)
+	if params.Timeout != 0 {
+		go func() {
+			time.Sleep(time.Duration(params.Timeout) * time.Second)
+			c <- os.Interrupt
+		}()
+		fmt.Printf("Tracing block device I/O...")
+	} else {
+		fmt.Printf("Tracing block device I/O... Hit Ctrl-C to end.")
 	}
-	traceID := args[0]
 
-	err := utils.SetTraceOperation(traceID, "stop")
+	<-c
+
+	fmt.Println()
+	err = utils.SetTraceOperation(traceID, "stop")
 	if err != nil {
 		return utils.WrapInErrStopGadget(err)
 	}
@@ -111,11 +94,13 @@ func runBiolatencyStop(cmd *cobra.Command, args []string) error {
 			return errors.New("there should be only one result because biolatency runs on one node at a time")
 		}
 
-		fmt.Printf("%v", results[0].Status.Output)
+		// remove message printed by BCC tracer to avoid printing it twice
+		ret := strings.ReplaceAll(results[0].Status.Output,
+			"Tracing block device I/O... Hit Ctrl-C to end.\n", "")
+
+		fmt.Printf("%s", ret)
 		return nil
 	}
-
-	defer utils.DeleteTrace(traceID)
 
 	err = utils.PrintTraceOutputFromStatus(traceID,
 		biolatencyTraceConfig.TraceOutputState, displayResultsCallback)
@@ -123,13 +108,5 @@ func runBiolatencyStop(cmd *cobra.Command, args []string) error {
 		return utils.WrapInErrGetGadgetOutput(err)
 	}
 
-	return nil
-}
-
-func runBiolatencyList(cmd *cobra.Command, args []string) error {
-	err := utils.PrintAllTraces(biolatencyTraceConfig)
-	if err != nil {
-		return utils.WrapInErrListGadgetTraces(err)
-	}
 	return nil
 }

--- a/docs/guides/profile/block-io.md
+++ b/docs/guides/profile/block-io.md
@@ -31,15 +31,12 @@ Firstly, let's use the profile block-io gadget to see the I/O latency in our
 testing node with its normal load work:
 
 ```bash
-# Start the gadget on the worker-node node
-$ kubectl gadget profile block-io start --node worker-node
-4b5501BrEjiw2GxG
+# Run the gadget on the worker-node node
+$ kubectl gadget profile block-io --node worker-node
+Tracing block device I/O... Hit Ctrl-C to end
 
-# Wait for around 1 minute
-
-# Stop the gadget to generate the histogram
-$ kubectl gadget profile block-io stop 4b5501BrEjiw2GxG
-Tracing block device I/O... Hit Ctrl-C to end.
+# Wait for around 1 minute and hit Ctrl+C to stop the gadget and see the results
+^C
 
      usecs               : count     distribution
          0 -> 1          : 0        |                                        |
@@ -84,14 +81,12 @@ Using the profile block-io gadget, we can generate another histogram to analyse 
 disk I/O with this load:
 
 ```bash
-# Start the gadget again
-$ kubectl gadget profile block-io start --node worker-node
-pCkmJ3jDtDz9yVyc
+# Run the gadget again
+$ kubectl gadget profile block-io --node worker-node
+Tracing block device I/O... Hit Ctrl-C to end
 
-# Wait again for 1 minute
-
-$ kubectl-gadget profile block-io stop pCkmJ3jDtDz9yVyc
-Tracing block device I/O... Hit Ctrl-C to end.
+# Wait again for 1 minute and hit Ctrl+C to stop the gadget and see the results
+^C
 
      usecs               : count     distribution
          0 -> 1          : 0        |                                        |

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -268,7 +268,7 @@ func TestBiolatency(t *testing.T) {
 	commands := []*command{
 		{
 			name:           "Run biolatency gadget",
-			cmd:            "id=$($KUBECTL_GADGET profile block-io start --node $(kubectl get node --no-headers | cut -d' ' -f1 | head -1)); sleep 15; $KUBECTL_GADGET profile block-io stop $id",
+			cmd:            "$KUBECTL_GADGET profile block-io --node $(kubectl get node --no-headers | cut -d' ' -f1 | head -1) & sleep 15; kill -s INT $!",
 			expectedRegexp: `usecs\s+:\s+count\s+distribution`,
 		},
 	}


### PR DESCRIPTION
Before this commit the profile block-io (biolatency) gadget needed
multiple iterations to get a result:

$ kubectl gadget profile block-io start --node worker-node
4b5501BrEjiw2GxG

$ kubectl gadget profile block-io stop 4b5501BrEjiw2GxG
<histogram printed here>

This commit changes it to make it a "single execution" command printing
the results when Ctrl+C is hit:

$ kubectl gadget profile block-io --node worker-node
Tracing block device I/O... Hit Ctrl-C to end^C
Tracing block device I/O... Hit Ctrl-C to end.

     usecs               : count     distribution
         0 -> 1          : 0        |                                        |
         2 -> 3          : 0        |                                        |
         4 -> 7          : 0        |                                        |
         8 -> 15         : 0        |                                        |
        16 -> 31         : 0        |                                        |
        32 -> 63         : 6        |**********                              |
        64 -> 127        : 22       |****************************************|
       128 -> 255        : 9        |****************                        |
       256 -> 511        : 2        |***                                     |
       512 -> 1023       : 1        |*

--- 

It's  a RFC, what do you all think? 
---

TODO:
- [x] Update documentation
- [x] Update integration tests 
- [x] Avoid printing  "Tracing block device I/O... Hit Ctrl-C to end" twice