### PR TITLE
ci/integration-tests: Clean up resources when the workflow run is cancelled

### DIFF
--- a/.github/actions/run-integration-tests/action.yml
+++ b/.github/actions/run-integration-tests/action.yml
@@ -33,13 +33,40 @@ runs:
     - name: Integration tests
       shell: bash
       run: |
-        echo "Using IMAGE_TAG=$IMAGE_TAG"
+        echo "IntegrationTestsJob: Using IMAGE_TAG=$IMAGE_TAG"
 
         tar zxvf /home/runner/work/inspektor-gadget/kubectl-gadget-linux-amd64.tar.gz
         mv kubectl-gadget kubectl-gadget-linux-amd64
 
+        cleanup() { \
+            echo "IntegrationTestsJob: Workflow run is being cancelled: $1 was received"; \
+            trap - $1; \
+            if [[ $1 == "SIGINT" ]]; then \
+              echo "IntegrationTestsJob: Start the clean-up..."; \
+            else \
+              echo "IntegrationTestsJob: Just wait until the clean-up finishes..."; \
+              return; \
+            fi; \
+            echo "IntegrationTestsJob: Notifying the integration tests container about the cancellation"; \
+            docker kill --signal="SIGINT" ig-integration-tests > /dev/null; \
+            echo "IntegrationTestsJob: Waiting for the integration tests container to finish"; \
+            docker wait ig-integration-tests & wait $!; \
+            echo "IntegrationTestsJob: We are done with the clean-up. Let the job exit"; \
+            exit 0; \
+        }
+
+        # Capture the SIGINT to start the clean-up. Then, capture also the
+        # SIGTERM to have those 2.5 extra seconds before the runner kills the
+        # process tree:
+        # https://docs.github.com/en/actions/managing-workflow-runs/canceling-a-workflow#steps-github-takes-to-cancel-a-workflow-run
+        trap 'cleanup SIGINT' SIGINT
+        trap 'cleanup SIGTERM' SIGTERM
+
+        echo "IntegrationTestsJob: Start"
         TESTS_DOCKER_ARGS="-e KUBECONFIG=/root/.kube/config -v /home/runner/.kube:/root/.kube -v /home/runner/work/_temp/.minikube:/home/runner/work/_temp/.minikube" \
-            make -C integration build test
+            make -C integration build test &
+        wait $!
+        echo "IntegrationTestsJob: Done"
 
         sed -i "s/latest/$IMAGE_TAG/g" integration/gadget-integration-tests-job.yaml
     - name: Add integration asset as artifact.

--- a/integration/Makefile
+++ b/integration/Makefile
@@ -1,7 +1,7 @@
 CONTAINER_REPO ?= docker.io/kinvolk/gadget
 IMAGE_TAG ?= $(shell ./tools/image-tag branch)
 
-TESTS_DOCKER_ARGS ?= "-e KUBECONFIG=/opt/kubeconfig/config -v $(HOME)/.kube:/opt/kubeconfig"
+TESTS_DOCKER_ARGS ?= -e KUBECONFIG=/opt/kubeconfig/config -v $(HOME)/.kube:/opt/kubeconfig
 
 KUBERNETES_DISTRIBUTION ?= ""
 

--- a/integration/command.go
+++ b/integration/command.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"math/rand"
 	"os/exec"
@@ -25,6 +26,11 @@ import (
 	"testing"
 
 	"github.com/kr/pretty"
+)
+
+const (
+	namespaceLabelKey   string = "scope"
+	namespaceLabelValue string = "ig-integration-tests"
 )
 
 type command struct {
@@ -149,6 +155,16 @@ func (c *command) createExecCmd() {
 	cmd.Stdout = &c.stdout
 	cmd.Stderr = &c.stderr
 
+	// To be able to kill the process of /bin/sh and its child (the process of
+	// c.cmd), we need to send the termination signal to their process group ID
+	// (PGID). However, child processes get the same PGID as their parents by
+	// default, so in order to avoid killing also the integration tests process,
+	// we set the fields Setpgid and Pgid of syscall.SysProcAttr before
+	// executing /bin/sh. Doing so, the PGID of /bin/sh (and its children)
+	// will be set to its process ID, see:
+	// https://cs.opensource.google/go/go/+/refs/tags/go1.17.8:src/syscall/exec_linux.go;l=32-34.
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true, Pgid: 0}
+
 	c.command = cmd
 }
 
@@ -198,6 +214,125 @@ func (c *command) verifyOutput() error {
 	return nil
 }
 
