### PR TITLE
Fix GetContainers with multiple Docker containers

### DIFF
--- a/pkg/container-utils/docker/docker.go
+++ b/pkg/container-utils/docker/docker.go
@@ -118,7 +118,7 @@ func (c *DockerClient) GetContainers() ([]*runtimeclient.ContainerData, error) {
 	for i, container := range containers {
 		ret[i] = &runtimeclient.ContainerData{
 			ID:      container.ID,
-			Name:    strings.TrimPrefix(containers[0].Names[0], "/"),
+			Name:    strings.TrimPrefix(containers[i].Names[0], "/"),
 			Running: container.State == "running",
 		}
 	}


### PR DESCRIPTION
local-gadget was reporting wrong names when there are several Docker
containers:
```
» list-containers
zealous_robinson
zealous_robinson
```
