### PR TITLE
ci/integration-tests: Improve SPO installation and enable AuditSeccomp test on ARO

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -169,11 +169,13 @@ func testMain(m *testing.M) int {
 
 	if !*doNotDeploySPO {
 		limitReplicas := false
+		bestEffortResourceMgmt := false
 		if *k8sDistro == K8sDistroMinikubeGH {
 			limitReplicas = true
+			bestEffortResourceMgmt = true
 		}
 
-		initCommands = append(initCommands, deploySPO(limitReplicas))
+		initCommands = append(initCommands, deploySPO(limitReplicas, bestEffortResourceMgmt))
 		cleanupCommands = append(cleanupCommands, cleanupSPO)
 	}
 

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -269,11 +269,8 @@ func TestMain(m *testing.M) {
 }
 
 func TestAuditSeccomp(t *testing.T) {
-	if *k8sDistro == K8sDistroARO {
-		t.Skip("Skip running audit-seccomp gadget on ARO: see issue #631")
-	}
-
 	ns := generateTestNamespaceName("test-audit-seccomp")
+	spName := "log"
 
 	t.Parallel()
 
@@ -286,7 +283,7 @@ func TestAuditSeccomp(t *testing.T) {
 apiVersion: security-profiles-operator.x-k8s.io/v1beta1
 kind: SeccompProfile
 metadata:
-  name: log
+  name: %s
   namespace: %s
   annotations:
     description: "Log some syscalls"
@@ -302,8 +299,12 @@ spec:
     names:
     - mkdir
 EOF
-			`, ns),
-			expectedRegexp: "seccompprofile.security-profiles-operator.x-k8s.io/log created",
+			`, spName, ns),
+			expectedRegexp: fmt.Sprintf("seccompprofile.security-profiles-operator.x-k8s.io/%s created", spName),
+		},
+		{
+			name: "WaitForSeccompProfile",
+			cmd:  fmt.Sprintf("kubectl wait sp --for condition=ready -n %s %s", ns, spName),
 		},
 		{
 			name: "RunSeccompAuditTestPod",
@@ -332,7 +333,7 @@ EOF
 		waitUntilTestPodReadyCommand(ns),
 		{
 			name:           "RunAuditSeccompGadget",
-			cmd:            fmt.Sprintf("$KUBECTL_GADGET audit seccomp -n %s & sleep 5; kill $!", ns),
+			cmd:            fmt.Sprintf("$KUBECTL_GADGET audit seccomp -n %s --timeout 15", ns),
 			expectedRegexp: fmt.Sprintf(`%s\s+test-pod\s+container1\s+unshare\s+\d+\s+unshare\s+kill_thread`, ns),
 		},
 		deleteTestNamespaceCommand(ns),


### PR DESCRIPTION
# Improve SPO installation and enable AuditSeccomp test on ARO

This PR fixes two issues:

1. The SPO installation was sometimes failing with timeout (also in Minikube) because we were not waiting correctly for the SPO daemon to be ready. 
2. The AuditSeccomp test was failing on ARO because the seccomp profile took around 2 minutes to be installed into the nodes. After investigating this issue, I found that those 2 minutes are not needed to install the seccomp profile but to wait until the SPO daemon is ready. That's why these two issues are correlated. Therefore, I decided to create one single PR to solve them.

Proposed solutions:

1. Manually wait for the SPO daemon to be created (It is not installed as part of the YAML but by the SPO so we cannot use kubectl-wait). Then, if needed, remove the resource management from the SPO webhook and daemon and let Kubernetes use the BestEffor QoS approach. And finally, wait for the daemon set to be available.
2. Given that we are now waiting for the SPO daemon to be ready. The seccomp profile is installed in a couple of seconds as expected. I took advantage of this PR to modify the test to use `--timeout`.

## How to use

Just run the integration tests on different k8s distro. I tested ARO, AKS and Minikube on GH.