+// kill kills a command by sending SIGKILL because we want to stop the process
+// immediatly and avoid that the signal is trapped.
+func (c *command) kill() error {
+	const sig syscall.Signal = syscall.SIGKILL
+
+	// No need to kill, command has not been executed yet or it already exited
+	if c.command == nil || (c.command.ProcessState != nil && c.command.ProcessState.Exited()) {
+		return nil
+	}
+
+	// Given that we set Setpgid, here we just need to send the PID of /bin/sh
+	// (which is the same PGID) as a negative number to syscall.Kill(). As a
+	// result, the signal will be received by all the processes with such PGID,
+	// in our case, the process of /bin/sh and c.cmd.
+	err := syscall.Kill(-c.command.Process.Pid, sig)
+	if err != nil {
+		return err
+	}
+
+	// In some cases, we do not have to wait here because the cmd was executed
+	// with Run(), which already waits. On the contrary, in the case it was
+	// executed with Start() thus c.started is true, we need to wait indeed.
+	if c.started {
+		err = c.command.Wait()
+		if err == nil {
+			return nil
+		}
+
+		// Verify if the error is about the signal we just sent. In that case,
+		// do not return error, it is what we were expecting.
+		var exiterr *exec.ExitError
+		if ok := errors.As(err, &exiterr); !ok {
+			return err
+		}
+
+		waitStatus, ok := exiterr.Sys().(syscall.WaitStatus)
+		if !ok {
+			return err
+		}
+
+		if waitStatus.Signal() != sig {
+			return err
+		}
+
+		return nil
+	}
+
+	return err
+}
+
+// runWithoutTest runs the command, this is thought to be used in TestMain().
+func (c *command) runWithoutTest() error {
+	c.createExecCmd()
+
+	fmt.Printf("Run command: %s\n", c.cmd)
+	err := c.command.Run()
+	fmt.Printf("Command returned:\n%s\n%s\n", c.stderr.String(), c.stdout.String())
+
+	if err != nil {
+		return err
+	}
+
+	return c.verifyOutput()
+}
+
+// startWithoutTest starts the command, this is thought to be used in TestMain().
+func (c *command) startWithoutTest() error {
+	if c.started {
+		fmt.Printf("Warn: trying to start a command but it is not running: %s\n", c.cmd)
+		return nil
+	}
+
+	c.createExecCmd()
+
+	fmt.Printf("Start command: %s\n", c.cmd)
+	err := c.command.Start()
+	if err != nil {
+		return err
+	}
+
+	c.started = true
+
+	return nil
+}
+
+// waitWithoutTest waits for a command that was started with startWithoutTest(),
+// this is thought to be used in TestMain().
+func (c *command) waitWithoutTest() error {
+	if !c.started {
+		fmt.Printf("Warn: trying to wait for a command that has not been started yet: %s\n", c.cmd)
+		return nil
+	}
+
+	fmt.Printf("Wait for command: %s\n", c.cmd)
+	err := c.command.Wait()
+	fmt.Printf("Command returned:\n%s\n%s\n", c.stderr.String(), c.stdout.String())
+
+	if err != nil {
+		return err
+	}
+
+	c.started = false
+
+	return nil
+}
+
+// killWithoutTest kills for a command that was started with startWithoutTest()
+// or runWithoutTest() and we do not need to verify its output. This is thought
+// to be used in TestMain().
+func (c *command) killWithoutTest() error {
+	fmt.Printf("Kill command(%s)\n", c.name)
+
+	if err := c.kill(); err != nil {
+		return fmt.Errorf("failed to kill command(%s): %w", c.name, err)
+	}
+
+	return nil
+}
+
 // run runs the command on the given as parameter test.
 func (c *command) run(t *testing.T) {
 	c.createExecCmd()
@@ -209,7 +344,6 @@ func (c *command) run(t *testing.T) {
 
 	t.Logf("Run command: %s\n", c.cmd)
 	err := c.command.Run()
-
 	t.Logf("Command returned:\n%s\n%s\n", c.stderr.String(), c.stdout.String())
 
 	if err != nil {
@@ -222,22 +356,6 @@ func (c *command) run(t *testing.T) {
 	}
 }
 
-// runWithoutTest runs the command, this is thought to be used in TestMain().
-func (c *command) runWithoutTest() error {
-	fmt.Printf("Run command: %s\n", c.cmd)
-
-	c.createExecCmd()
-	err := c.command.Run()
-
-	fmt.Printf("Command returned:\n%s\n%s\n", c.stderr.String(), c.stdout.String())
-
-	if err != nil {
-		return err
-	}
-
-	return c.verifyOutput()
-}
-
 // start starts the command on the given as parameter test, you need to
 // wait it using stop().
 func (c *command) start(t *testing.T) {
@@ -247,17 +365,6 @@ func (c *command) start(t *testing.T) {
 	}
 
 	t.Logf("Start command: %s\n", c.cmd)
-
-	// To be able to kill the process of /bin/sh and its child (the process of
-	// c.cmd), we need to send the termination signal to their process group ID
-	// (PGID). However, child processes get the same PGID as their parents by
-	// default, so in order to avoid killing also the integration tests process,
-	// we set the fields Setpgid and Pgid of syscall.SysProcAttr before
-	// executing /bin/sh. Doing so, the PGID of /bin/sh (and its children)
-	// will be set to its process ID, see:
-	// https://cs.opensource.google/go/go/+/refs/tags/go1.17.8:src/syscall/exec_linux.go;l=32-34.
-	c.command.SysProcAttr = &syscall.SysProcAttr{Setpgid: true, Pgid: 0}
-
 	err := c.command.Start()
 	if err != nil {
 		t.Fatal(err)
@@ -276,15 +383,10 @@ func (c *command) stop(t *testing.T) {
 		return
 	}
 
-	t.Logf("Stop command: %s\n", c.cmd)
-
-	// Here, we just need to send the PID of /bin/sh (which is the same PGID) as
-	// a negative number to syscall.Kill(). As a result, the signal will be
-	// received by all the processes with such PGID, in our case, the process of
-	// /bin/sh and c.cmd.
-	err := syscall.Kill(-c.command.Process.Pid, syscall.SIGTERM)
-
-	t.Logf("Command returned:\n%s\n%s\n", c.stderr.String(), c.stdout.String())
+	t.Logf("Stop command(%s)\n", c.name)
+	err := c.kill()
+	t.Logf("Command returned(%s):\n%s\n%s\n",
+		c.name, c.stderr.String(), c.stdout.String())
 
 	if err != nil {
 		t.Fatal(err)
@@ -342,16 +444,21 @@ func generateTestNamespaceName(namespace string) string {
 // createTestNamespaceCommand returns a command which creates a namespace whom
 // name is given as parameter.
 func createTestNamespaceCommand(namespace string) *command {
-	cmd := fmt.Sprintf(`
-	kubectl create ns %s && \
-	while true; do
-		kubectl -n %s get serviceaccount default
-		if [ $? -eq 0 ]; then
-			break
-		fi
-		sleep 1
-	done
-	`, namespace, namespace)
+	cmd := fmt.Sprintf(`kubectl apply -f - <<"EOF"
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: %s
+  labels: {"%s": "%s"}
+EOF
+while true; do
+  kubectl -n %s get serviceaccount default
+  if [ $? -eq 0 ]; then
+    break
+  fi
+  sleep 1
+done
+	`, namespace, namespaceLabelKey, namespaceLabelValue, namespace)
 
 	return &command{
 		name: "Create test namespace",
@@ -367,6 +474,17 @@ func deleteTestNamespaceCommand(namespace string) *command {
 		cmd:            fmt.Sprintf("kubectl delete ns %s", namespace),
 		expectedString: fmt.Sprintf("namespace \"%s\" deleted\n", namespace),
 		cleanup:        true,
+	}
+}
+
+// deleteRemainingNamespacesCommand returns a command which deletes a namespace whom
+// name is given as parameter.
+func deleteRemainingNamespacesCommand() *command {
+	return &command{
+		name: "Delete remaining test namespace",
+		cmd: fmt.Sprintf("kubectl delete ns -l %s=%s",
+			namespaceLabelKey, namespaceLabelValue),
+		cleanup: true,
 	}
 }
 

--- a/integration/command.go
+++ b/integration/command.go
@@ -70,13 +70,13 @@ type command struct {
 }
 
 var deployInspektorGadget *command = &command{
-	name:           "Deploy Inspektor Gadget",
+	name:           "DeployInspektorGadget",
 	cmd:            "$KUBECTL_GADGET deploy $GADGET_IMAGE_FLAG | kubectl apply -f -",
 	expectedRegexp: "gadget created",
 }
 
 var waitUntilInspektorGadgetPodsDeployed *command = &command{
-	name: "Wait until the gadget pods are started",
+	name: "WaitForGadgetPods",
 	cmd: `
 	for POD in $(sleep 5; kubectl get pod -n gadget -l k8s-app=gadget -o name) ; do
 		kubectl wait --timeout=30s -n gadget --for=condition=ready $POD
@@ -124,19 +124,19 @@ kubectl --namespace security-profiles-operator wait --for condition=ready pod -l
 
 func waitUntilInspektorGadgetPodsInitialized(initialDelay int) *command {
 	return &command{
-		name: "Wait until Inspektor Gadget is initialised",
+		name: "WaitForInspektorGadgetInit",
 		cmd:  fmt.Sprintf("sleep %d", initialDelay),
 	}
 }
 
 var cleanupInspektorGadget *command = &command{
-	name:    "cleanup gadget deployment",
+	name:    "CleanupInspektorGadget",
 	cmd:     "$KUBECTL_GADGET undeploy",
 	cleanup: true,
 }
 
 var cleanupSPO *command = &command{
-	name: "Remove Security Profiles Operator (SPO)",
+	name: "RemoveSecurityProfilesOperator",
 	cmd: `
 	kubectl delete seccompprofile -n security-profiles-operator --all
 	kubectl delete -f https://raw.githubusercontent.com/kubernetes-sigs/security-profiles-operator/v0.4.2/deploy/operator.yaml
@@ -268,30 +268,35 @@ func (c *command) kill() error {
 func (c *command) runWithoutTest() error {
 	c.createExecCmd()
 
-	fmt.Printf("Run command: %s\n", c.cmd)
+	fmt.Printf("Run command(%s):\n%s\n", c.name, c.cmd)
 	err := c.command.Run()
-	fmt.Printf("Command returned:\n%s\n%s\n", c.stderr.String(), c.stdout.String())
+	fmt.Printf("Command returned(%s):\n%s\n%s\n",
+		c.name, c.stderr.String(), c.stdout.String())
 
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to run command(%s): %w", c.name, err)
 	}
 
-	return c.verifyOutput()
+	if err = c.verifyOutput(); err != nil {
+		return fmt.Errorf("invalid command output(%s): %w", c.name, err)
+	}
+
+	return nil
 }
 
 // startWithoutTest starts the command, this is thought to be used in TestMain().
 func (c *command) startWithoutTest() error {
 	if c.started {
-		fmt.Printf("Warn: trying to start a command but it is not running: %s\n", c.cmd)
+		fmt.Printf("Warn(%s): trying to start command but it was already started\n", c.name)
 		return nil
 	}
 
 	c.createExecCmd()
 
-	fmt.Printf("Start command: %s\n", c.cmd)
+	fmt.Printf("Start command(%s): %s\n", c.name, c.cmd)
 	err := c.command.Start()
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to start command(%s): %w", c.name, err)
 	}
 
 	c.started = true
@@ -303,16 +308,17 @@ func (c *command) startWithoutTest() error {
 // this is thought to be used in TestMain().
 func (c *command) waitWithoutTest() error {
 	if !c.started {
-		fmt.Printf("Warn: trying to wait for a command that has not been started yet: %s\n", c.cmd)
+		fmt.Printf("Warn(%s): trying to wait for a command that has not been started yet\n", c.name)
 		return nil
 	}
 
-	fmt.Printf("Wait for command: %s\n", c.cmd)
+	fmt.Printf("Wait for command(%s)\n", c.name)
 	err := c.command.Wait()
-	fmt.Printf("Command returned:\n%s\n%s\n", c.stderr.String(), c.stdout.String())
+	fmt.Printf("Command returned(%s):\n%s\n%s\n",
+		c.name, c.stderr.String(), c.stdout.String())
 
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to wait for command(%s): %w", c.name, err)
 	}
 
 	c.started = false
@@ -342,17 +348,18 @@ func (c *command) run(t *testing.T) {
 		return
 	}
 
-	t.Logf("Run command: %s\n", c.cmd)
+	t.Logf("Run command(%s):\n%s\n", c.name, c.cmd)
 	err := c.command.Run()
-	t.Logf("Command returned:\n%s\n%s\n", c.stderr.String(), c.stdout.String())
+	t.Logf("Command returned(%s):\n%s\n%s\n",
+		c.name, c.stderr.String(), c.stdout.String())
 
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("failed to run command(%s): %s\n", c.name, err)
 	}
 
 	err = c.verifyOutput()
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("invalid command output(%s): %s\n", c.name, err)
 	}
 }
 
@@ -360,14 +367,14 @@ func (c *command) run(t *testing.T) {
 // wait it using stop().
 func (c *command) start(t *testing.T) {
 	if c.started {
-		t.Logf("Warn: trying to start command but it was already started: %s\n", c.cmd)
+		t.Logf("Warn(%s): trying to start command but it was already started\n", c.name)
 		return
 	}
 
-	t.Logf("Start command: %s\n", c.cmd)
+	t.Logf("Start command(%s): %s\n", c.name, c.cmd)
 	err := c.command.Start()
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("failed to start command(%s): %s\n", c.name, err)
 	}
 
 	c.started = true
@@ -379,7 +386,7 @@ func (c *command) start(t *testing.T) {
 // Cmd output is then checked with regard to expectedString and expectedRegexp
 func (c *command) stop(t *testing.T) {
 	if !c.started {
-		t.Logf("Warn: trying to stop command but it was not started: %s\n", c.cmd)
+		t.Logf("Warn(%s): trying to stop command but it was not started\n", c.name)
 		return
 	}
 
@@ -389,12 +396,12 @@ func (c *command) stop(t *testing.T) {
 		c.name, c.stderr.String(), c.stdout.String())
 
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("failed to stop command(%s): %s\n", c.name, err)
 	}
 
 	err = c.verifyOutput()
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("invalid command output(%s): %s\n", c.name, err)
 	}
 
 	c.started = false
@@ -428,7 +435,7 @@ EOF
 `, namespace, cmd)
 
 	return &command{
-		name:           "Run test-pod",
+		name:           "RunTestPod",
 		cmd:            cmdStr,
 		expectedString: "pod/test-pod created\n",
 	}
@@ -470,7 +477,7 @@ done
 // name is given as parameter.
 func deleteTestNamespaceCommand(namespace string) *command {
 	return &command{
-		name:           "Delete test namespace",
+		name:           "DeleteTestNamespace",
 		cmd:            fmt.Sprintf("kubectl delete ns %s", namespace),
 		expectedString: fmt.Sprintf("namespace \"%s\" deleted\n", namespace),
 		cleanup:        true,
@@ -481,7 +488,7 @@ func deleteTestNamespaceCommand(namespace string) *command {
 // name is given as parameter.
 func deleteRemainingNamespacesCommand() *command {
 	return &command{
-		name: "Delete remaining test namespace",
+		name: "DeleteRemainingTestNamespace",
 		cmd: fmt.Sprintf("kubectl delete ns -l %s=%s",
 			namespaceLabelKey, namespaceLabelValue),
 		cleanup: true,
@@ -492,7 +499,7 @@ func deleteRemainingNamespacesCommand() *command {
 // the given as parameter namespace is ready.
 func waitUntilTestPodReadyCommand(namespace string) *command {
 	return &command{
-		name:           "Wait until test pod ready",
+		name:           "WaitForTestPod",
 		cmd:            fmt.Sprintf("kubectl wait pod --for condition=ready -n %s test-pod", namespace),
 		expectedString: "pod/test-pod condition met\n",
 	}

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -99,14 +99,14 @@ func cleanupFunc(cleanupCommands []*command) {
 	for _, cmd := range cleanupCommands {
 		err := cmd.startWithoutTest()
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "%s: Error: %s\n", cmd.name, err)
+			fmt.Fprintf(os.Stderr, "%s\n", err)
 		}
 	}
 
 	for _, cmd := range cleanupCommands {
 		err := cmd.waitWithoutTest()
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "%s: Error: %s\n", cmd.name, err)
+			fmt.Fprintf(os.Stderr, "%s\n", err)
 		}
 	}
 }
@@ -207,11 +207,11 @@ func testMain(m *testing.M) int {
 				// Start by stopping the init commands (in the case they are
 				// still running) to avoid trying to undeploy resources that are
 				// being deployed.
-				fmt.Println("Stop possible ongoing operations...")
+				fmt.Println("Stop init commands (if they are still running)...")
 				for _, cmd := range initCommands {
 					err := cmd.killWithoutTest()
 					if err != nil {
-						fmt.Fprintf(os.Stderr, "%s: Error: %s\n", cmd.name, err)
+						fmt.Fprintf(os.Stderr, "%s\n", err)
 					}
 				}
 
@@ -236,7 +236,7 @@ func testMain(m *testing.M) int {
 
 		err := cmd.runWithoutTest()
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "%s: Error: %s\n", cmd.name, err)
+			fmt.Fprintf(os.Stderr, "%s\n", err)
 			initDone = false
 			break
 		}
@@ -258,7 +258,7 @@ func testMain(m *testing.M) int {
 		return 1
 	}
 
-	fmt.Printf("Start running tests:\n")
+	fmt.Println("Start running tests:")
 	return m.Run()
 }
 
@@ -278,7 +278,7 @@ func TestAuditSeccomp(t *testing.T) {
 	commands := []*command{
 		createTestNamespaceCommand(ns),
 		{
-			name: "Create SeccompProfile",
+			name: "CreateSeccompProfile",
 			cmd: fmt.Sprintf(`
 				kubectl apply -f - <<EOF
 apiVersion: security-profiles-operator.x-k8s.io/v1beta1
@@ -304,7 +304,7 @@ EOF
 			expectedRegexp: "seccompprofile.security-profiles-operator.x-k8s.io/log created",
 		},
 		{
-			name: "Run test pod",
+			name: "RunSeccompAuditTestPod",
 			cmd: fmt.Sprintf(`
 				kubectl apply -f - <<EOF
 apiVersion: v1
@@ -329,7 +329,7 @@ EOF
 		},
 		waitUntilTestPodReadyCommand(ns),
 		{
-			name:           "Run audit-seccomp gadget",
+			name:           "RunAuditSeccompGadget",
 			cmd:            fmt.Sprintf("$KUBECTL_GADGET audit seccomp -n %s & sleep 5; kill $!", ns),
 			expectedRegexp: fmt.Sprintf(`%s\s+test-pod\s+container1\s+unshare\s+\d+\s+unshare\s+kill_thread`, ns),
 		},
@@ -345,7 +345,7 @@ func TestBindsnoop(t *testing.T) {
 	t.Parallel()
 
 	bindsnoopCmd := &command{
-		name:           "Start bindsnoop gadget",
+		name:           "StartBindsnoopGadget",
 		cmd:            fmt.Sprintf("$KUBECTL_GADGET trace bind -n %s", ns),
 		expectedRegexp: fmt.Sprintf(`%s\s+test-pod\s+test-pod\s+\d+\s+nc`, ns),
 		startAndStop:   true,
@@ -371,7 +371,7 @@ func TestBiolatency(t *testing.T) {
 
 	commands := []*command{
 		{
-			name:           "Run biolatency gadget",
+			name:           "RunBiolatencyGadget",
 			cmd:            "$KUBECTL_GADGET profile block-io --node $(kubectl get node --no-headers | cut -d' ' -f1 | head -1) --timeout 15",
 			expectedRegexp: `usecs\s+:\s+count\s+distribution`,
 		},
@@ -390,7 +390,7 @@ func TestBiotop(t *testing.T) {
 	t.Parallel()
 
 	biotopCmd := &command{
-		name:           "Start biotop gadget",
+		name:           "StartBiotopGadget",
 		cmd:            fmt.Sprintf("$KUBECTL_GADGET top block-io -n %s", ns),
 		expectedRegexp: `test-pod\s+test-pod\s+\d+\s+dd`,
 		startAndStop:   true,
@@ -417,7 +417,7 @@ func TestCapabilities(t *testing.T) {
 	t.Parallel()
 
 	capabilitiesCmd := &command{
-		name:           "Start capabilities gadget",
+		name:           "StartCapabilitiesGadget",
 		cmd:            fmt.Sprintf("$KUBECTL_GADGET trace capabilities -n %s", ns),
 		expectedRegexp: fmt.Sprintf(`%s\s+test-pod.*nice.*CAP_SYS_NICE`, ns),
 		startAndStop:   true,
@@ -440,7 +440,7 @@ func TestDns(t *testing.T) {
 	t.Parallel()
 
 	dnsCmd := &command{
-		name:           "Start dns gadget",
+		name:           "StartDnsGadget",
 		cmd:            fmt.Sprintf("$KUBECTL_GADGET trace dns -n %s", ns),
 		expectedRegexp: `test-pod\s+OUTGOING\s+A\s+microsoft.com`,
 		startAndStop:   true,
@@ -463,7 +463,7 @@ func TestExecsnoop(t *testing.T) {
 	t.Parallel()
 
 	execsnoopCmd := &command{
-		name:           "Start execsnoop gadget",
+		name:           "StartExecsnoopGadget",
 		cmd:            fmt.Sprintf("$KUBECTL_GADGET trace exec -n %s", ns),
 		expectedRegexp: fmt.Sprintf(`%s\s+test-pod\s+test-pod\s+date`, ns),
 		startAndStop:   true,
@@ -486,7 +486,7 @@ func TestFiletop(t *testing.T) {
 	t.Parallel()
 
 	filetopCmd := &command{
-		name:           "Start filetop gadget",
+		name:           "StartFiletopGadget",
 		cmd:            fmt.Sprintf("$KUBECTL_GADGET top file -n %s", ns),
 		expectedRegexp: fmt.Sprintf(`%s\s+test-pod\s+test-pod\s+\d+\s+\S*\s+0\s+\d+\s+0\s+\d+\s+R\s+date`, ns),
 		startAndStop:   true,
@@ -514,7 +514,7 @@ func TestFsslower(t *testing.T) {
 	t.Parallel()
 
 	fsslowerCmd := &command{
-		name:           "Start fsslower gadget",
+		name:           "StartFsslowerGadget",
 		cmd:            fmt.Sprintf("$KUBECTL_GADGET trace fsslower -n %s -t %s -m 0", ns, fsType),
 		expectedRegexp: fmt.Sprintf(`%s\s+test-pod\s+test-pod\s+cat`, ns),
 		startAndStop:   true,
@@ -537,7 +537,7 @@ func TestMountsnoop(t *testing.T) {
 	t.Parallel()
 
 	mountsnoopCmd := &command{
-		name:           "Start mountsnoop gadget",
+		name:           "StartMountsnoopGadget",
 		cmd:            fmt.Sprintf("$KUBECTL_GADGET trace mount -n %s", ns),
 		expectedRegexp: `test-pod\s+test-pod\s+mount.*mount\("/mnt", "/mnt", .*\) = -2`,
 		startAndStop:   true,
@@ -564,7 +564,7 @@ func TestNetworkpolicy(t *testing.T) {
 		busyboxPodRepeatCommand(ns, "wget -q -O /dev/null https://kinvolk.io"),
 		waitUntilTestPodReadyCommand(ns),
 		{
-			name:           "Run network-policy gadget",
+			name:           "RunNetworkPolicyGadget",
 			cmd:            fmt.Sprintf("$KUBECTL_GADGET advise network-policy monitor -n %s --output ./networktrace.log & sleep 15; kill $!; head networktrace.log", ns),
 			expectedRegexp: fmt.Sprintf(`"type":"connect".*"%s".*"test-pod"`, ns),
 		},
@@ -580,7 +580,7 @@ func TestOomkill(t *testing.T) {
 	t.Parallel()
 
 	oomkillCmd := &command{
-		name:           "Start oomkill gadget",
+		name:           "StarOomkilGadget",
 		cmd:            fmt.Sprintf("$KUBECTL_GADGET trace oomkill -n %s", ns),
 		expectedRegexp: `\d+\s+tail`,
 		startAndStop:   true,
@@ -608,7 +608,7 @@ spec:
 		createTestNamespaceCommand(ns),
 		oomkillCmd,
 		{
-			name:           "Run pod which exhaust memory with memory limits",
+			name:           "RunOomkillTestPod",
 			cmd:            fmt.Sprintf("echo '%s' | kubectl apply -f -", limitPodYaml),
 			expectedRegexp: "pod/test-pod created",
 		},
@@ -625,7 +625,7 @@ func TestOpensnoop(t *testing.T) {
 	t.Parallel()
 
 	opensnoopCmd := &command{
-		name:           "Start opensnoop gadget",
+		name:           "StartOpensnoopGadget",
 		cmd:            fmt.Sprintf("$KUBECTL_GADGET trace open -n %s", ns),
 		expectedRegexp: fmt.Sprintf(`%s\s+test-pod\s+test-pod\s+\d+\s+whoami\s+3`, ns),
 		startAndStop:   true,
@@ -656,7 +656,7 @@ func TestProcessCollector(t *testing.T) {
 		busyboxPodCommand(ns, "nc -l -p 9090"),
 		waitUntilTestPodReadyCommand(ns),
 		{
-			name:           "Run process-collector gadget",
+			name:           "RunPprocessCollectorGadget",
 			cmd:            fmt.Sprintf("$KUBECTL_GADGET snapshot process -n %s", ns),
 			expectedRegexp: fmt.Sprintf(`%s\s+test-pod\s+test-pod\s+nc\s+\d+`, ns),
 		},
@@ -680,7 +680,7 @@ func TestProfile(t *testing.T) {
 		busyboxPodCommand(ns, "while true; do echo foo > /dev/null; done"),
 		waitUntilTestPodReadyCommand(ns),
 		{
-			name:           "Run profile gadget",
+			name:           "RunProfileGadget",
 			cmd:            fmt.Sprintf("$KUBECTL_GADGET profile cpu -n %s -p test-pod -K --timeout 15", ns),
 			expectedRegexp: `sh;\w+;\w+;\w+open`, // echo is builtin.
 		},
@@ -700,7 +700,7 @@ func TestSeccompadvisor(t *testing.T) {
 		busyboxPodRepeatCommand(ns, "echo foo"),
 		waitUntilTestPodReadyCommand(ns),
 		{
-			name:           "Run seccomp-advisor gadget",
+			name:           "RunSeccompAdvisorGadget",
 			cmd:            fmt.Sprintf("id=$($KUBECTL_GADGET advise seccomp-profile start -n %s -p test-pod); sleep 30; $KUBECTL_GADGET advise seccomp-profile stop $id", ns),
 			expectedRegexp: `write`,
 		},
@@ -716,7 +716,7 @@ func TestSigsnoop(t *testing.T) {
 	t.Parallel()
 
 	sigsnoopCmd := &command{
-		name:           "Start sigsnoop gadget",
+		name:           "StartSigsnoopGadget",
 		cmd:            fmt.Sprintf("$KUBECTL_GADGET trace signal -n %s", ns),
 		expectedRegexp: fmt.Sprintf(`%s\s+test-pod\s+test-pod\s+\d+\s+sh\s+SIGTERM`, ns),
 		startAndStop:   true,
@@ -739,7 +739,7 @@ func TestSnisnoop(t *testing.T) {
 	t.Parallel()
 
 	snisnoopCmd := &command{
-		name:           "Start snisnoop gadget",
+		name:           "StartSnisnoopGadget",
 		cmd:            fmt.Sprintf("$KUBECTL_GADGET trace sni -n %s", ns),
 		expectedRegexp: `test-pod\s+kinvolk.io`,
 		startAndStop:   true,
@@ -770,7 +770,7 @@ func TestSocketCollector(t *testing.T) {
 		busyboxPodCommand(ns, "nc -l 0.0.0.0 -p 9090"),
 		waitUntilTestPodReadyCommand(ns),
 		{
-			name:           "Run socket-collector gadget",
+			name:           "RunSocketCollectorGadget",
 			cmd:            fmt.Sprintf("$KUBECTL_GADGET snapshot socket -n %s", ns),
 			expectedRegexp: fmt.Sprintf(`%s\s+test-pod\s+TCP\s+0\.0\.0\.0`, ns),
 		},
@@ -786,7 +786,7 @@ func TestTcpconnect(t *testing.T) {
 	t.Parallel()
 
 	tcpconnectCmd := &command{
-		name:           "Start tcpconnect gadget",
+		name:           "StartTcpconnectGadget",
 		cmd:            fmt.Sprintf("$KUBECTL_GADGET trace tcpconnect -n %s", ns),
 		expectedRegexp: fmt.Sprintf(`%s\s+test-pod\s+test-pod\s+\d+\s+wget`, ns),
 		startAndStop:   true,
@@ -813,7 +813,7 @@ func TestTcptracer(t *testing.T) {
 	t.Parallel()
 
 	tcptracerCmd := &command{
-		name:           "Start tcptracer gadget",
+		name:           "StartTcptracerGadget",
 		cmd:            fmt.Sprintf("$KUBECTL_GADGET trace tcp -n %s", ns),
 		expectedRegexp: `C\s+\d+\s+wget\s+\d\s+[\w\.:]+\s+1\.1\.1\.1\s+\d+\s+80`,
 		startAndStop:   true,
@@ -836,7 +836,7 @@ func TestTcptop(t *testing.T) {
 	t.Parallel()
 
 	tcptopCmd := &command{
-		name:           "Start tcptop gadget",
+		name:           "StartTcptopGadget",
 		cmd:            fmt.Sprintf("$KUBECTL_GADGET top tcp -n %s", ns),
 		expectedRegexp: `wget`,
 		startAndStop:   true,
@@ -861,44 +861,44 @@ func TestTraceloop(t *testing.T) {
 	commands := []*command{
 		createTestNamespaceCommand(ns),
 		{
-			name: "Start the traceloop gadget",
+			name: "StartTraceloopGadget",
 			cmd:  "$KUBECTL_GADGET traceloop start",
 		},
 		{
-			name: "Wait traceloop to be started",
+			name: "WaitForTraceloopStarted",
 			cmd:  "sleep 15",
 		},
 		{
-			name: "Run multiplication pod",
+			name: "RunTraceloopTestPod",
 			cmd:  fmt.Sprintf("kubectl run --restart=Never -n %s --image=busybox multiplication -- sh -c 'RANDOM=output ; echo \"3*7*2\" | bc > /tmp/file-$RANDOM ; sleep infinity'", ns),
 		},
 		{
-			name: "Wait until multiplication pod is ready",
+			name: "WaitForTraceloopTestPod",
 			cmd:  fmt.Sprintf("sleep 5 ; kubectl wait -n %s --for=condition=ready pod/multiplication ; kubectl get pod -n %s ; sleep 2", ns, ns),
 		},
 		{
-			name:           "Check traceloop list",
+			name:           "CheckTraceloopList",
 			cmd:            fmt.Sprintf("sleep 20 ; $KUBECTL_GADGET traceloop list -n %s --no-headers | grep multiplication | awk '{print $1\" \"$6}'", ns),
 			expectedString: "multiplication started\n",
 		},
 		{
-			name:           "Check traceloop show",
+			name:           "CheckTraceloopShow",
 			cmd:            fmt.Sprintf(`TRACE_ID=$($KUBECTL_GADGET traceloop list -n %s --no-headers | `, ns) + `grep multiplication | awk '{printf "%s", $4}') ; $KUBECTL_GADGET traceloop show $TRACE_ID | grep -C 5 write`,
 			expectedRegexp: "\\[bc\\] write\\(1, \"42\\\\n\", 3\\)",
 		},
 		{
-			name:    "traceloop list",
+			name:    "PrintTraceloopList",
 			cmd:     "$KUBECTL_GADGET traceloop list -A",
 			cleanup: true,
 		},
 		{
-			name:           "Stop the traceloop gadget",
+			name:           "StopTraceloopGadget",
 			cmd:            "$KUBECTL_GADGET traceloop stop",
 			expectedString: "",
 			cleanup:        true,
 		},
 		{
-			name:    "Wait until traceloop is stopped",
+			name:    "WaitForTraceloopStopped",
 			cmd:     "sleep 15",
 			cleanup: true,
 		},


### PR DESCRIPTION
# Clean up resources when the workflow run is cancelled

Fixes: https://github.com/kinvolk/inspektor-gadget/issues/641 

Based on the [GitHub documentation](https://docs.github.com/en/actions/managing-workflow-runs/canceling-a-workflow#steps-github-takes-to-cancel-a-workflow-run), this is the proposed solution:

1. Capture the `SIGINT` sent from bash on runner: [here](https://github.com/kinvolk/inspektor-gadget/blob/b47a55db25c1f976e9ac73200e34034512737b58/.github/actions/run-integration-tests/action.yml#L58-L63).
2. Notify the container that the workflow run is being cancelled, [here](https://github.com/kinvolk/inspektor-gadget/blob/b47a55db25c1f976e9ac73200e34034512737b58/.github/actions/run-integration-tests/action.yml#L41-L56). Notice that it is done only when the `SIGINT` is received. For `SIGTERM`, we just capture the signal so that we have that additional 2.5s to finish the cleanup.
3. The integration-tests binary captures the signal [here](https://github.com/kinvolk/inspektor-gadget/blob/b47a55db25c1f976e9ac73200e34034512737b58/integration/integration_test.go#L183-L189) and starts the cleanup procedure (see [here](https://github.com/kinvolk/inspektor-gadget/blob/b47a55db25c1f976e9ac73200e34034512737b58/integration/integration_test.go#L199-L215)):
    a. First, it kills the init commands (in case they are still running).
    b. Wait until the init commands to finish (in case they are still running) so that we do not start undeploying things that are being deployed.
    c. Run the cleanup commands: Remove the possible remaining namespaces, undeploy IG and SPO.

Given that we are not stopping the ongoing tests, there is still the possibility that the tests continue running and it creates the test namespace after we try to delete all the remaining namespaces. This will be managed in another PR.
 

## How to use

There are two options:

- As described in the issue, force-pushing a commit while it is running the integration tests or manually cancelling it on the Actions section of the repo. 
- The other option is to execute the integration-tests locally and hit Ctrl+C.

## Testing done

Check resources are cleaned up when:
- Integration tests are executed successfully
- One of the init commands fails 
- Cancel request (Ctrl+C) arrives when the init commands are being executed
- Cancel request (Ctrl+C) arrives when running the integration tests themselves

I also tested the case when two cancel requests (Ctrl+C) are sent. It is useful when running the integration-tests locally. Of course, in this case, it is not guarantee that the resources will be correctly cleaned up.
