### PR TITLE
ci/integration-tests: Install a fixed version of SPO and CertManager

### DIFF
--- a/integration/command.go
+++ b/integration/command.go
@@ -92,9 +92,9 @@ var deploySPO *command = &command{
 	// security-profiles-operator-webhook to be started, hence the long
 	// timeout
 	cmd: `
-	kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.7.1/cert-manager.yaml
+	kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.7.2/cert-manager.yaml
 	kubectl --namespace cert-manager wait --for condition=ready pod -l app.kubernetes.io/instance=cert-manager
-	curl https://raw.githubusercontent.com/kubernetes-sigs/security-profiles-operator/main/deploy/operator.yaml | \
+	curl https://raw.githubusercontent.com/kubernetes-sigs/security-profiles-operator/v0.4.2/deploy/operator.yaml | \
 		sed 's/replicas: 3/replicas: 1/'|grep -v cpu: | \
 		kubectl apply -f -
 	for i in $(seq 1 120); do
@@ -103,8 +103,6 @@ var deploySPO *command = &command{
 		fi
 		sleep 1
 	done
-	kubectl patch deploy -n security-profiles-operator security-profiles-operator-webhook --type=json \
-		-p='[{"op": "remove", "path": "/spec/template/spec/containers/0/resources"}]'
 	kubectl patch ds -n security-profiles-operator spod --type=json \
 		-p='[{"op": "remove", "path": "/spec/template/spec/containers/0/resources"}, {"op": "remove", "path": "/spec/template/spec/containers/1/resources"}, {"op": "remove", "path": "/spec/template/spec/initContainers/0/resources"}]'
 	kubectl --namespace security-profiles-operator wait --for condition=ready pod -l app=security-profiles-operator || (kubectl get pod -n security-profiles-operator ; kubectl get events -n security-profiles-operator ; false)
@@ -129,8 +127,8 @@ var cleanupSPO *command = &command{
 	name: "Remove Security Profiles Operator (SPO)",
 	cmd: `
 	kubectl delete seccompprofile -n security-profiles-operator --all
-	kubectl delete -f https://raw.githubusercontent.com/kubernetes-sigs/security-profiles-operator/main/deploy/operator.yaml
-	kubectl delete -f https://github.com/jetstack/cert-manager/releases/download/v1.7.1/cert-manager.yaml
+	kubectl delete -f https://raw.githubusercontent.com/kubernetes-sigs/security-profiles-operator/v0.4.2/deploy/operator.yaml
+	kubectl delete -f https://github.com/jetstack/cert-manager/releases/download/v1.7.2/cert-manager.yaml
 	`,
 	cleanup: true,
 }

--- a/integration/command.go
+++ b/integration/command.go
@@ -82,32 +82,38 @@ var waitUntilInspektorGadgetPodsDeployed *command = &command{
 	done`,
 }
 
-var deploySPO *command = &command{
-	name: "Deploy Security Profiles Operator (SPO)",
-	// The security-profiles-operator-webhook deployment is not part of the
-	// yaml but created by SPO. We cannot use kubectl-wait before it is
-	// created, see also:
-	// https://github.com/kubernetes/kubernetes/issues/83242
+func deploySPO(limitReplicas bool) *command {
+	// The security-profiles-operator-webhook deployment is not part of the yaml
+	// but created by SPO. We cannot use kubectl-wait before it is created, see
+	// also: https://github.com/kubernetes/kubernetes/issues/83242
 	// Unfortunately, it takes quite a while for
-	// security-profiles-operator-webhook to be started, hence the long
-	// timeout
-	cmd: `
-	kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.7.2/cert-manager.yaml
-	kubectl --namespace cert-manager wait --for condition=ready pod -l app.kubernetes.io/instance=cert-manager
-	curl https://raw.githubusercontent.com/kubernetes-sigs/security-profiles-operator/v0.4.2/deploy/operator.yaml | \
-		sed 's/replicas: 3/replicas: 1/'|grep -v cpu: | \
-		kubectl apply -f -
-	for i in $(seq 1 120); do
-		if [ "$(kubectl get pod -n security-profiles-operator -l app=security-profiles-operator,name=security-profiles-operator-webhook -o go-template='{{len .items}}')" -ge 1 ] ; then
-			break
-		fi
-		sleep 1
-	done
-	kubectl patch ds -n security-profiles-operator spod --type=json \
-		-p='[{"op": "remove", "path": "/spec/template/spec/containers/0/resources"}, {"op": "remove", "path": "/spec/template/spec/containers/1/resources"}, {"op": "remove", "path": "/spec/template/spec/initContainers/0/resources"}]'
-	kubectl --namespace security-profiles-operator wait --for condition=ready pod -l app=security-profiles-operator || (kubectl get pod -n security-profiles-operator ; kubectl get events -n security-profiles-operator ; false)
-	`,
-	expectedRegexp: "pod/security-profiles-operator-.*-.* condition met",
+	// security-profiles-operator-webhook to be started, hence the long timeout
+	cmdStr := fmt.Sprintf(`
+kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.7.2/cert-manager.yaml
+kubectl --namespace cert-manager wait --for condition=ready pod -l app.kubernetes.io/instance=cert-manager
+curl https://raw.githubusercontent.com/kubernetes-sigs/security-profiles-operator/v0.4.2/deploy/operator.yaml | \
+  if [ %v = true ] ; then
+    sed 's/replicas: 3/replicas: 1/' | grep -v cpu:
+  else
+    cat
+  fi | \
+  kubectl apply -f -
+for i in $(seq 1 120); do
+  if [ "$(kubectl get pod -n security-profiles-operator -l app=security-profiles-operator,name=security-profiles-operator-webhook -o go-template='{{len .items}}')" -ge 1 ] ; then
+    break
+  fi
+  sleep 1
+done
+kubectl patch ds -n security-profiles-operator spod --type=json \
+  -p='[{"op": "remove", "path": "/spec/template/spec/containers/0/resources"}, {"op": "remove", "path": "/spec/template/spec/containers/1/resources"}, {"op": "remove", "path": "/spec/template/spec/initContainers/0/resources"}]'
+kubectl --namespace security-profiles-operator wait --for condition=ready pod -l app=security-profiles-operator || (kubectl get pod -n security-profiles-operator ; kubectl get events -n security-profiles-operator ; false)
+`, limitReplicas)
+
+	return &command{
+		name:           "DeploySecurityProfilesOperator",
+		cmd:            cmdStr,
+		expectedRegexp: "pod/security-profiles-operator-.*-.* condition met",
+	}
 }
 
 func waitUntilInspektorGadgetPodsInitialized(initialDelay int) *command {

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -117,7 +117,12 @@ func testMain(m *testing.M) int {
 	initCommands := []*command{}
 
 	if !*doNotDeploySPO {
-		initCommands = append(initCommands, deploySPO)
+		limitReplicas := false
+		if *k8sDistro == K8sDistroMinikubeGH {
+			limitReplicas = true
+		}
+
+		initCommands = append(initCommands, deploySPO(limitReplicas))
 		defer func() {
 			fmt.Printf("Clean SPO:\n")
 			cleanupSPO.runWithoutTest()


### PR DESCRIPTION
# Install a fixed version of SPO and CertManager

This PR modifies the integration tests to not install the SPO from the `main` branch but the latest released version to ease the maintenance of the CI. In this way, we just need to verify that the integration tests are working correctly after each new release instead of dealing with all the changes introduced to the `main` branch.

This PR also avoids limiting the resources when the integration tests are running on ARO where we have 6 nodes and we don't have resource limitations like in the case of Minikube running on a GH runner.