### PR TITLE
integration: Make sure default service account is created

### DIFF
--- a/integration/command.go
+++ b/integration/command.go
@@ -338,10 +338,20 @@ func generateTestNamespaceName(namespace string) string {
 // createTestNamespaceCommand returns a command which creates a namespace whom
 // name is given as parameter.
 func createTestNamespaceCommand(namespace string) *command {
+	cmd := fmt.Sprintf(`
+	kubectl create ns %s && \
+	while true; do
+		kubectl -n %s get serviceaccount default
+		if [ $? -eq 0 ]; then
+			break
+		fi
+		sleep 1
+	done
+	`, namespace, namespace)
+
 	return &command{
-		name:           "Create test namespace",
-		cmd:            fmt.Sprintf("kubectl create ns %s", namespace),
-		expectedString: fmt.Sprintf("namespace/%s created\n", namespace),
+		name: "Create test namespace",
+		cmd:  cmd,
 	}
 }
 


### PR DESCRIPTION
Sometimes we're hitting the following issue:
pods "test-pod" is forbidden: error looking up service account xxx: serviceaccount "default" not found

Let's add a bit of extra logic after the namespace creation to be sure
the default service account for the namespace is created before going
on.

