### PR TITLE
local-gadget: Do not pin maps

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/kinvolk/inspektor-gadget
 
 require (
 	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e
-	github.com/cilium/ebpf v0.8.2-0.20220329140945-23f447c3cb0c
+	github.com/cilium/ebpf v0.8.2-0.20220502122259-96aa1a7a929f
 	github.com/containerd/containerd v1.5.11 // indirect
 	github.com/containerd/nri v0.1.1-0.20210619071632-28f76457b672
 	github.com/containers/common v0.46.0
@@ -10,6 +10,7 @@ require (
 	github.com/docker/docker v20.10.8+incompatible
 	github.com/docker/go-units v0.4.0
 	github.com/giantswarm/crd-docs-generator v0.7.1
+	github.com/google/uuid v1.2.0 // indirect
 	github.com/iovisor/gobpf v0.2.0 // indirect
 	github.com/kinvolk/traceloop v0.0.0-20210623155108-6f4efc6fca46
 	github.com/kr/pretty v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -191,6 +191,8 @@ github.com/cilium/ebpf v0.4.0/go.mod h1:4tRaxcgiL706VnOzHOdBlY8IEAIdxINsQBcU4xJJ
 github.com/cilium/ebpf v0.6.2/go.mod h1:4tRaxcgiL706VnOzHOdBlY8IEAIdxINsQBcU4xJJXRs=
 github.com/cilium/ebpf v0.8.2-0.20220329140945-23f447c3cb0c h1:eA5PLaUAWdnThvVxM4ix0GuMHotHTQ3XdOmPzvGyEpo=
 github.com/cilium/ebpf v0.8.2-0.20220329140945-23f447c3cb0c/go.mod h1:f5zLIM0FSNuAkSyLAN7X+Hy6yznlF1mNiWUMfxMtrgk=
+github.com/cilium/ebpf v0.8.2-0.20220502122259-96aa1a7a929f h1:6s/s6X7MyRPonDp/GFzpmUzwL7vY1yeAr7eajLDxwA4=
+github.com/cilium/ebpf v0.8.2-0.20220502122259-96aa1a7a929f/go.mod h1:+OhNOIXx/Fnu1IE8bJz2dzOA+VSfyTfdNUVdlQnxUFY=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=

--- a/pkg/gadgets/bindsnoop/gadget.go
+++ b/pkg/gadgets/bindsnoop/gadget.go
@@ -147,8 +147,13 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 
 	var err error
 
+	mountNsMap, err := t.resolver.TracerMountNsMap(traceName)
+	if err != nil {
+		trace.Status.OperationError = fmt.Sprintf("failed to find tracer's mount ns map: %s", err)
+		return
+	}
 	config := &tracer.Config{
-		MountnsMap:   gadgets.TracePinPath(trace.ObjectMeta.Namespace, trace.ObjectMeta.Name),
+		MountnsMap:   mountNsMap,
 		TargetPid:    targetPid,
 		TargetPorts:  targetPorts,
 		IgnoreErrors: ignoreErrors,

--- a/pkg/gadgets/bindsnoop/tracer/interface.go
+++ b/pkg/gadgets/bindsnoop/tracer/interface.go
@@ -14,16 +14,14 @@
 
 package tracer
 
+import "github.com/cilium/ebpf"
+
 type Tracer interface {
 	Stop()
 }
 
 type Config struct {
-	// TODO: Make it a *ebpf.Map once
-	// https://github.com/cilium/ebpf/issues/515 and
-	// https://github.com/cilium/ebpf/issues/517 are fixed
-	MountnsMap string
-
+	MountnsMap   *ebpf.Map
 	TargetPid    int32
 	TargetPorts  []uint16
 	IgnoreErrors bool

--- a/pkg/gadgets/bindsnoop/tracer/standard/tracer.go
+++ b/pkg/gadgets/bindsnoop/tracer/standard/tracer.go
@@ -48,10 +48,9 @@ func NewTracer(config *tracer.Config, resolver containercollection.ContainerReso
 		eventCallback(event)
 	}
 
-	baseTracer, err := gadgets.NewStandardTracer(lineCallback,
+	baseTracer, err := gadgets.NewStandardTracer(lineCallback, config.MountnsMap,
 		"/usr/share/bcc/tools/bindsnoop",
-		"--json", "--mntnsmap", config.MountnsMap,
-		"--containersmap", "/sys/fs/bpf/gadget/containers")
+		"--json", "--containersmap", "/sys/fs/bpf/gadget/containers")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/gadgets/biotop/gadget.go
+++ b/pkg/gadgets/biotop/gadget.go
@@ -136,11 +136,16 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 		}
 	}
 
+	mountNsMap, err := t.resolver.TracerMountNsMap(traceName)
+	if err != nil {
+		trace.Status.OperationError = fmt.Sprintf("failed to find tracer's mount ns map: %s", err)
+		return
+	}
 	config := &biotoptracer.Config{
 		MaxRows:    maxRows,
 		Interval:   time.Second * time.Duration(intervalSeconds),
 		SortBy:     sortBy,
-		MountnsMap: gadgets.TracePinPath(trace.ObjectMeta.Namespace, trace.ObjectMeta.Name),
+		MountnsMap: mountNsMap,
 		Node:       trace.Spec.Node,
 	}
 

--- a/pkg/gadgets/biotop/tracer/tracer.go
+++ b/pkg/gadgets/biotop/tracer/tracer.go
@@ -22,7 +22,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 	"time"
 	"unsafe"
@@ -42,14 +41,11 @@ import "C"
 //go:generate sh -c "GOOS=$(go env GOHOSTOS) GOARCH=$(go env GOHOSTARCH) go run github.com/cilium/ebpf/cmd/bpf2go -target bpfel -cc clang biotop ./bpf/biotop.bpf.c -- -I./bpf/ -I../../.. -target bpf -D__TARGET_ARCH_x86"
 
 type Config struct {
-	TargetPid int
-	MaxRows   int
-	Interval  time.Duration
-	SortBy    types.SortBy
-	// TODO: Make it a *ebpf.Map once
-	// https://github.com/cilium/ebpf/issues/515 and
-	// https://github.com/cilium/ebpf/issues/517 are fixed
-	MountnsMap string
+	TargetPid  int
+	MaxRows    int
+	Interval   time.Duration
+	SortBy     types.SortBy
+	MountnsMap *ebpf.Map
 	Node       string
 }
 
@@ -141,13 +137,12 @@ func (t *Tracer) start() error {
 		return fmt.Errorf("failed to load ebpf program: %w", err)
 	}
 
+	mapReplacements := map[string]*ebpf.Map{}
 	filterByMntNs := false
 
-	if t.config.MountnsMap != "" {
+	if t.config.MountnsMap != nil {
 		filterByMntNs = true
-		m := spec.Maps["mount_ns_set"]
-		m.Pinning = ebpf.PinByName
-		m.Name = filepath.Base(t.config.MountnsMap)
+		mapReplacements["mount_ns_set"] = t.config.MountnsMap
 	}
 
 	consts := map[string]interface{}{
@@ -159,9 +154,7 @@ func (t *Tracer) start() error {
 	}
 
 	opts := ebpf.CollectionOptions{
-		Maps: ebpf.MapOptions{
-			PinPath: filepath.Dir(t.config.MountnsMap),
-		},
+		MapReplacements: mapReplacements,
 	}
 
 	if err := spec.LoadAndAssign(&t.objs, &opts); err != nil {

--- a/pkg/gadgets/capabilities/gadget.go
+++ b/pkg/gadgets/capabilities/gadget.go
@@ -106,8 +106,13 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 
 	var err error
 
+	mountNsMap, err := t.resolver.TracerMountNsMap(traceName)
+	if err != nil {
+		trace.Status.OperationError = fmt.Sprintf("failed to find tracer's mount ns map: %s", err)
+		return
+	}
 	config := &tracer.Config{
-		MountnsMap: gadgets.TracePinPath(trace.ObjectMeta.Namespace, trace.ObjectMeta.Name),
+		MountnsMap: mountNsMap,
 	}
 
 	t.tracer, err = coretracer.NewTracer(config, t.resolver, eventCallback, trace.Spec.Node)

--- a/pkg/gadgets/capabilities/tracer/core/tracer.go
+++ b/pkg/gadgets/capabilities/tracer/core/tracer.go
@@ -25,7 +25,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path/filepath"
 	"strconv"
 	"unsafe"
 
@@ -130,13 +129,12 @@ func (t *Tracer) start() error {
 		return fmt.Errorf("failed to load ebpf program: %w", err)
 	}
 
+	mapReplacements := map[string]*ebpf.Map{}
 	filterByMntNs := false
 
-	if t.config.MountnsMap != "" {
+	if t.config.MountnsMap != nil {
 		filterByMntNs = true
-		m := spec.Maps["mount_ns_set"]
-		m.Pinning = ebpf.PinByName
-		m.Name = filepath.Base(t.config.MountnsMap)
+		mapReplacements["mount_ns_set"] = t.config.MountnsMap
 	}
 
 	consts := map[string]interface{}{
@@ -148,9 +146,7 @@ func (t *Tracer) start() error {
 	}
 
 	opts := ebpf.CollectionOptions{
-		Maps: ebpf.MapOptions{
-			PinPath: filepath.Dir(t.config.MountnsMap),
-		},
+		MapReplacements: mapReplacements,
 	}
 
 	if err := spec.LoadAndAssign(&t.objs, &opts); err != nil {

--- a/pkg/gadgets/capabilities/tracer/interface.go
+++ b/pkg/gadgets/capabilities/tracer/interface.go
@@ -14,13 +14,12 @@
 
 package tracer
 
+import "github.com/cilium/ebpf"
+
 type Tracer interface {
 	Stop()
 }
 
 type Config struct {
-	// TODO: Make it a *ebpf.Map once
-	// https://github.com/cilium/ebpf/issues/515 and
-	// https://github.com/cilium/ebpf/issues/517 are fixed
-	MountnsMap string
+	MountnsMap *ebpf.Map
 }

--- a/pkg/gadgets/capabilities/tracer/standard/tracer.go
+++ b/pkg/gadgets/capabilities/tracer/standard/tracer.go
@@ -49,10 +49,9 @@ func NewTracer(config *tracer.Config, resolver containercollection.ContainerReso
 		eventCallback(event)
 	}
 
-	baseTracer, err := gadgets.NewStandardTracer(lineCallback,
+	baseTracer, err := gadgets.NewStandardTracer(lineCallback, config.MountnsMap,
 		"/usr/share/bcc/tools/capable",
-		"--json", "--mntnsmap", config.MountnsMap,
-		"--containersmap", "/sys/fs/bpf/gadget/containers")
+		"--json", "--containersmap", "/sys/fs/bpf/gadget/containers")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/gadgets/execsnoop/gadget.go
+++ b/pkg/gadgets/execsnoop/gadget.go
@@ -106,8 +106,13 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 
 	var err error
 
+	mountNsMap, err := t.resolver.TracerMountNsMap(traceName)
+	if err != nil {
+		trace.Status.OperationError = fmt.Sprintf("failed to find tracer's mount ns map: %s", err)
+		return
+	}
 	config := &tracer.Config{
-		MountnsMap: gadgets.TracePinPath(trace.ObjectMeta.Namespace, trace.ObjectMeta.Name),
+		MountnsMap: mountNsMap,
 	}
 	t.tracer, err = coretracer.NewTracer(config, t.resolver, eventCallback, trace.Spec.Node)
 	if err != nil {

--- a/pkg/gadgets/execsnoop/tracer/core/tracer.go
+++ b/pkg/gadgets/execsnoop/tracer/core/tracer.go
@@ -25,7 +25,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path/filepath"
 	"unsafe"
 
 	"github.com/cilium/ebpf"
@@ -87,13 +86,12 @@ func (t *Tracer) start() error {
 		return fmt.Errorf("failed to load ebpf program: %w", err)
 	}
 
+	mapReplacements := map[string]*ebpf.Map{}
 	filterByMntNs := false
 
-	if t.config.MountnsMap != "" {
+	if t.config.MountnsMap != nil {
 		filterByMntNs = true
-		m := spec.Maps["mount_ns_set"]
-		m.Pinning = ebpf.PinByName
-		m.Name = filepath.Base(t.config.MountnsMap)
+		mapReplacements["mount_ns_set"] = t.config.MountnsMap
 	}
 
 	consts := map[string]interface{}{
@@ -105,9 +103,7 @@ func (t *Tracer) start() error {
 	}
 
 	opts := ebpf.CollectionOptions{
-		Maps: ebpf.MapOptions{
-			PinPath: filepath.Dir(t.config.MountnsMap),
-		},
+		MapReplacements: mapReplacements,
 	}
 
 	if err := spec.LoadAndAssign(&t.objs, &opts); err != nil {

--- a/pkg/gadgets/execsnoop/tracer/interface.go
+++ b/pkg/gadgets/execsnoop/tracer/interface.go
@@ -14,13 +14,12 @@
 
 package tracer
 
+import "github.com/cilium/ebpf"
+
 type Tracer interface {
 	Stop()
 }
 
 type Config struct {
-	// TODO: Make it a *ebpf.Map once
-	// https://github.com/cilium/ebpf/issues/515 and
-	// https://github.com/cilium/ebpf/issues/517 are fixed
-	MountnsMap string
+	MountnsMap *ebpf.Map
 }

--- a/pkg/gadgets/execsnoop/tracer/standard/tracer.go
+++ b/pkg/gadgets/execsnoop/tracer/standard/tracer.go
@@ -50,10 +50,9 @@ func NewTracer(config *tracer.Config, resolver containercollection.ContainerReso
 		eventCallback(event)
 	}
 
-	baseTracer, err := gadgets.NewStandardTracer(lineCallback,
+	baseTracer, err := gadgets.NewStandardTracer(lineCallback, config.MountnsMap,
 		"/usr/share/bcc/tools/execsnoop",
-		"--json", "--mntnsmap", config.MountnsMap,
-		"--containersmap", "/sys/fs/bpf/gadget/containers")
+		"--json", "--containersmap", "/sys/fs/bpf/gadget/containers")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/gadgets/filetop/gadget.go
+++ b/pkg/gadgets/filetop/gadget.go
@@ -147,12 +147,18 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 		}
 	}
 
+	mountNsMap, err := t.resolver.TracerMountNsMap(traceName)
+	if err != nil {
+		trace.Status.OperationError = fmt.Sprintf("failed to find tracer's mount ns map: %s", err)
+		return
+	}
+
 	config := &filetoptracer.Config{
 		AllFiles:   allFiles,
 		MaxRows:    maxRows,
 		Interval:   time.Second * time.Duration(intervalSeconds),
 		SortBy:     sortBy,
-		MountnsMap: gadgets.TracePinPath(trace.ObjectMeta.Namespace, trace.ObjectMeta.Name),
+		MountnsMap: mountNsMap,
 		Node:       trace.Spec.Node,
 	}
 

--- a/pkg/gadgets/filetop/tracer/tracer.go
+++ b/pkg/gadgets/filetop/tracer/tracer.go
@@ -20,7 +20,6 @@ package tracer
 import (
 	"errors"
 	"fmt"
-	"path/filepath"
 	"time"
 	"unsafe"
 
@@ -39,15 +38,12 @@ import "C"
 //go:generate sh -c "GOOS=$(go env GOHOSTOS) GOARCH=$(go env GOHOSTARCH) go run github.com/cilium/ebpf/cmd/bpf2go -target bpfel -cc clang filetop ./bpf/filetop.bpf.c -- -I./bpf/ -I../../.. -target bpf -D__TARGET_ARCH_x86"
 
 type Config struct {
-	TargetPid int
-	AllFiles  bool
-	MaxRows   int
-	Interval  time.Duration
-	SortBy    types.SortBy
-	// TODO: Make it a *ebpf.Map once
-	// https://github.com/cilium/ebpf/issues/515 and
-	// https://github.com/cilium/ebpf/issues/517 are fixed
-	MountnsMap string
+	MountnsMap *ebpf.Map
+	TargetPid  int
+	AllFiles   bool
+	MaxRows    int
+	Interval   time.Duration
+	SortBy     types.SortBy
 	Node       string
 }
 
@@ -95,13 +91,12 @@ func (t *Tracer) start() error {
 		return fmt.Errorf("failed to load ebpf program: %w", err)
 	}
 
+	mapReplacements := map[string]*ebpf.Map{}
 	filterByMntNs := false
 
-	if t.config.MountnsMap != "" {
+	if t.config.MountnsMap != nil {
 		filterByMntNs = true
-		m := spec.Maps["mount_ns_set"]
-		m.Pinning = ebpf.PinByName
-		m.Name = filepath.Base(t.config.MountnsMap)
+		mapReplacements["mount_ns_set"] = t.config.MountnsMap
 	}
 
 	consts := map[string]interface{}{
@@ -115,9 +110,7 @@ func (t *Tracer) start() error {
 	}
 
 	opts := ebpf.CollectionOptions{
-		Maps: ebpf.MapOptions{
-			PinPath: filepath.Dir(t.config.MountnsMap),
-		},
+		MapReplacements: mapReplacements,
 	}
 
 	if err := spec.LoadAndAssign(&t.objs, &opts); err != nil {

--- a/pkg/gadgets/fsslower/gadget.go
+++ b/pkg/gadgets/fsslower/gadget.go
@@ -138,8 +138,14 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 		minLatency = uint(minLatencyParsed)
 	}
 
+	mountNsMap, err := t.resolver.TracerMountNsMap(traceName)
+	if err != nil {
+		trace.Status.OperationError = fmt.Sprintf("failed to find tracer's mount ns map: %s", err)
+		return
+	}
+
 	config := &tracer.Config{
-		MountnsMap: gadgets.TracePinPath(trace.ObjectMeta.Namespace, trace.ObjectMeta.Name),
+		MountnsMap: mountNsMap,
 		Filesystem: filesystem,
 		MinLatency: minLatency,
 	}

--- a/pkg/gadgets/fsslower/tracer/core/tracer.go
+++ b/pkg/gadgets/fsslower/tracer/core/tracer.go
@@ -25,7 +25,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path/filepath"
 	"unsafe"
 
 	"github.com/cilium/ebpf"
@@ -142,13 +141,12 @@ func (t *Tracer) start() error {
 		return fmt.Errorf("failed to load ebpf program: %w", err)
 	}
 
+	mapReplacements := map[string]*ebpf.Map{}
 	filterByMntNs := false
 
-	if t.config.MountnsMap != "" {
+	if t.config.MountnsMap != nil {
 		filterByMntNs = true
-		m := spec.Maps["mount_ns_set"]
-		m.Pinning = ebpf.PinByName
-		m.Name = filepath.Base(t.config.MountnsMap)
+		mapReplacements["mount_ns_set"] = t.config.MountnsMap
 	}
 
 	consts := map[string]interface{}{
@@ -161,9 +159,7 @@ func (t *Tracer) start() error {
 	}
 
 	opts := ebpf.CollectionOptions{
-		Maps: ebpf.MapOptions{
-			PinPath: filepath.Dir(t.config.MountnsMap),
-		},
+		MapReplacements: mapReplacements,
 	}
 
 	if err := spec.LoadAndAssign(&t.objs, &opts); err != nil {

--- a/pkg/gadgets/fsslower/tracer/interface.go
+++ b/pkg/gadgets/fsslower/tracer/interface.go
@@ -14,15 +14,14 @@
 
 package tracer
 
+import "github.com/cilium/ebpf"
+
 type Tracer interface {
 	Stop()
 }
 
 type Config struct {
-	// TODO: Make it a *ebpf.Map once
-	// https://github.com/cilium/ebpf/issues/515 and
-	// https://github.com/cilium/ebpf/issues/517 are fixed
-	MountnsMap string
+	MountnsMap *ebpf.Map
 
 	Filesystem string
 	MinLatency uint

--- a/pkg/gadgets/helpers.go
+++ b/pkg/gadgets/helpers.go
@@ -15,8 +15,6 @@
 package gadgets
 
 import (
-	"fmt"
-
 	"github.com/cilium/ebpf/link"
 	gadgetv1alpha1 "github.com/kinvolk/inspektor-gadget/pkg/apis/gadget/v1alpha1"
 	pb "github.com/kinvolk/inspektor-gadget/pkg/gadgettracermanager/api"
@@ -24,9 +22,7 @@ import (
 )
 
 const (
-	PinPath         = "/sys/fs/bpf/gadget"
-	MountMapPrefix  = "mntnsset_"
-	CGroupMapPrefix = "cgroupidset_"
+	PinPath = "/sys/fs/bpf/gadget"
 
 	// The Trace custom resource is preferably in the "gadget" namespace
 	TraceDefaultNamespace = "gadget"
@@ -40,14 +36,6 @@ func TraceName(namespace, name string) string {
 
 func TraceNameFromNamespacedName(n types.NamespacedName) string {
 	return TraceName(n.Namespace, n.Name)
-}
-
-func TracePinPath(namespace, name string) string {
-	return fmt.Sprintf("%s/%s%s", PinPath, MountMapPrefix, TraceName(namespace, name))
-}
-
-func TracePinPathFromNamespacedName(n types.NamespacedName) string {
-	return TracePinPath(n.Namespace, n.Name)
 }
 
 func ContainerSelectorFromContainerFilter(f *gadgetv1alpha1.ContainerFilter) *pb.ContainerSelector {

--- a/pkg/gadgets/interface.go
+++ b/pkg/gadgets/interface.go
@@ -17,6 +17,7 @@ package gadgets
 import (
 	"sync"
 
+	"github.com/cilium/ebpf"
 	gadgetv1alpha1 "github.com/kinvolk/inspektor-gadget/pkg/apis/gadget/v1alpha1"
 	containercollection "github.com/kinvolk/inspektor-gadget/pkg/container-collection"
 
@@ -76,6 +77,8 @@ type Resolver interface {
 	containercollection.ContainerResolver
 
 	PublishEvent(tracerID string, line string) error
+	TracerMountNsMap(tracerID string) (*ebpf.Map, error)
+	ContainersMap() *ebpf.Map
 }
 
 type BaseFactory struct {

--- a/pkg/gadgets/mountsnoop/gadget.go
+++ b/pkg/gadgets/mountsnoop/gadget.go
@@ -106,8 +106,13 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 
 	var err error
 
+	mountNsMap, err := t.resolver.TracerMountNsMap(traceName)
+	if err != nil {
+		trace.Status.OperationError = fmt.Sprintf("failed to find tracer's mount ns map: %s", err)
+		return
+	}
 	config := &tracer.Config{
-		MountnsMap: gadgets.TracePinPath(trace.ObjectMeta.Namespace, trace.ObjectMeta.Name),
+		MountnsMap: mountNsMap,
 	}
 	t.tracer, err = coretracer.NewTracer(config, t.resolver, eventCallback, trace.Spec.Node)
 	if err != nil {

--- a/pkg/gadgets/mountsnoop/tracer/core/tracer.go
+++ b/pkg/gadgets/mountsnoop/tracer/core/tracer.go
@@ -25,7 +25,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path/filepath"
 	"unsafe"
 
 	"github.com/cilium/ebpf"
@@ -91,13 +90,12 @@ func (t *Tracer) start() error {
 		return fmt.Errorf("failed to load ebpf program: %w", err)
 	}
 
+	mapReplacements := map[string]*ebpf.Map{}
 	filterByMntNs := false
 
-	if t.config.MountnsMap != "" {
+	if t.config.MountnsMap != nil {
 		filterByMntNs = true
-		m := spec.Maps["mount_ns_set"]
-		m.Pinning = ebpf.PinByName
-		m.Name = filepath.Base(t.config.MountnsMap)
+		mapReplacements["mount_ns_set"] = t.config.MountnsMap
 	}
 
 	consts := map[string]interface{}{
@@ -109,9 +107,7 @@ func (t *Tracer) start() error {
 	}
 
 	opts := ebpf.CollectionOptions{
-		Maps: ebpf.MapOptions{
-			PinPath: filepath.Dir(t.config.MountnsMap),
-		},
+		MapReplacements: mapReplacements,
 	}
 
 	if err := spec.LoadAndAssign(&t.objs, &opts); err != nil {

--- a/pkg/gadgets/mountsnoop/tracer/interface.go
+++ b/pkg/gadgets/mountsnoop/tracer/interface.go
@@ -14,13 +14,12 @@
 
 package tracer
 
+import "github.com/cilium/ebpf"
+
 type Tracer interface {
 	Stop()
 }
 
 type Config struct {
-	// TODO: Make it a *ebpf.Map once
-	// https://github.com/cilium/ebpf/issues/515 and
-	// https://github.com/cilium/ebpf/issues/517 are fixed
-	MountnsMap string
+	MountnsMap *ebpf.Map
 }

--- a/pkg/gadgets/mountsnoop/tracer/standard/tracer.go
+++ b/pkg/gadgets/mountsnoop/tracer/standard/tracer.go
@@ -57,10 +57,9 @@ func NewTracer(config *tracer.Config, resolver containercollection.ContainerReso
 		eventCallback(event)
 	}
 
-	baseTracer, err := gadgets.NewStandardTracer(lineCallback,
+	baseTracer, err := gadgets.NewStandardTracer(lineCallback, config.MountnsMap,
 		"/usr/share/bcc/tools/mountsnoop",
-		"--json", "--mntnsmap", config.MountnsMap,
-		"--containersmap", "/sys/fs/bpf/gadget/containers")
+		"--json", "--containersmap", "/sys/fs/bpf/gadget/containers")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/gadgets/oomkill/gadget.go
+++ b/pkg/gadgets/oomkill/gadget.go
@@ -103,8 +103,13 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 
 	var err error
 
+	mountNsMap, err := t.resolver.TracerMountNsMap(traceName)
+	if err != nil {
+		trace.Status.OperationError = fmt.Sprintf("failed to find tracer's mount ns map: %s", err)
+		return
+	}
 	config := &tracer.Config{
-		MountnsMap: gadgets.TracePinPath(trace.ObjectMeta.Namespace, trace.ObjectMeta.Name),
+		MountnsMap: mountNsMap,
 	}
 	t.tracer, err = tracer.NewTracer(config, t.resolver, eventCallback, trace.Spec.Node)
 	if err != nil {

--- a/pkg/gadgets/oomkill/tracer/tracer.go
+++ b/pkg/gadgets/oomkill/tracer/tracer.go
@@ -25,7 +25,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path/filepath"
 	"unsafe"
 
 	"github.com/cilium/ebpf"
@@ -40,10 +39,7 @@ import (
 //go:generate sh -c "GOOS=$(go env GOHOSTOS) GOARCH=$(go env GOHOSTARCH) go run github.com/cilium/ebpf/cmd/bpf2go -target bpfel -cc clang oomkill ./bpf/oomkill.bpf.c -- -I./bpf/ -I../../.. -target bpf -D__TARGET_ARCH_x86"
 
 type Config struct {
-	// TODO: Make it a *ebpf.Map once
-	// https://github.com/cilium/ebpf/issues/515 and
-	// https://github.com/cilium/ebpf/issues/517 are fixed
-	MountnsMap string
+	MountnsMap *ebpf.Map
 }
 
 type Tracer struct {
@@ -93,13 +89,12 @@ func (t *Tracer) start() error {
 		return fmt.Errorf("failed to load ebpf program: %w", err)
 	}
 
+	mapReplacements := map[string]*ebpf.Map{}
 	filterByMntNs := false
 
-	if t.config.MountnsMap != "" {
+	if t.config.MountnsMap != nil {
 		filterByMntNs = true
-		m := spec.Maps["mount_ns_set"]
-		m.Pinning = ebpf.PinByName
-		m.Name = filepath.Base(t.config.MountnsMap)
+		mapReplacements["mount_ns_set"] = t.config.MountnsMap
 	}
 
 	consts := map[string]interface{}{
@@ -111,9 +106,7 @@ func (t *Tracer) start() error {
 	}
 
 	opts := ebpf.CollectionOptions{
-		Maps: ebpf.MapOptions{
-			PinPath: filepath.Dir(t.config.MountnsMap),
-		},
+		MapReplacements: mapReplacements,
 	}
 
 	if err := spec.LoadAndAssign(&t.objs, &opts); err != nil {

--- a/pkg/gadgets/opensnoop/gadget.go
+++ b/pkg/gadgets/opensnoop/gadget.go
@@ -106,8 +106,13 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 
 	var err error
 
+	mountNsMap, err := t.resolver.TracerMountNsMap(traceName)
+	if err != nil {
+		trace.Status.OperationError = fmt.Sprintf("failed to find tracer's mount ns map: %s", err)
+		return
+	}
 	config := &tracer.Config{
-		MountnsMap: gadgets.TracePinPath(trace.ObjectMeta.Namespace, trace.ObjectMeta.Name),
+		MountnsMap: mountNsMap,
 	}
 	t.tracer, err = coretracer.NewTracer(config, t.resolver, eventCallback, trace.Spec.Node)
 	if err != nil {

--- a/pkg/gadgets/opensnoop/tracer/core/tracer.go
+++ b/pkg/gadgets/opensnoop/tracer/core/tracer.go
@@ -25,7 +25,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path/filepath"
 	"unsafe"
 
 	"github.com/cilium/ebpf"
@@ -90,13 +89,12 @@ func (t *Tracer) start() error {
 		return fmt.Errorf("failed to load ebpf program: %w", err)
 	}
 
+	mapReplacements := map[string]*ebpf.Map{}
 	filterByMntNs := false
 
-	if t.config.MountnsMap != "" {
+	if t.config.MountnsMap != nil {
 		filterByMntNs = true
-		m := spec.Maps["mount_ns_set"]
-		m.Pinning = ebpf.PinByName
-		m.Name = filepath.Base(t.config.MountnsMap)
+		mapReplacements["mount_ns_set"] = t.config.MountnsMap
 	}
 
 	consts := map[string]interface{}{
@@ -108,9 +106,7 @@ func (t *Tracer) start() error {
 	}
 
 	opts := ebpf.CollectionOptions{
-		Maps: ebpf.MapOptions{
-			PinPath: filepath.Dir(t.config.MountnsMap),
-		},
+		MapReplacements: mapReplacements,
 	}
 
 	if err := spec.LoadAndAssign(&t.objs, &opts); err != nil {

--- a/pkg/gadgets/opensnoop/tracer/interface.go
+++ b/pkg/gadgets/opensnoop/tracer/interface.go
@@ -14,13 +14,12 @@
 
 package tracer
 
+import "github.com/cilium/ebpf"
+
 type Tracer interface {
 	Stop()
 }
 
 type Config struct {
-	// TODO: Make it a *ebpf.Map once
-	// https://github.com/cilium/ebpf/issues/515 and
-	// https://github.com/cilium/ebpf/issues/517 are fixed
-	MountnsMap string
+	MountnsMap *ebpf.Map
 }

--- a/pkg/gadgets/opensnoop/tracer/standard/tracer.go
+++ b/pkg/gadgets/opensnoop/tracer/standard/tracer.go
@@ -49,10 +49,9 @@ func NewTracer(config *tracer.Config, resolver containercollection.ContainerReso
 		eventCallback(event)
 	}
 
-	baseTracer, err := gadgets.NewStandardTracer(lineCallback,
+	baseTracer, err := gadgets.NewStandardTracer(lineCallback, config.MountnsMap,
 		"/usr/share/bcc/tools/opensnoop",
-		"--json", "--mntnsmap", config.MountnsMap,
-		"--containersmap", "/sys/fs/bpf/gadget/containers")
+		"--json", "--containersmap", "/sys/fs/bpf/gadget/containers")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/gadgets/process-collector/gadget.go
+++ b/pkg/gadgets/process-collector/gadget.go
@@ -65,7 +65,13 @@ func (f *TraceFactory) Operations() map[string]gadgets.TraceOperation {
 }
 
 func (t *Trace) Collect(trace *gadgetv1alpha1.Trace) {
-	events, err := tracer.RunCollector(t.resolver, trace.Spec.Node, gadgets.TracePinPath(trace.ObjectMeta.Namespace, trace.ObjectMeta.Name))
+	traceName := gadgets.TraceName(trace.ObjectMeta.Namespace, trace.ObjectMeta.Name)
+	mountNsMap, err := t.resolver.TracerMountNsMap(traceName)
+	if err != nil {
+		trace.Status.OperationError = fmt.Sprintf("failed to find tracer's mount ns map: %s", err)
+		return
+	}
+	events, err := tracer.RunCollector(t.resolver, trace.Spec.Node, mountNsMap)
 	if err != nil {
 		trace.Status.OperationError = err.Error()
 		return

--- a/pkg/gadgets/sigsnoop/gadget.go
+++ b/pkg/gadgets/sigsnoop/gadget.go
@@ -141,8 +141,13 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 
 	var err error
 
+	mountNsMap, err := t.resolver.TracerMountNsMap(traceName)
+	if err != nil {
+		trace.Status.OperationError = fmt.Sprintf("failed to find tracer's mount ns map: %s", err)
+		return
+	}
 	config := &tracer.Config{
-		MountnsMap:   gadgets.TracePinPath(trace.ObjectMeta.Namespace, trace.ObjectMeta.Name),
+		MountnsMap:   mountNsMap,
 		TargetPid:    targetPid,
 		TargetSignal: targetSignal,
 		FailedOnly:   failedOnly,

--- a/pkg/gadgets/sigsnoop/tracer/core/tracer.go
+++ b/pkg/gadgets/sigsnoop/tracer/core/tracer.go
@@ -14,7 +14,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"syscall"
@@ -122,13 +121,12 @@ func (t *Tracer) start() error {
 		return fmt.Errorf("failed to load ebpf program: %w", err)
 	}
 
+	mapReplacements := map[string]*ebpf.Map{}
 	filterByMntNs := false
 
-	if t.config.MountnsMap != "" {
+	if t.config.MountnsMap != nil {
 		filterByMntNs = true
-		m := spec.Maps["mount_ns_set"]
-		m.Pinning = ebpf.PinByName
-		m.Name = filepath.Base(t.config.MountnsMap)
+		mapReplacements["mount_ns_set"] = t.config.MountnsMap
 	}
 
 	signal, err := signalStringToInt(t.config.TargetSignal)
@@ -148,9 +146,7 @@ func (t *Tracer) start() error {
 	}
 
 	opts := ebpf.CollectionOptions{
-		Maps: ebpf.MapOptions{
-			PinPath: filepath.Dir(t.config.MountnsMap),
-		},
+		MapReplacements: mapReplacements,
 	}
 
 	if err := spec.LoadAndAssign(&t.objs, &opts); err != nil {

--- a/pkg/gadgets/sigsnoop/tracer/interface.go
+++ b/pkg/gadgets/sigsnoop/tracer/interface.go
@@ -14,16 +14,14 @@
 
 package tracer
 
+import "github.com/cilium/ebpf"
+
 type Tracer interface {
 	Stop()
 }
 
 type Config struct {
-	// TODO: Make it a *ebpf.Map once
-	// https://github.com/cilium/ebpf/issues/515 and
-	// https://github.com/cilium/ebpf/issues/517 are fixed
-	MountnsMap string
-
+	MountnsMap   *ebpf.Map
 	TargetSignal string
 	TargetPid    int32
 	FailedOnly   bool

--- a/pkg/gadgets/tcpconnect/gadget.go
+++ b/pkg/gadgets/tcpconnect/gadget.go
@@ -106,8 +106,13 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 
 	var err error
 
+	mountNsMap, err := t.resolver.TracerMountNsMap(traceName)
+	if err != nil {
+		trace.Status.OperationError = fmt.Sprintf("failed to find tracer's mount ns map: %s", err)
+		return
+	}
 	config := &tracer.Config{
-		MountnsMap: gadgets.TracePinPath(trace.ObjectMeta.Namespace, trace.ObjectMeta.Name),
+		MountnsMap: mountNsMap,
 	}
 	t.tracer, err = coretracer.NewTracer(config, t.resolver, eventCallback, trace.Spec.Node)
 	if err != nil {

--- a/pkg/gadgets/tcpconnect/tracer/core/tracer.go
+++ b/pkg/gadgets/tcpconnect/tracer/core/tracer.go
@@ -58,7 +58,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path/filepath"
 	"unsafe"
 
 	"github.com/cilium/ebpf"
@@ -119,13 +118,12 @@ func (t *Tracer) start() error {
 		return fmt.Errorf("failed to load ebpf program: %w", err)
 	}
 
+	mapReplacements := map[string]*ebpf.Map{}
 	filterByMntNs := false
 
-	if t.config.MountnsMap != "" {
+	if t.config.MountnsMap != nil {
 		filterByMntNs = true
-		m := spec.Maps["mount_ns_set"]
-		m.Pinning = ebpf.PinByName
-		m.Name = filepath.Base(t.config.MountnsMap)
+		mapReplacements["mount_ns_set"] = t.config.MountnsMap
 	}
 
 	consts := map[string]interface{}{
@@ -137,9 +135,7 @@ func (t *Tracer) start() error {
 	}
 
 	opts := ebpf.CollectionOptions{
-		Maps: ebpf.MapOptions{
-			PinPath: filepath.Dir(t.config.MountnsMap),
-		},
+		MapReplacements: mapReplacements,
 	}
 
 	if err := spec.LoadAndAssign(&t.objs, &opts); err != nil {

--- a/pkg/gadgets/tcpconnect/tracer/interface.go
+++ b/pkg/gadgets/tcpconnect/tracer/interface.go
@@ -14,13 +14,12 @@
 
 package tracer
 
+import "github.com/cilium/ebpf"
+
 type Tracer interface {
 	Stop()
 }
 
 type Config struct {
-	// TODO: Make it a *ebpf.Map once
-	// https://github.com/cilium/ebpf/issues/515 and
-	// https://github.com/cilium/ebpf/issues/517 are fixed
-	MountnsMap string
+	MountnsMap *ebpf.Map
 }

--- a/pkg/gadgets/tcpconnect/tracer/standard/tracer.go
+++ b/pkg/gadgets/tcpconnect/tracer/standard/tracer.go
@@ -53,10 +53,9 @@ func NewTracer(config *tracer.Config, resolver containercollection.ContainerReso
 		eventCallback(event)
 	}
 
-	baseTracer, err := gadgets.NewStandardTracer(lineCallback,
+	baseTracer, err := gadgets.NewStandardTracer(lineCallback, config.MountnsMap,
 		"/usr/share/bcc/tools/tcpconnect",
-		"--json", "--mntnsmap", config.MountnsMap,
-		"--containersmap", "/sys/fs/bpf/gadget/containers")
+		"--json", "--containersmap", "/sys/fs/bpf/gadget/containers")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/gadgets/tcptop/gadget.go
+++ b/pkg/gadgets/tcptop/gadget.go
@@ -159,11 +159,16 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 		}
 	}
 
+	mountNsMap, err := t.resolver.TracerMountNsMap(traceName)
+	if err != nil {
+		trace.Status.OperationError = fmt.Sprintf("failed to find tracer's mount ns map: %s", err)
+		return
+	}
 	config := &tcptoptracer.Config{
 		MaxRows:      maxRows,
 		Interval:     time.Second * time.Duration(intervalSeconds),
 		SortBy:       sortBy,
-		MountnsMap:   gadgets.TracePinPath(trace.ObjectMeta.Namespace, trace.ObjectMeta.Name),
+		MountnsMap:   mountNsMap,
 		TargetPid:    targetPid,
 		TargetFamily: targetFamily,
 		Node:         trace.Spec.Node,

--- a/pkg/gadgets/tcptracer/gadget.go
+++ b/pkg/gadgets/tcptracer/gadget.go
@@ -105,8 +105,13 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 
 	var err error
 
+	mountNsMap, err := t.resolver.TracerMountNsMap(traceName)
+	if err != nil {
+		trace.Status.OperationError = fmt.Sprintf("failed to find tracer's mount ns map: %s", err)
+		return
+	}
 	config := &tracer.Config{
-		MountnsMap: gadgets.TracePinPath(trace.ObjectMeta.Namespace, trace.ObjectMeta.Name),
+		MountnsMap: mountNsMap,
 	}
 
 	t.tracer, err = standardtracer.NewTracer(config, t.resolver, eventCallback, trace.Spec.Node)

--- a/pkg/gadgets/tcptracer/tracer/interface.go
+++ b/pkg/gadgets/tcptracer/tracer/interface.go
@@ -14,13 +14,12 @@
 
 package tracer
 
+import "github.com/cilium/ebpf"
+
 type Tracer interface {
 	Stop()
 }
 
 type Config struct {
-	// TODO: Make it a *ebpf.Map once
-	// https://github.com/cilium/ebpf/issues/515 and
-	// https://github.com/cilium/ebpf/issues/517 are fixed
-	MountnsMap string
+	MountnsMap *ebpf.Map
 }

--- a/pkg/gadgets/tcptracer/tracer/standard/tracer.go
+++ b/pkg/gadgets/tcptracer/tracer/standard/tracer.go
@@ -21,6 +21,7 @@ import (
 
 	containercollection "github.com/kinvolk/inspektor-gadget/pkg/container-collection"
 	"github.com/kinvolk/inspektor-gadget/pkg/gadgets"
+
 	"github.com/kinvolk/inspektor-gadget/pkg/gadgets/tcptracer/tracer"
 	"github.com/kinvolk/inspektor-gadget/pkg/gadgets/tcptracer/types"
 	eventtypes "github.com/kinvolk/inspektor-gadget/pkg/types"
@@ -54,10 +55,9 @@ func NewTracer(config *tracer.Config, resolver containercollection.ContainerReso
 		eventCallback(event)
 	}
 
-	baseTracer, err := gadgets.NewStandardTracer(lineCallback,
+	baseTracer, err := gadgets.NewStandardTracer(lineCallback, config.MountnsMap,
 		"/usr/share/bcc/tools/tcptracer",
-		"--json", "--mntnsmap", config.MountnsMap,
-		"--containersmap", "/sys/fs/bpf/gadget/containers")
+		"--json", "--containersmap", "/sys/fs/bpf/gadget/containers")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/gadgettracermanager/containers-map/bpf/containers-map.c
+++ b/pkg/gadgettracermanager/containers-map/bpf/containers-map.c
@@ -12,7 +12,6 @@ struct {
 	__type(key, __u64);
 	__type(value, struct container);
 	__uint(max_entries, MAX_CONTAINERS_PER_NODE);
-	__uint(pinning, LIBBPF_PIN_BY_NAME);
 } containers SEC(".maps");
 
 char _license[] SEC("license") = "GPL";

--- a/pkg/gadgettracermanager/gadgettracermanager.go
+++ b/pkg/gadgettracermanager/gadgettracermanager.go
@@ -22,6 +22,7 @@ import (
 	"runtime"
 	"sync"
 
+	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/rlimit"
 	log "github.com/sirupsen/logrus"
 
@@ -147,6 +148,21 @@ func (g *GadgetTracerManager) PublishEvent(tracerID string, line string) error {
 	return nil
 }
 
+func (g *GadgetTracerManager) TracerMountNsMap(tracerID string) (*ebpf.Map, error) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	return g.tracerCollection.TracerMountNsMap(tracerID)
+}
+
+func (g *GadgetTracerManager) ContainersMap() *ebpf.Map {
+	if g.containersMap == nil {
+		return nil
+	}
+
+	return g.containersMap.ContainersMap()
+}
+
 func (g *GadgetTracerManager) AddContainer(_ context.Context, containerDefinition *pb.ContainerDefinition) (*pb.AddContainerResponse, error) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
@@ -206,7 +222,7 @@ func newServer(conf *Conf) (*GadgetTracerManager, error) {
 		withBPF:  !conf.TestOnly,
 	}
 
-	tracerCollection, err := tracercollection.NewTracerCollection(gadgets.PinPath, gadgets.MountMapPrefix, !conf.TestOnly, &g.ContainerCollection)
+	tracerCollection, err := tracercollection.NewTracerCollection(!conf.TestOnly, &g.ContainerCollection)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
local-gadget runs as a single process, hence it's not needed to pin
the eBPF maps. Instead, they can be passed as file descriptors
(or ebpf.Map). Pinning the maps is an issue in systems where bpffs is
not mounted by default (systemd <v238).

This commit modifies the gadgets to receive maps like ebpf.Maps objects.
Maps aren't pinned at all for local-gadget but they are still pinned in
the gadget tracer manager as the profile cpu gadgets still needs them.

Fixes #619 #620 

TODO after merging
- [x] Create issue for https://github.com/kinvolk/inspektor-gadget/pull/654#discussion_r871494812
- [x] Create issue for https://github.com/kinvolk/inspektor-gadget/pull/654#discussion_r871544448