### PR TITLE
cmd/kubectl-gadget: Avoid repeated code on snapshot gadgets

### DIFF
--- a/cmd/kubectl-gadget/main.go
+++ b/cmd/kubectl-gadget/main.go
@@ -43,7 +43,7 @@ func init() {
 	rootCmd.AddCommand(advise.AdviseCmd)
 	rootCmd.AddCommand(audit.AuditCmd)
 	rootCmd.AddCommand(profile.ProfilerCmd)
-	rootCmd.AddCommand(snapshot.SnapshotCmd)
+	rootCmd.AddCommand(snapshot.NewSnapshotCmd())
 	rootCmd.AddCommand(top.TopCmd)
 	rootCmd.AddCommand(trace.TraceCmd)
 }

--- a/cmd/kubectl-gadget/snapshot/process.go
+++ b/cmd/kubectl-gadget/snapshot/process.go
@@ -15,31 +15,28 @@
 package snapshot
 
 import (
-	"encoding/json"
 	"fmt"
-	"os"
 	"sort"
 	"strings"
-	"text/tabwriter"
 
 	"github.com/spf13/cobra"
 
 	"github.com/kinvolk/inspektor-gadget/cmd/kubectl-gadget/utils"
-	gadgetv1alpha1 "github.com/kinvolk/inspektor-gadget/pkg/apis/gadget/v1alpha1"
 	"github.com/kinvolk/inspektor-gadget/pkg/gadgets/process-collector/types"
-	eventtypes "github.com/kinvolk/inspektor-gadget/pkg/types"
 )
 
 type ProcessFlags struct {
 	showThreads bool
 }
 
