### PR TITLE
GadgetTracerManager: Fix error handling for Stream() operation

### DIFF
--- a/pkg/gadgettracermanager/gadgettracermanager.go
+++ b/pkg/gadgettracermanager/gadgettracermanager.go
@@ -122,7 +122,11 @@ func (g *GadgetTracerManager) ReceiveStream(tracerID *pb.TracerID, stream pb.Gad
 			}
 			line, _ := json.Marshal(ev)
 			err := stream.Send(&pb.StreamData{Line: string(line)})
-			return err
+			if err != nil {
+				return err
+			}
+
+			continue
 		}
 
 		line := &pb.StreamData{Line: l.Line}


### PR DESCRIPTION
If the sender is reporting that the channel is full, do not close the
grpc stream but only report the error and continue processing the events.
This is the same approach we're following in trace gadgets when the perf
ring buffer is full.

It seems it's one of the causes of test failures like https://github.com/kinvolk/inspektor-gadget/runs/6795495979?check_suite_focus=true, however I'm not 100% sure. 