### PR TITLE
ci/integration-tests: Name the container to notify it about cancellation

### DIFF
--- a/integration/Makefile
+++ b/integration/Makefile
@@ -23,12 +23,14 @@ test:
 		echo "Running tests without KUBECONFIG variable" ; \
 		docker run --rm -i \
 			--net=host \
+			--name ig-integration-tests \
 			$(TESTS_DOCKER_ARGS) \
 			$(CONTAINER_REPO)test:$(IMAGE_TAG) ; \
 	else \
 		echo "Running tests with KUBECONFIG = $(KUBECONFIG)" ; \
 		docker run --rm -i \
 			--net=host \
+			--name ig-integration-tests \
 			-e KUBECONFIG=/opt/kubeconfig/$(shell basename "$(KUBECONFIG)") \
 			-v $(shell dirname "$(KUBECONFIG)"):/opt/kubeconfig \
 			$(CONTAINER_REPO)test:$(IMAGE_TAG) ; \


### PR DESCRIPTION
# Name the integration-tests container to notify it about the cancellation

The CI is capturing the signal sent by GH when a cancellation occurs, but it is not able to forward it to the integration-tests container because it does not have the expected name:

[CI is notifying](https://github.com/kinvolk/inspektor-gadget/blob/820cf8312ac0d89a3907b5d0149dd39597a37a66/.github/actions/run-integration-tests/action.yml#L41-L63) the container, but it is not named as expected:
```
docker kill --signal="SIGINT" ig-integration-tests
```

This error comes from a wrong rebased of https://github.com/kinvolk/inspektor-gadget/pull/653 where this modification got lost somehow.

## How to use

Force-pushing a commit on the same branch while running the integration tests or manually cancelling it on the Actions section of the repo.

## Testing done

### Before this PR
The cancellation request is captured, but it is not forwarded to the integration-tests container. Therefore, the ARO cluster is not cleaned up. Example [here](https://github.com/kinvolk/inspektor-gadget/runs/6791067420?check_suite_focus=true#step:4:396):
```
IntegrationTestsJob: Workflow run is being cancelled: SIGINT was received
IntegrationTestsJob: Start the clean-up...
IntegrationTestsJob: Notifying the integration tests container about the cancellation
Error response from daemon: Cannot kill container: ig-integration-tests: No such container: ig-integration-tests
```

It implies that the next execution of the integration-tests on the ARO cluster (which is always the same) will fail while trying to deploy IG and SPO because they are still there. Example [here](https://github.com/kinvolk/inspektor-gadget/runs/6791283075?check_suite_focus=true#step:4:257):
```
customresourcedefinition.apiextensions.k8s.io/traces.gadget.kinvolk.io configured
namespace/gadget unchanged
serviceaccount/gadget unchanged
role.rbac.authorization.k8s.io/gadget-role unchanged
rolebinding.rbac.authorization.k8s.io/gadget-role-binding unchanged
clusterrole.rbac.authorization.k8s.io/gadget-cluster-role unchanged
clusterrolebinding.rbac.authorization.k8s.io/gadget-cluster-role-binding unchanged
daemonset.apps/gadget configured
invalid command output(DeployInspektorGadget): output didn't match the expected regexp: gadget created
```

### After this PR
The cancellation request is captured and forwarded to the integration-tests container, which starts with the cleanup process. Example [here](https://github.com/kinvolk/inspektor-gadget/runs/6797335232?check_suite_focus=true#step:4:680):
```
IntegrationTestsJob: Workflow run is being cancelled: SIGINT was received
IntegrationTestsJob: Start the clean-up...
IntegrationTestsJob: Notifying the integration tests container about the cancellation
Handling cancellation...
Stop init commands (if they are still running)...
Kill command(DeployInspektorGadget)
Kill command(WaitForGadgetPods)
Kill command(WaitForInspektorGadgetInit)
Kill command(DeploySecurityProfilesOperator)
Cleaning up...
Start command(DeleteRemainingTestNamespace): kubectl delete ns -l scope=ig-integration-tests
Start command(CleanupInspektorGadget): $KUBECTL_GADGET undeploy
Start command(RemoveSecurityProfilesOperator): 
	kubectl delete seccompprofile -n security-profiles-operator --all
	kubectl delete -f https://raw.githubusercontent.com/kubernetes-sigs/security-profiles-operator/v0.4.2/deploy/operator.yaml
	kubectl delete -f https://github.com/jetstack/cert-manager/releases/download/v1.7.2/cert-manager.yaml
```