-func init() {
-	processCmd := initProcessCmd()
-	SnapshotCmd.AddCommand(processCmd)
+type ProcessParser struct {
+	BaseSnapshotParser
+
+	outputConfig *utils.OutputConfig
+	processFlags *ProcessFlags
 }
 
-func initProcessCmd() *cobra.Command {
+func newProcessCmd() *cobra.Command {
 	var commonFlags utils.CommonFlags
 	var processFlags ProcessFlags
 
@@ -47,69 +44,14 @@ func initProcessCmd() *cobra.Command {
 		Use:   "process",
 		Short: "Gather information about running processes",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			config := &utils.TraceConfig{
-				GadgetName:       "process-collector",
-				Operation:        "collect",
-				TraceOutputMode:  "Status",
-				TraceOutputState: "Completed",
-				CommonFlags:      &commonFlags,
+			processGadget := &SnapshotGadget[types.Event]{
+				name:        "process-collector",
+				commonFlags: &commonFlags,
+				parser:      NewProcessParser(&commonFlags.OutputConfig, &processFlags),
+				params:      nil,
 			}
 
-			callback := func(results []gadgetv1alpha1.Trace) error {
-				allEvents := []types.Event{}
-
-				for _, i := range results {
-					if len(i.Status.Output) == 0 {
-						continue
-					}
-
-					var events []types.Event
-					if err := json.Unmarshal([]byte(i.Status.Output), &events); err != nil {
-						return utils.WrapInErrUnmarshalOutput(err, i.Status.Output)
-					}
-					allEvents = append(allEvents, events...)
-				}
-
-				allEvents = sortProcessEvents(allEvents, &processFlags)
-
-				switch commonFlags.OutputMode {
-				case utils.OutputModeJSON:
-					b, err := json.MarshalIndent(allEvents, "", "  ")
-					if err != nil {
-						return utils.WrapInErrMarshalOutput(err)
-					}
-
-					fmt.Printf("%s\n", b)
-					return nil
-				case utils.OutputModeColumns:
-					fallthrough
-				case utils.OutputModeCustomColumns:
-					// In the snapshot gadgets it's possible to use a tabwriter because
-					// we have the full list of events to print available, hence the
-					// tablewriter is able to determine the columns width. In other
-					// gadgets we don't know the size of all columns "a priori", hence
-					// we have to do a best effort printing fixed-width columns.
-					w := tabwriter.NewWriter(os.Stdout, 0, 0, 4, ' ', 0)
-
-					fmt.Fprintln(w, getProcessColsHeader(&processFlags, commonFlags.CustomColumns))
-					for _, e := range allEvents {
-						if e.Type != eventtypes.NORMAL {
-							utils.ManageSpecialEvent(e.Event, commonFlags.Verbose)
-							continue
-						}
-
-						fmt.Fprintln(w, transformProcessEvent(&e, &processFlags, &commonFlags.OutputConfig))
-					}
-
-					w.Flush()
-				default:
-					return utils.WrapInErrOutputModeNotSupported(commonFlags.OutputMode)
-				}
-
-				return nil
-			}
-
-			return utils.RunTraceAndPrintStatusOutput(config, callback)
+			return processGadget.Run()
 		},
 	}
 
@@ -126,9 +68,7 @@ func initProcessCmd() *cobra.Command {
 	return cmd
 }
 
-// getProcessColsHeader returns a header with the default list of columns
-// when it is not requested to use a subset of custom columns.
-func getProcessColsHeader(processFlags *ProcessFlags, requestedCols []string) string {
+func NewProcessParser(outputConfig *utils.OutputConfig, processFlags *ProcessFlags) SnapshotParser[types.Event] {
 	availableCols := map[string]struct{}{
 		"node":      {},
 		"namespace": {},
@@ -139,24 +79,33 @@ func getProcessColsHeader(processFlags *ProcessFlags, requestedCols []string) st
 		"pid":       {},
 	}
 
+	return &ProcessParser{
+		BaseSnapshotParser: BaseSnapshotParser{
+			availableCols: availableCols,
+		},
+		outputConfig: outputConfig,
+		processFlags: processFlags,
+	}
+}
+
+func (p *ProcessParser) GetColumnsHeader() string {
+	requestedCols := p.outputConfig.CustomColumns
 	if len(requestedCols) == 0 {
 		requestedCols = []string{"node", "namespace", "pod", "container", "comm", "pid"}
-		if processFlags.showThreads {
+		if p.processFlags.showThreads {
 			requestedCols = []string{"node", "namespace", "pod", "container", "comm", "tgid", "pid"}
 		}
 	}
 
-	return buildSnapshotColsHeader(availableCols, requestedCols)
+	return p.BuildSnapshotColsHeader(requestedCols)
 }
 
-// transformProcessEvent is called to transform an event to columns
-// format according to the parameters.
-func transformProcessEvent(e *types.Event, processFlags *ProcessFlags, outputConf *utils.OutputConfig) string {
+func (p *ProcessParser) TransformEvent(e *types.Event) string {
 	var sb strings.Builder
 
-	switch outputConf.OutputMode {
+	switch p.outputConfig.OutputMode {
 	case utils.OutputModeColumns:
-		if processFlags.showThreads {
+		if p.processFlags.showThreads {
 			sb.WriteString(fmt.Sprintf("%s\t%s\t%s\t%s\t%s\t%d\t%d",
 				e.Node, e.Namespace, e.Pod, e.Container,
 				e.Command, e.Tgid, e.Pid))
@@ -166,7 +115,7 @@ func transformProcessEvent(e *types.Event, processFlags *ProcessFlags, outputCon
 				e.Command, e.Pid))
 		}
 	case utils.OutputModeCustomColumns:
-		for _, col := range outputConf.CustomColumns {
+		for _, col := range p.outputConfig.CustomColumns {
 			switch col {
 			case "node":
 				sb.WriteString(fmt.Sprintf("%s", e.Node))
@@ -192,19 +141,19 @@ func transformProcessEvent(e *types.Event, processFlags *ProcessFlags, outputCon
 	return sb.String()
 }
 
-func sortProcessEvents(allProcesses []types.Event, processFlags *ProcessFlags) []types.Event {
-	if !processFlags.showThreads {
+func (p *ProcessParser) SortEvents(allProcesses *[]types.Event) {
+	if !p.processFlags.showThreads {
 		allProcessesTrimmed := []types.Event{}
-		for _, i := range allProcesses {
+		for _, i := range *allProcesses {
 			if i.Tgid == i.Pid {
 				allProcessesTrimmed = append(allProcessesTrimmed, i)
 			}
 		}
-		allProcesses = allProcessesTrimmed
+		*allProcesses = allProcessesTrimmed
 	}
 
-	sort.Slice(allProcesses, func(i, j int) bool {
-		pi, pj := allProcesses[i], allProcesses[j]
+	sort.Slice(*allProcesses, func(i, j int) bool {
+		pi, pj := (*allProcesses)[i], (*allProcesses)[j]
 		switch {
 		case pi.Node != pj.Node:
 			return pi.Node < pj.Node
@@ -222,6 +171,4 @@ func sortProcessEvents(allProcesses []types.Event, processFlags *ProcessFlags) [
 			return pi.Pid < pj.Pid
 		}
 	})
-
-	return allProcesses
 }

--- a/cmd/kubectl-gadget/snapshot/process.go
+++ b/cmd/kubectl-gadget/snapshot/process.go
@@ -1,4 +1,4 @@
-// Copyright 2019-2021 The Inspektor Gadget authors
+// Copyright 2019-2022 The Inspektor Gadget authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -30,95 +30,133 @@ import (
 	eventtypes "github.com/kinvolk/inspektor-gadget/pkg/types"
 )
 
-var processCollectorParamThreads bool
-
-var processCollectorCmd = &cobra.Command{
-	Use:   "process",
-	Short: "Gather information about running processes",
-	RunE: func(cmd *cobra.Command, args []string) error {
-		callback := func(results []gadgetv1alpha1.Trace) error {
-			allProcesses := []types.Event{}
-
-			for _, i := range results {
-				if len(i.Status.Output) == 0 {
-					continue
-				}
-
-				var processes []types.Event
-				if err := json.Unmarshal([]byte(i.Status.Output), &processes); err != nil {
-					return utils.WrapInErrUnmarshalOutput(err, i.Status.Output)
-				}
-
-				allProcesses = append(allProcesses, processes...)
-			}
-
-			return printProcesses(allProcesses)
-		}
-
-		config := &utils.TraceConfig{
-			GadgetName:       "process-collector",
-			Operation:        "collect",
-			TraceOutputMode:  "Status",
-			TraceOutputState: "Completed",
-			CommonFlags:      &params,
-		}
-
-		return utils.RunTraceAndPrintStatusOutput(config, callback)
-	},
+type ProcessFlags struct {
+	showThreads bool
 }
 
 func init() {
-	SnapshotCmd.AddCommand(processCollectorCmd)
-	utils.AddCommonFlags(processCollectorCmd, &params)
+	processCmd := initProcessCmd()
+	SnapshotCmd.AddCommand(processCmd)
+}
 
-	processCollectorCmd.PersistentFlags().BoolVarP(
-		&processCollectorParamThreads,
+func initProcessCmd() *cobra.Command {
+	var commonFlags utils.CommonFlags
+	var processFlags ProcessFlags
+
+	cmd := &cobra.Command{
+		Use:   "process",
+		Short: "Gather information about running processes",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			config := &utils.TraceConfig{
+				GadgetName:       "process-collector",
+				Operation:        "collect",
+				TraceOutputMode:  "Status",
+				TraceOutputState: "Completed",
+				CommonFlags:      &commonFlags,
+			}
+
+			callback := func(results []gadgetv1alpha1.Trace) error {
+				allEvents := []types.Event{}
+
+				for _, i := range results {
+					if len(i.Status.Output) == 0 {
+						continue
+					}
+
+					var events []types.Event
+					if err := json.Unmarshal([]byte(i.Status.Output), &events); err != nil {
+						return utils.WrapInErrUnmarshalOutput(err, i.Status.Output)
+					}
+					allEvents = append(allEvents, events...)
+				}
+
+				allEvents = sortProcessEvents(allEvents, &processFlags)
+
+				switch commonFlags.OutputMode {
+				case utils.OutputModeJSON:
+					b, err := json.MarshalIndent(allEvents, "", "  ")
+					if err != nil {
+						return utils.WrapInErrMarshalOutput(err)
+					}
+
+					fmt.Printf("%s\n", b)
+					return nil
+				case utils.OutputModeColumns:
+					fallthrough
+				case utils.OutputModeCustomColumns:
+					// In the snapshot gadgets it's possible to use a tabwriter because
+					// we have the full list of events to print available, hence the
+					// tablewriter is able to determine the columns width. In other
+					// gadgets we don't know the size of all columns "a priori", hence
+					// we have to do a best effort printing fixed-width columns.
+					w := tabwriter.NewWriter(os.Stdout, 0, 0, 4, ' ', 0)
+
+					fmt.Fprintln(w, getProcessColsHeader(&processFlags, commonFlags.CustomColumns))
+					for _, e := range allEvents {
+						if e.Type != eventtypes.NORMAL {
+							utils.ManageSpecialEvent(e.Event, commonFlags.Verbose)
+							continue
+						}
+
+						fmt.Fprintln(w, transformProcessEvent(&e, &processFlags, &commonFlags.OutputConfig))
+					}
+
+					w.Flush()
+				default:
+					return utils.WrapInErrOutputModeNotSupported(commonFlags.OutputMode)
+				}
+
+				return nil
+			}
+
+			return utils.RunTraceAndPrintStatusOutput(config, callback)
+		},
+	}
+
+	cmd.PersistentFlags().BoolVarP(
+		&processFlags.showThreads,
 		"threads",
 		"t",
 		false,
 		"Show all threads",
 	)
+
+	utils.AddCommonFlags(cmd, &commonFlags)
+
+	return cmd
 }
 
-func getCustomProcessColsHeader(cols []string) string {
-	var sb strings.Builder
+// getProcessColsHeader returns a header with the default list of columns
+// when it is not requested to use a subset of custom columns.
+func getProcessColsHeader(processFlags *ProcessFlags, requestedCols []string) string {
+	availableCols := map[string]struct{}{
+		"node":      {},
+		"namespace": {},
+		"pod":       {},
+		"container": {},
+		"comm":      {},
+		"tgid":      {},
+		"pid":       {},
+	}
 
-	for _, col := range cols {
-		switch col {
-		case "node":
-			sb.WriteString("NODE\t")
-		case "namespace":
-			sb.WriteString("NAMESPACE\t")
-		case "pod":
-			sb.WriteString("POD\t")
-		case "container":
-			sb.WriteString("CONTAINER\t")
-		case "comm":
-			sb.WriteString("COMM\t")
-		case "tgid":
-			sb.WriteString("TGID\t")
-		case "pid":
-			sb.WriteString("PID\t")
+	if len(requestedCols) == 0 {
+		requestedCols = []string{"node", "namespace", "pod", "container", "comm", "pid"}
+		if processFlags.showThreads {
+			requestedCols = []string{"node", "namespace", "pod", "container", "comm", "tgid", "pid"}
 		}
-		sb.WriteRune(' ')
 	}
 
-	return sb.String()
+	return buildSnapshotColsHeader(availableCols, requestedCols)
 }
 
-// processTransformEvent is called to transform an event to columns
-// format according to the parameters
-func processTransformEvent(e types.Event) string {
+// transformProcessEvent is called to transform an event to columns
+// format according to the parameters.
+func transformProcessEvent(e *types.Event, processFlags *ProcessFlags, outputConf *utils.OutputConfig) string {
 	var sb strings.Builder
 
-	if e.Type != eventtypes.NORMAL {
-		utils.ManageSpecialEvent(e.Event, params.Verbose)
-		return ""
-	}
-
-	switch params.OutputMode {
+	switch outputConf.OutputMode {
 	case utils.OutputModeColumns:
-		if processCollectorParamThreads {
+		if processFlags.showThreads {
 			sb.WriteString(fmt.Sprintf("%s\t%s\t%s\t%s\t%s\t%d\t%d",
 				e.Node, e.Namespace, e.Pod, e.Container,
 				e.Command, e.Tgid, e.Pid))
@@ -128,32 +166,34 @@ func processTransformEvent(e types.Event) string {
 				e.Command, e.Pid))
 		}
 	case utils.OutputModeCustomColumns:
-		for _, col := range params.CustomColumns {
+		for _, col := range outputConf.CustomColumns {
 			switch col {
 			case "node":
-				sb.WriteString(fmt.Sprintf("%s\t", e.Node))
+				sb.WriteString(fmt.Sprintf("%s", e.Node))
 			case "namespace":
-				sb.WriteString(fmt.Sprintf("%s\t", e.Namespace))
+				sb.WriteString(fmt.Sprintf("%s", e.Namespace))
 			case "pod":
-				sb.WriteString(fmt.Sprintf("%s\t", e.Pod))
+				sb.WriteString(fmt.Sprintf("%s", e.Pod))
 			case "container":
-				sb.WriteString(fmt.Sprintf("%s\t", e.Container))
+				sb.WriteString(fmt.Sprintf("%s", e.Container))
 			case "comm":
-				sb.WriteString(fmt.Sprintf("%s\t", e.Command))
+				sb.WriteString(fmt.Sprintf("%s", e.Command))
 			case "tgid":
-				sb.WriteString(fmt.Sprintf("%d\t", e.Tgid))
+				sb.WriteString(fmt.Sprintf("%d", e.Tgid))
 			case "pid":
-				sb.WriteString(fmt.Sprintf("%d\t", e.Pid))
+				sb.WriteString(fmt.Sprintf("%d", e.Pid))
+			default:
+				continue
 			}
-			sb.WriteRune(' ')
+			sb.WriteRune('\t')
 		}
 	}
 
 	return sb.String()
 }
 
-func printProcesses(allProcesses []types.Event) error {
-	if !processCollectorParamThreads {
+func sortProcessEvents(allProcesses []types.Event, processFlags *ProcessFlags) []types.Event {
+	if !processFlags.showThreads {
 		allProcessesTrimmed := []types.Event{}
 		for _, i := range allProcesses {
 			if i.Tgid == i.Pid {
@@ -183,40 +223,5 @@ func printProcesses(allProcesses []types.Event) error {
 		}
 	})
 
-	// JSON output mode does not need any additional parsing
-	if params.OutputMode == utils.OutputModeJSON {
-		b, err := json.MarshalIndent(allProcesses, "", "  ")
-		if err != nil {
-			return utils.WrapInErrMarshalOutput(err)
-		}
-		fmt.Printf("%s\n", b)
-		return nil
-	}
-
-	// In the snapshot gadgets it's possible to use a tabwriter because we have
-	// the full list of events to print available, hence the tablewriter is able
-	// to determine the columns width. In other gadgets we don't know the size
-	// of all columns "a priori", hence we have to do a best effort printing
-	// fixed-width columns.
-	w := tabwriter.NewWriter(os.Stdout, 0, 0, 4, ' ', 0)
-
-	// Print all or requested columns
-	switch params.OutputMode {
-	case utils.OutputModeCustomColumns:
-		fmt.Fprintln(w, getCustomProcessColsHeader(params.CustomColumns))
-	case utils.OutputModeColumns:
-		if processCollectorParamThreads {
-			fmt.Fprintln(w, "NODE\tNAMESPACE\tPOD\tCONTAINER\tCOMM\tTGID\tPID")
-		} else {
-			fmt.Fprintln(w, "NODE\tNAMESPACE\tPOD\tCONTAINER\tCOMM\tPID")
-		}
-	}
-
-	for _, p := range allProcesses {
-		fmt.Fprintln(w, processTransformEvent(p))
-	}
-
-	w.Flush()
-
-	return nil
+	return allProcesses
 }

--- a/cmd/kubectl-gadget/snapshot/snapshot.go
+++ b/cmd/kubectl-gadget/snapshot/snapshot.go
@@ -15,26 +15,158 @@
 package snapshot
 
 import (
+	"encoding/json"
+	"fmt"
+	"os"
 	"strings"
+	"text/tabwriter"
 
 	"github.com/spf13/cobra"
+
+	"github.com/kinvolk/inspektor-gadget/cmd/kubectl-gadget/utils"
+	gadgetv1alpha1 "github.com/kinvolk/inspektor-gadget/pkg/apis/gadget/v1alpha1"
+	processcollectortypes "github.com/kinvolk/inspektor-gadget/pkg/gadgets/process-collector/types"
+	socketcollectortypes "github.com/kinvolk/inspektor-gadget/pkg/gadgets/socket-collector/types"
+	eventtypes "github.com/kinvolk/inspektor-gadget/pkg/types"
 )
 
-var SnapshotCmd = &cobra.Command{
-	Use:   "snapshot",
-	Short: "Take a snapshot of a subsystem and print it",
+// BaseSnapshotParser is a base for a SnapshotParser to reuse the shared
+// fields and methods.
+type BaseSnapshotParser struct {
+	availableCols map[string]struct{}
 }
 
-// buildSnapshotColsHeader returns a header with the requested custom columns
-// that exist in the availableCols. The columns are separated by taps.
-func buildSnapshotColsHeader(availableCols map[string]struct{}, requestedCols []string) string {
+func (p *BaseSnapshotParser) BuildSnapshotColsHeader(requestedCols []string) string {
 	var sb strings.Builder
 
 	for _, col := range requestedCols {
-		if _, ok := availableCols[col]; ok {
+		if _, ok := p.availableCols[col]; ok {
 			sb.WriteString(strings.ToUpper(col) + "\t")
 		}
 	}
 
 	return sb.String()
+}
+
+type SnapshotEvent interface {
+	socketcollectortypes.Event | processcollectortypes.Event
+
+	// The Go compiler does not support accessing a struct field x.f where x is
+	// of type parameter type even if all types in the type parameter's type set
+	// have a field f. We may remove this restriction in Go 1.19. See
+	// https://tip.golang.org/doc/go1.18#generics.
+	GetBaseEvent() eventtypes.Event
+}
+
+// SnapshotParser defines the interface that every snapshot-gadget parser has to
+// implement.
+type SnapshotParser[Event SnapshotEvent] interface {
+	// SortEvents sorts a slice of events based on a predefined prioritization.
+	SortEvents(*[]Event)
+
+	// GetColumnsHeader returns a header based on the requested output format.
+	GetColumnsHeader() string
+
+	// TransformEvent is called to transform an event to columns
+	// format according to the parameters.
+	TransformEvent(*Event) string
+
+	// BuildSnapshotColsHeader returns a header with the requested custom
+	// columns that exist in the availableCols. The columns are separated by
+	// taps.
+	BuildSnapshotColsHeader([]string) string
+}
+
+// SnapshotGadget represents a gadget belonging to the snapshot category.
+type SnapshotGadget[Event SnapshotEvent] struct {
+	name        string
+	commonFlags *utils.CommonFlags
+	params      map[string]string
+	parser      SnapshotParser[Event]
+}
+
+// Run runs a SnapshotGadget and prints the output after parsing it using the
+// SnapshotParser's methods.
+func (g *SnapshotGadget[Event]) Run() error {
+	config := &utils.TraceConfig{
+		GadgetName:       g.name,
+		Operation:        "collect",
+		TraceOutputMode:  "Status",
+		TraceOutputState: "Completed",
+		CommonFlags:      g.commonFlags,
+		Parameters:       g.params,
+	}
+
+	// This callback function be called when a snapshot gadget finishes without
+	// errors and generates a list of results per node. It merges, sorts and
+	// print all of them in the requested mode.
+	callback := func(results []gadgetv1alpha1.Trace) error {
+		allEvents := []Event{}
+
+		for _, i := range results {
+			if len(i.Status.Output) == 0 {
+				continue
+			}
+
+			var events []Event
+			if err := json.Unmarshal([]byte(i.Status.Output), &events); err != nil {
+				return utils.WrapInErrUnmarshalOutput(err, i.Status.Output)
+			}
+			allEvents = append(allEvents, events...)
+		}
+
+		g.parser.SortEvents(&allEvents)
+
+		switch g.commonFlags.OutputMode {
+		case utils.OutputModeJSON:
+			b, err := json.MarshalIndent(allEvents, "", "  ")
+			if err != nil {
+				return utils.WrapInErrMarshalOutput(err)
+			}
+
+			fmt.Printf("%s\n", b)
+			return nil
+		case utils.OutputModeColumns:
+			fallthrough
+		case utils.OutputModeCustomColumns:
+			// In the snapshot gadgets it's possible to use a tabwriter because
+			// we have the full list of events to print available, hence the
+			// tablewriter is able to determine the columns width. In other
+			// gadgets we don't know the size of all columns "a priori", hence
+			// we have to do a best effort printing fixed-width columns.
+			w := tabwriter.NewWriter(os.Stdout, 0, 0, 4, ' ', 0)
+
+			fmt.Fprintln(w, g.parser.GetColumnsHeader())
+
+			for _, e := range allEvents {
+				baseEvent := e.GetBaseEvent()
+				if baseEvent.Type != eventtypes.NORMAL {
+					utils.ManageSpecialEvent(baseEvent, g.commonFlags.Verbose)
+					continue
+				}
+
+				fmt.Fprintln(w, g.parser.TransformEvent(&e))
+			}
+
+			w.Flush()
+		default:
+			return utils.WrapInErrOutputModeNotSupported(g.commonFlags.OutputMode)
+		}
+
+		return nil
+	}
+
+	return utils.RunTraceAndPrintStatusOutput(config, callback)
+}
+
+func NewSnapshotCmd() *cobra.Command {
+	snapshotCmd := &cobra.Command{
+		Use:   "snapshot",
+		Short: "Take a snapshot of a subsystem and print it",
+	}
+
+	snapshotCmd.AddCommand(newProcessCmd())
+	snapshotCmd.AddCommand(newSocketCmd())
+
+	return snapshotCmd
 }

--- a/cmd/kubectl-gadget/snapshot/snapshot.go
+++ b/cmd/kubectl-gadget/snapshot/snapshot.go
@@ -15,16 +15,26 @@
 package snapshot
 
 import (
-	"github.com/kinvolk/inspektor-gadget/cmd/kubectl-gadget/utils"
+	"strings"
 
 	"github.com/spf13/cobra"
 )
 
-// All the gadgets within this package use this global variable, so let's
-// declare it here.
-var params utils.CommonFlags
-
 var SnapshotCmd = &cobra.Command{
 	Use:   "snapshot",
 	Short: "Take a snapshot of a subsystem and print it",
+}
+
+// buildSnapshotColsHeader returns a header with the requested custom columns
+// that exist in the availableCols. The columns are separated by taps.
+func buildSnapshotColsHeader(availableCols map[string]struct{}, requestedCols []string) string {
+	var sb strings.Builder
+
+	for _, col := range requestedCols {
+		if _, ok := availableCols[col]; ok {
+			sb.WriteString(strings.ToUpper(col) + "\t")
+		}
+	}
+
+	return sb.String()
 }

--- a/cmd/kubectl-gadget/snapshot/socket.go
+++ b/cmd/kubectl-gadget/snapshot/socket.go
@@ -15,19 +15,14 @@
 package snapshot
 
 import (
-	"encoding/json"
 	"fmt"
-	"os"
 	"sort"
 	"strings"
-	"text/tabwriter"
 
 	"github.com/spf13/cobra"
 
 	"github.com/kinvolk/inspektor-gadget/cmd/kubectl-gadget/utils"
-	gadgetv1alpha1 "github.com/kinvolk/inspektor-gadget/pkg/apis/gadget/v1alpha1"
 	"github.com/kinvolk/inspektor-gadget/pkg/gadgets/socket-collector/types"
-	eventtypes "github.com/kinvolk/inspektor-gadget/pkg/types"
 )
 
 type SocketFlags struct {
@@ -35,12 +30,14 @@ type SocketFlags struct {
 	extended bool
 }
 
-func init() {
-	socketCmd := initSocketCmd()
-	SnapshotCmd.AddCommand(socketCmd)
+type SocketParser struct {
+	BaseSnapshotParser
+
+	outputConfig *utils.OutputConfig
+	socketFlags  *SocketFlags
 }
 
-func initSocketCmd() *cobra.Command {
+func newSocketCmd() *cobra.Command {
 	var commonFlags utils.CommonFlags
 	var socketFlags SocketFlags
 
@@ -55,73 +52,16 @@ func initSocketCmd() *cobra.Command {
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			config := &utils.TraceConfig{
-				GadgetName:       "socket-collector",
-				Operation:        "collect",
-				TraceOutputMode:  "Status",
-				TraceOutputState: "Completed",
-				CommonFlags:      &commonFlags,
-				Parameters: map[string]string{
+			socketGadget := &SnapshotGadget[types.Event]{
+				name:        "socket-collector",
+				commonFlags: &commonFlags,
+				parser:      NewSocketParser(&commonFlags.OutputConfig, &socketFlags),
+				params: map[string]string{
 					"protocol": socketFlags.protocol,
 				},
 			}
 
-			callback := func(results []gadgetv1alpha1.Trace) error {
-				allEvents := []types.Event{}
-
-				for _, i := range results {
-					if len(i.Status.Output) == 0 {
-						continue
-					}
-
-					var events []types.Event
-					if err := json.Unmarshal([]byte(i.Status.Output), &events); err != nil {
-						return utils.WrapInErrUnmarshalOutput(err, i.Status.Output)
-					}
-					allEvents = append(allEvents, events...)
-				}
-
-				sortSocketEvents(allEvents)
-
-				switch commonFlags.OutputMode {
-				case utils.OutputModeJSON:
-					b, err := json.MarshalIndent(allEvents, "", "  ")
-					if err != nil {
-						return utils.WrapInErrMarshalOutput(err)
-					}
-
-					fmt.Printf("%s\n", b)
-					return nil
-				case utils.OutputModeColumns:
-					fallthrough
-				case utils.OutputModeCustomColumns:
-					// In the snapshot gadgets it's possible to use a tabwriter because
-					// we have the full list of events to print available, hence the
-					// tablewriter is able to determine the columns width. In other
-					// gadgets we don't know the size of all columns "a priori", hence
-					// we have to do a best effort printing fixed-width columns.
-					w := tabwriter.NewWriter(os.Stdout, 0, 0, 4, ' ', 0)
-
-					fmt.Fprintln(w, getSocketColsHeader(&socketFlags, commonFlags.CustomColumns))
-
-					for _, e := range allEvents {
-						if e.Type != eventtypes.NORMAL {
-							utils.ManageSpecialEvent(e.Event, commonFlags.Verbose)
-							continue
-						}
-
-						fmt.Fprintln(w, transformSocketEvent(&e, &socketFlags, &commonFlags.OutputConfig))
-					}
-
-					w.Flush()
-				default:
-					return utils.WrapInErrOutputModeNotSupported(commonFlags.OutputMode)
-				}
-
-				return nil
-			}
-
-			return utils.RunTraceAndPrintStatusOutput(config, callback)
+			return socketGadget.Run()
 		},
 	}
 
@@ -150,9 +90,7 @@ func initSocketCmd() *cobra.Command {
 	return cmd
 }
 
-// getSocketColsHeader returns a header with the default list of columns
-// when it is not requested to use a subset of custom columns.
-func getSocketColsHeader(socketFlags *SocketFlags, requestedCols []string) string {
+func NewSocketParser(outputConfig *utils.OutputConfig, socketFlags *SocketFlags) SnapshotParser[types.Event] {
 	availableCols := map[string]struct{}{
 		"node":      {},
 		"namespace": {},
@@ -164,25 +102,34 @@ func getSocketColsHeader(socketFlags *SocketFlags, requestedCols []string) strin
 		"inode":     {},
 	}
 
+	return &SocketParser{
+		BaseSnapshotParser: BaseSnapshotParser{
+			availableCols: availableCols,
+		},
+		outputConfig: outputConfig,
+		socketFlags:  socketFlags,
+	}
+}
+
+func (s *SocketParser) GetColumnsHeader() string {
+	requestedCols := s.outputConfig.CustomColumns
 	if len(requestedCols) == 0 {
 		requestedCols = []string{"node", "namespace", "pod", "protocol", "local", "remote", "status"}
-		if socketFlags.extended {
+		if s.socketFlags.extended {
 			requestedCols = append(requestedCols, "inode")
 		}
 	}
 
-	return buildSnapshotColsHeader(availableCols, requestedCols)
+	return s.BuildSnapshotColsHeader(requestedCols)
 }
 
-// transformSocketEvent is called to transform an event to columns
-// format according to the parameters.
-func transformSocketEvent(e *types.Event, socketFlags *SocketFlags, outputConf *utils.OutputConfig) string {
+func (s *SocketParser) TransformEvent(e *types.Event) string {
 	var sb strings.Builder
 
-	switch outputConf.OutputMode {
+	switch s.outputConfig.OutputMode {
 	case utils.OutputModeColumns:
 		extendedInformation := ""
-		if socketFlags.extended {
+		if s.socketFlags.extended {
 			extendedInformation = fmt.Sprintf("\t%d", e.InodeNumber)
 		}
 
@@ -191,7 +138,7 @@ func transformSocketEvent(e *types.Event, socketFlags *SocketFlags, outputConf *
 			e.LocalAddress, e.LocalPort, e.RemoteAddress, e.RemotePort,
 			e.Status, extendedInformation))
 	case utils.OutputModeCustomColumns:
-		for _, col := range outputConf.CustomColumns {
+		for _, col := range s.outputConfig.CustomColumns {
 			switch col {
 			case "node":
 				sb.WriteString(fmt.Sprintf("%s", e.Node))
@@ -219,9 +166,9 @@ func transformSocketEvent(e *types.Event, socketFlags *SocketFlags, outputConf *
 	return sb.String()
 }
 
-func sortSocketEvents(allSockets []types.Event) {
-	sort.Slice(allSockets, func(i, j int) bool {
-		si, sj := allSockets[i], allSockets[j]
+func (s *SocketParser) SortEvents(allSockets *[]types.Event) {
+	sort.Slice(*allSockets, func(i, j int) bool {
+		si, sj := (*allSockets)[i], (*allSockets)[j]
 		switch {
 		case si.Node != sj.Node:
 			return si.Node < sj.Node

--- a/cmd/kubectl-gadget/snapshot/socket.go
+++ b/cmd/kubectl-gadget/snapshot/socket.go
@@ -1,4 +1,4 @@
-// Copyright 2019-2021 The Inspektor Gadget authors
+// Copyright 2019-2022 The Inspektor Gadget authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -30,120 +30,159 @@ import (
 	eventtypes "github.com/kinvolk/inspektor-gadget/pkg/types"
 )
 
-var (
-	socketCollectorProtocol      string
-	socketCollectorParamExtended bool
-)
-
-var socketCollectorCmd = &cobra.Command{
-	Use:   "socket",
-	Short: "Gather information about TCP and UDP sockets",
-	RunE: func(cmd *cobra.Command, args []string) error {
-		callback := func(results []gadgetv1alpha1.Trace) error {
-			allSockets := []types.Event{}
-
-			for _, i := range results {
-				if len(i.Status.Output) == 0 {
-					continue
-				}
-
-				var sockets []types.Event
-				if err := json.Unmarshal([]byte(i.Status.Output), &sockets); err != nil {
-					return utils.WrapInErrUnmarshalOutput(err, i.Status.Output)
-				}
-
-				allSockets = append(allSockets, sockets...)
-			}
-
-			return printSockets(allSockets)
-		}
-
-		if _, err := types.ParseProtocol(socketCollectorProtocol); err != nil {
-			return err
-		}
-
-		config := &utils.TraceConfig{
-			GadgetName:       "socket-collector",
-			Operation:        "collect",
-			TraceOutputMode:  "Status",
-			TraceOutputState: "Completed",
-			CommonFlags:      &params,
-			Parameters: map[string]string{
-				"protocol": socketCollectorProtocol,
-			},
-		}
-
-		return utils.RunTraceAndPrintStatusOutput(config, callback)
-	},
+type SocketFlags struct {
+	protocol string
+	extended bool
 }
 
 func init() {
-	SnapshotCmd.AddCommand(socketCollectorCmd)
-	utils.AddCommonFlags(socketCollectorCmd, &params)
+	socketCmd := initSocketCmd()
+	SnapshotCmd.AddCommand(socketCmd)
+}
+
+func initSocketCmd() *cobra.Command {
+	var commonFlags utils.CommonFlags
+	var socketFlags SocketFlags
+
+	cmd := &cobra.Command{
+		Use:   "socket",
+		Short: "Gather information about TCP and UDP sockets",
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if _, err := types.ParseProtocol(socketFlags.protocol); err != nil {
+				return err
+			}
+
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			config := &utils.TraceConfig{
+				GadgetName:       "socket-collector",
+				Operation:        "collect",
+				TraceOutputMode:  "Status",
+				TraceOutputState: "Completed",
+				CommonFlags:      &commonFlags,
+				Parameters: map[string]string{
+					"protocol": socketFlags.protocol,
+				},
+			}
+
+			callback := func(results []gadgetv1alpha1.Trace) error {
+				allEvents := []types.Event{}
+
+				for _, i := range results {
+					if len(i.Status.Output) == 0 {
+						continue
+					}
+
+					var events []types.Event
+					if err := json.Unmarshal([]byte(i.Status.Output), &events); err != nil {
+						return utils.WrapInErrUnmarshalOutput(err, i.Status.Output)
+					}
+					allEvents = append(allEvents, events...)
+				}
+
+				sortSocketEvents(allEvents)
+
+				switch commonFlags.OutputMode {
+				case utils.OutputModeJSON:
+					b, err := json.MarshalIndent(allEvents, "", "  ")
+					if err != nil {
+						return utils.WrapInErrMarshalOutput(err)
+					}
+
+					fmt.Printf("%s\n", b)
+					return nil
+				case utils.OutputModeColumns:
+					fallthrough
+				case utils.OutputModeCustomColumns:
+					// In the snapshot gadgets it's possible to use a tabwriter because
+					// we have the full list of events to print available, hence the
+					// tablewriter is able to determine the columns width. In other
+					// gadgets we don't know the size of all columns "a priori", hence
+					// we have to do a best effort printing fixed-width columns.
+					w := tabwriter.NewWriter(os.Stdout, 0, 0, 4, ' ', 0)
+
+					fmt.Fprintln(w, getSocketColsHeader(&socketFlags, commonFlags.CustomColumns))
+
+					for _, e := range allEvents {
+						if e.Type != eventtypes.NORMAL {
+							utils.ManageSpecialEvent(e.Event, commonFlags.Verbose)
+							continue
+						}
+
+						fmt.Fprintln(w, transformSocketEvent(&e, &socketFlags, &commonFlags.OutputConfig))
+					}
+
+					w.Flush()
+				default:
+					return utils.WrapInErrOutputModeNotSupported(commonFlags.OutputMode)
+				}
+
+				return nil
+			}
+
+			return utils.RunTraceAndPrintStatusOutput(config, callback)
+		},
+	}
 
 	var protocols []string
 	for protocol := range types.ProtocolsMap {
 		protocols = append(protocols, protocol)
 	}
 
-	socketCollectorCmd.PersistentFlags().StringVarP(
-		&socketCollectorProtocol,
+	cmd.PersistentFlags().StringVarP(
+		&socketFlags.protocol,
 		"proto",
 		"",
 		"all",
 		fmt.Sprintf("Show only sockets using this protocol (%s)", strings.Join(protocols, ", ")),
 	)
-	socketCollectorCmd.PersistentFlags().BoolVarP(
-		&socketCollectorParamExtended,
+	cmd.PersistentFlags().BoolVarP(
+		&socketFlags.extended,
 		"extend",
 		"e",
 		false,
 		"Display other/more information (like socket inode)",
 	)
+
+	utils.AddCommonFlags(cmd, &commonFlags)
+
+	return cmd
 }
 
-func getCustomSocketColsHeader(cols []string) string {
-	var sb strings.Builder
+// getSocketColsHeader returns a header with the default list of columns
+// when it is not requested to use a subset of custom columns.
+func getSocketColsHeader(socketFlags *SocketFlags, requestedCols []string) string {
+	availableCols := map[string]struct{}{
+		"node":      {},
+		"namespace": {},
+		"pod":       {},
+		"protocol":  {},
+		"local":     {},
+		"remote":    {},
+		"status":    {},
+		"inode":     {},
+	}
 
-	for _, col := range cols {
-		switch col {
-		case "node":
-			sb.WriteString("NODE\t")
-		case "namespace":
-			sb.WriteString("NAMESPACE\t")
-		case "pod":
-			sb.WriteString("POD\t")
-		case "protocol":
-			sb.WriteString("PROTOCOL\t")
-		case "local":
-			sb.WriteString("LOCAL\t")
-		case "remote":
-			sb.WriteString("REMOTE\t")
-		case "status":
-			sb.WriteString("STATUS\t")
-		case "inode":
-			sb.WriteString("INODE\t")
+	if len(requestedCols) == 0 {
+		requestedCols = []string{"node", "namespace", "pod", "protocol", "local", "remote", "status"}
+		if socketFlags.extended {
+			requestedCols = append(requestedCols, "inode")
 		}
-		sb.WriteRune(' ')
 	}
 
-	return sb.String()
+	return buildSnapshotColsHeader(availableCols, requestedCols)
 }
 
-// socketTransformEvent is called to transform an event to columns
-// format according to the parameters
-func socketTransformEvent(e types.Event) string {
+// transformSocketEvent is called to transform an event to columns
+// format according to the parameters.
+func transformSocketEvent(e *types.Event, socketFlags *SocketFlags, outputConf *utils.OutputConfig) string {
 	var sb strings.Builder
 
-	if e.Type != eventtypes.NORMAL {
-		utils.ManageSpecialEvent(e.Event, params.Verbose)
-		return ""
-	}
-
-	switch params.OutputMode {
+	switch outputConf.OutputMode {
 	case utils.OutputModeColumns:
 		extendedInformation := ""
-		if socketCollectorParamExtended {
+		if socketFlags.extended {
 			extendedInformation = fmt.Sprintf("\t%d", e.InodeNumber)
 		}
 
@@ -152,33 +191,35 @@ func socketTransformEvent(e types.Event) string {
 			e.LocalAddress, e.LocalPort, e.RemoteAddress, e.RemotePort,
 			e.Status, extendedInformation))
 	case utils.OutputModeCustomColumns:
-		for _, col := range params.CustomColumns {
+		for _, col := range outputConf.CustomColumns {
 			switch col {
 			case "node":
-				sb.WriteString(fmt.Sprintf("%s\t", e.Node))
+				sb.WriteString(fmt.Sprintf("%s", e.Node))
 			case "namespace":
-				sb.WriteString(fmt.Sprintf("%s\t", e.Namespace))
+				sb.WriteString(fmt.Sprintf("%s", e.Namespace))
 			case "pod":
-				sb.WriteString(fmt.Sprintf("%s\t", e.Pod))
+				sb.WriteString(fmt.Sprintf("%s", e.Pod))
 			case "protocol":
-				sb.WriteString(fmt.Sprintf("%s\t", e.Protocol))
+				sb.WriteString(fmt.Sprintf("%s", e.Protocol))
 			case "local":
-				sb.WriteString(fmt.Sprintf("%s:%d\t", e.LocalAddress, e.LocalPort))
+				sb.WriteString(fmt.Sprintf("%s:%d", e.LocalAddress, e.LocalPort))
 			case "remote":
-				sb.WriteString(fmt.Sprintf("%s:%d\t", e.RemoteAddress, e.RemotePort))
+				sb.WriteString(fmt.Sprintf("%s:%d", e.RemoteAddress, e.RemotePort))
 			case "status":
-				sb.WriteString(fmt.Sprintf("%s\t", e.Status))
+				sb.WriteString(fmt.Sprintf("%s", e.Status))
 			case "inode":
-				sb.WriteString(fmt.Sprintf("%d\t", e.InodeNumber))
+				sb.WriteString(fmt.Sprintf("%d", e.InodeNumber))
+			default:
+				continue
 			}
-			sb.WriteRune(' ')
+			sb.WriteRune('\t')
 		}
 	}
 
 	return sb.String()
 }
 
-func printSockets(allSockets []types.Event) error {
+func sortSocketEvents(allSockets []types.Event) {
 	sort.Slice(allSockets, func(i, j int) bool {
 		si, sj := allSockets[i], allSockets[j]
 		switch {
@@ -204,41 +245,4 @@ func printSockets(allSockets []types.Event) error {
 			return si.InodeNumber < sj.InodeNumber
 		}
 	})
-
-	// JSON output mode does not need any additional parsing
-	if params.OutputMode == utils.OutputModeJSON {
-		b, err := json.MarshalIndent(allSockets, "", "  ")
-		if err != nil {
-			return utils.WrapInErrMarshalOutput(err)
-		}
-		fmt.Printf("%s\n", b)
-		return nil
-	}
-
-	// In the snapshot gadgets it's possible to use a tabwriter because we have
-	// the full list of events to print available, hence the tablewriter is able
-	// to determine the columns width. In other gadgets we don't know the size
-	// of all columns "a priori", hence we have to do a best effort printing
-	// fixed-width columns.
-	w := tabwriter.NewWriter(os.Stdout, 0, 0, 4, ' ', 0)
-
-	// Print all or requested columns
-	switch params.OutputMode {
-	case utils.OutputModeCustomColumns:
-		fmt.Fprintln(w, getCustomSocketColsHeader(params.CustomColumns))
-	case utils.OutputModeColumns:
-		extendedHeader := ""
-		if socketCollectorParamExtended {
-			extendedHeader = "\tINODE"
-		}
-		fmt.Fprintf(w, "NODE\tNAMESPACE\tPOD\tPROTOCOL\tLOCAL\tREMOTE\tSTATUS%s\n", extendedHeader)
-	}
-
-	for _, s := range allSockets {
-		fmt.Fprintln(w, socketTransformEvent(s))
-	}
-
-	w.Flush()
-
-	return nil
 }

--- a/cmd/kubectl-gadget/utils/errors.go
+++ b/cmd/kubectl-gadget/utils/errors.go
@@ -67,7 +67,9 @@ func WrapInErrListGadgetTraces(err error) error {
 
 // Arguments
 
-var ErrJSONNotSupported = errors.New("JSON output format is not supported")
+func WrapInErrOutputModeNotSupported(mode string) error {
+	return fmt.Errorf("%q output mode is not supported", mode)
+}
 
 func WrapInErrArgsNotSupported(args string) error {
 	return fmt.Errorf("arguments not supported: %s", args)

--- a/cmd/kubectl-gadget/utils/flags.go
+++ b/cmd/kubectl-gadget/utils/flags.go
@@ -47,8 +47,23 @@ const (
 
 var supportedOutputModes = []string{OutputModeColumns, OutputModeJSON, OutputModeCustomColumns}
 
+// OutputConfig contains the flags that describes how to print the gadget's output
+type OutputConfig struct {
+	// OutputMode specifies the format output should be printed
+	OutputMode string
+
+	// List of columns to print (only meaningful when OutputMode is "columns=...")
+	CustomColumns []string
+
+	// Verbose prints additional information
+	Verbose bool
+}
+
 // CommonFlags contains CLI flags common to several gadgets
 type CommonFlags struct {
+	// OutputConfig describes the way output should be printed
+	OutputConfig
+
 	// LabelsRaw allows to filter containers with a label selector in the
 	// following format: key1=value1,key2=value2.
 	// It's the raw representation as passed by the user.
@@ -77,15 +92,6 @@ type CommonFlags struct {
 
 	// Containername allows to filter containers by name
 	Containername string
-
-	// OutputMode specifies the way output should be printed
-	OutputMode string
-
-	// Verbose prints additional information
-	Verbose bool
-
-	// List of columns to print (only meaningful when OutputMode is "columns=...")
-	CustomColumns []string
 
 	// Number of seconds that the gadget will run for
 	Timeout int

--- a/pkg/gadgets/process-collector/types/process-collector.go
+++ b/pkg/gadgets/process-collector/types/process-collector.go
@@ -25,3 +25,7 @@ type Event struct {
 	Command   string `json:"comm"`
 	MountNsID uint64 `json:"mntns"`
 }
+
+func (e Event) GetBaseEvent() eventtypes.Event {
+	return e.Event
+}

--- a/pkg/gadgets/socket-collector/types/socket-collector.go
+++ b/pkg/gadgets/socket-collector/types/socket-collector.go
@@ -55,3 +55,7 @@ func ParseProtocol(protocol string) (Proto, error) {
 
 	return INVALID, fmt.Errorf("%q is not a valid protocol value", protocol)
 }
+
+func (e Event) GetBaseEvent() eventtypes.Event {
+	return e.Event
+}


### PR DESCRIPTION
# Avoid repeated code on snapshot gadgets

This PR factorizes the code of the snapshot gadgets to avoid repeating patterns on each of them. The common code was moved to a snapshot source code, and each gadget kept only its specific code.

## Implementation details

I used generics to simplify the code. It implies updating the required Go to v1.18.

## Notes for reviewers

- I tried to make progressive changes at each commit so that it is easier to do a review per commit.
- Please consider that the final goal of this series of PRs is to move most of the code to other packages and then use it from local-gadget.
