### PR TITLE
go: Update to version 1.18

### DIFF
--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -49,9 +49,9 @@ jobs:
       run: |
         make -C gadget-container ebpf-objects
     - name: Lint
-      uses: golangci/golangci-lint-action@v3.1.0
+      uses: golangci/golangci-lint-action@v3.2.0
       with:
-        version: v1.44.2
+        version: v1.46.2
         working-directory: /home/runner/work/inspektor-gadget/inspektor-gadget
         # Workaround to display the output:
         # https://github.com/golangci/golangci-lint-action/issues/119#issuecomment-981090648

--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -17,22 +17,13 @@ jobs:
     # level: 0
     runs-on: ubuntu-latest
     steps:
-    - name: Setup go 1.17
-      uses: actions/setup-go@v1
+    - uses: actions/checkout@v3
+    - name: Setup go
+      uses: actions/setup-go@v3
       with:
-        go-version: 1.17
+        go-version: 1.18.3
+        cache: true
       id: go
-    - name: Cache go 1.17
-      uses: actions/cache@v2
-      with:
-        path: |
-          ~/.cache/go-build
-          ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-
-    - name: Check out code
-      uses: actions/checkout@v1
     - name: Check if generated files are updated
       run: |
         make manifests generate generate-documentation
@@ -43,22 +34,13 @@ jobs:
     # level: 0
     runs-on: ubuntu-latest
     steps:
-    - name: Setup go 1.17
-      uses: actions/setup-go@v1
+    - uses: actions/checkout@v3
+    - name: Setup go
+      uses: actions/setup-go@v3
       with:
-        go-version: 1.17
+        go-version: 1.18.3
+        cache: true
       id: go
-    - name: Cache go 1.17
-      uses: actions/cache@v2
-      with:
-        path: |
-          ~/.cache/go-build
-          ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-
-    - name: Check out code
-      uses: actions/checkout@v1
     - name: Install debian packages
       # ALERT This action must be run after code was checkout otherwise it will
       # not find this file.
@@ -87,22 +69,13 @@ jobs:
           - os: windows
             arch: arm64
     steps:
-    - name: Setup go 1.17
-      uses: actions/setup-go@v1
+    - uses: actions/checkout@v3
+    - name: Setup go
+      uses: actions/setup-go@v3
       with:
-        go-version: 1.17
+        go-version: 1.18.3
+        cache: true
       id: go
-    - name: Cache go 1.17
-      uses: actions/cache@v2
-      with:
-        path: |
-          ~/.cache/go-build
-          ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-
-    - name: Check out code
-      uses: actions/checkout@v1
     - name: Install debian packages
       uses: ./.github/actions/install-debian-packages
     - name: Set IMAGE_TAG
@@ -154,22 +127,13 @@ jobs:
         # TODO add local-gadget-linux-arm64
         local-gadget-target: [local-gadget-linux-amd64]
     steps:
-    - name: Setup go 1.17
-      uses: actions/setup-go@v1
+    - uses: actions/checkout@v3
+    - name: Setup go
+      uses: actions/setup-go@v3
       with:
-        go-version: 1.17
+        go-version: 1.18.3
+        cache: true
       id: go
-    - name: Cache go 1.17
-      uses: actions/cache@v2
-      with:
-        path: |
-          ~/.cache/go-build
-          ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-
-    - name: Check out code
-      uses: actions/checkout@v1
     - name: Install debian packages
       # ALERT This action must be run after code was checkout otherwise it will
       # not find this file.
@@ -198,6 +162,7 @@ jobs:
     # level: 0
     runs-on: ubuntu-latest
     steps:
+    - uses: actions/checkout@v3
     - name: Set up Docker Buildx
       id: buildx
       uses: docker/setup-buildx-action@v1
@@ -214,8 +179,6 @@ jobs:
         registry: ${{ secrets.CONTAINER_REGISTRY }}
         username: ${{ secrets.CONTAINER_REGISTRY_USERNAME }}
         password: ${{ secrets.CONTAINER_REGISTRY_PASSWORD }}
-    - name: Check out code
-      uses: actions/checkout@v1
     - name: Set IMAGE_TAG
       run: |
         TMP1=${GITHUB_REF#*/}
@@ -245,6 +208,7 @@ jobs:
     # level: 0
     runs-on: ubuntu-latest
     steps:
+    - uses: actions/checkout@v3
     - name: Set up Docker Buildx
       id: buildx
       uses: docker/setup-buildx-action@v1
@@ -261,8 +225,6 @@ jobs:
         registry: ${{ secrets.CONTAINER_REGISTRY }}
         username: ${{ secrets.CONTAINER_REGISTRY_USERNAME }}
         password: ${{ secrets.CONTAINER_REGISTRY_PASSWORD }}
-    - name: Check out code
-      uses: actions/checkout@v1
     - name: Set IMAGE_TAG
       run: |
         TMP1=${GITHUB_REF#*/}
@@ -295,6 +257,7 @@ jobs:
       matrix:
         example: [runc-hook, kube-container-collection]
     steps:
+    - uses: actions/checkout@v3
     - name: Set up Docker Buildx
       id: buildx
       uses: docker/setup-buildx-action@v1
@@ -304,8 +267,6 @@ jobs:
         registry: ${{ secrets.CONTAINER_REGISTRY }}
         username: ${{ secrets.CONTAINER_REGISTRY_USERNAME }}
         password: ${{ secrets.CONTAINER_REGISTRY_PASSWORD }}
-    - name: Check out code
-      uses: actions/checkout@v1
     - name: Set IMAGE_TAG
       run: |
         TMP1=${GITHUB_REF#*/}
@@ -328,22 +289,13 @@ jobs:
     # level: 0
     runs-on: ubuntu-latest
     steps:
-    - name: Setup go 1.17
-      uses: actions/setup-go@v1
+    - uses: actions/checkout@v3
+    - name: Setup go
+      uses: actions/setup-go@v3
       with:
-        go-version: 1.17
+        go-version: 1.18.3
+        cache: true
       id: go
-    - name: Cache go 1.17
-      uses: actions/cache@v2
-      with:
-        path: |
-          ~/.cache/go-build
-          ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-
-    - name: Check out code
-      uses: actions/checkout@v1
     - name: Install debian packages
       uses: ./.github/actions/install-debian-packages
     - name: Basic unit tests
@@ -358,22 +310,13 @@ jobs:
     # level: 0
     runs-on: ubuntu-latest
     steps:
-    - name: Setup go 1.17
-      uses: actions/setup-go@v1
+    - uses: actions/checkout@v3
+    - name: Setup go
+      uses: actions/setup-go@v3
       with:
-        go-version: 1.17
+        go-version: 1.18.3
+        cache: true
       id: go
-    - name: Cache go 1.17
-      uses: actions/cache@v2
-      with:
-        path: |
-          ~/.cache/go-build
-          ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-
-    - name: Check out code
-      uses: actions/checkout@v1
     - name: Install debian packages
       uses: ./.github/actions/install-debian-packages
     - name: Unit tests for local-gadget (as root)
@@ -441,8 +384,7 @@ jobs:
     concurrency:
       group: no-simultaneous-test-integration-aro
     steps:
-    - name: Check out code
-      uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Authenticate and set ARO cluster context
       # NOTE: This action generates the Kubernetes config file in the current
       # directory. Therefore, it must be run after checking out code otherwise
@@ -469,8 +411,7 @@ jobs:
     needs: [test-unit, build-kubectl-gadget, build-local-gadget, build-gadget-default-container-image]
     runs-on: ubuntu-latest
     steps:
-    - name: Check out code
-      uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Setup Minikube
       uses: manusa/actions-setup-minikube@v2.4.3
       with:
@@ -493,6 +434,7 @@ jobs:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
+    - uses: actions/checkout@v3
     - name: Create Release
       id: create_release
       uses: actions/create-release@v1.0.0
@@ -521,8 +463,6 @@ jobs:
         asset_path: integration-asset/gadget-integration-tests-job.yaml
         asset_name: gadget-integration-tests-job.yaml
         asset_content_type: application/x-yaml
-    - name: Check out code
-      uses: actions/checkout@v1
     - name: Update new version in krew-index
       if: github.repository == 'kinvolk/inspektor-gadget'
       uses: rajatjindal/krew-release-bot@v0.0.40

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -35,12 +35,12 @@ linters:
 
 linters-settings:
   gofumpt:
-    lang-version: "1.17"
+    lang-version: "1.18"
   staticcheck:
-    go: "1.17"
+    go: "1.18"
     checks: ["all"]
   stylecheck:
-    go: "1.17"
+    go: "1.18"
     checks: ["all"]
   errorlint:
     # https://github.com/polyfloyd/go-errorlint

--- a/crd.mk
+++ b/crd.mk
@@ -7,7 +7,9 @@ TMP_DIR=$$(mktemp -d) ;\
 cd $$TMP_DIR ;\
 go mod init tmp ;\
 echo "Downloading $(2)" ;\
-GOBIN=$(PROJECT_DIR)/bin go get $(2) ;\
+go get $(2) ;\
+echo "Installing $(2)" ;\
+GOBIN=$(PROJECT_DIR)/bin go install $(2) ;\
 rm -rf $$TMP_DIR ;\
 }
 endef

--- a/docs/install.md
+++ b/docs/install.md
@@ -52,7 +52,7 @@ $ kubectl gadget version
 ### Compile from source
 
 To build Inspektor Gadget from source, you'll need to have a Golang version
-1.16 or higher installed.
+1.18 or higher installed.
 
 ```bash
 $ git clone https://github.com/kinvolk/inspektor-gadget.git

--- a/go.mod
+++ b/go.mod
@@ -1,23 +1,21 @@
 module github.com/kinvolk/inspektor-gadget
 
+go 1.18
+
 require (
 	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e
 	github.com/cilium/ebpf v0.8.2-0.20220502122259-96aa1a7a929f
-	github.com/containerd/containerd v1.5.11 // indirect
 	github.com/containerd/nri v0.1.1-0.20210619071632-28f76457b672
 	github.com/containers/common v0.46.0
-	github.com/docker/distribution v2.8.0+incompatible // indirect
 	github.com/docker/docker v20.10.8+incompatible
 	github.com/docker/go-units v0.4.0
 	github.com/giantswarm/crd-docs-generator v0.7.1
-	github.com/google/uuid v1.2.0 // indirect
-	github.com/iovisor/gobpf v0.2.0 // indirect
+	github.com/google/uuid v1.2.0
 	github.com/kinvolk/traceloop v0.0.0-20210623155108-6f4efc6fca46
 	github.com/kr/pretty v0.3.0
 	github.com/onsi/ginkgo v1.16.4
 	github.com/onsi/gomega v1.16.0
 	github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417
-	github.com/opencontainers/selinux v1.10.0 // indirect
 	github.com/s3rj1k/go-fanotify/fanotify v0.0.0-20210917134616-9c00a300bb7a
 	github.com/seccomp/libseccomp-golang v0.9.2-0.20210429002308-3879420cc921
 	github.com/sirupsen/logrus v1.8.1
@@ -43,7 +41,119 @@ require (
 	sigs.k8s.io/yaml v1.2.0
 )
 
-go 1.16
+require (
+	cloud.google.com/go v0.81.0 // indirect
+	github.com/Azure/go-autorest v14.2.0+incompatible // indirect
+	github.com/Azure/go-autorest/autorest v0.11.18 // indirect
+	github.com/Azure/go-autorest/autorest/adal v0.9.13 // indirect
+	github.com/Azure/go-autorest/autorest/date v0.3.0 // indirect
+	github.com/Azure/go-autorest/logger v0.2.1 // indirect
+	github.com/Azure/go-autorest/tracing v0.6.0 // indirect
+	github.com/Masterminds/goutils v1.1.0 // indirect
+	github.com/Masterminds/semver v1.5.0 // indirect
+	github.com/Masterminds/sprig v2.22.0+incompatible // indirect
+	github.com/Microsoft/go-winio v0.5.0 // indirect
+	github.com/PuerkitoBio/purell v1.1.1 // indirect
+	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
+	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/cespare/xxhash/v2 v2.1.1 // indirect
+	github.com/containerd/containerd v1.5.11 // indirect
+	github.com/crossplane/crossplane-runtime v0.14.1-0.20210713194031-85b19c28ea88 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/docker/distribution v2.8.0+incompatible // indirect
+	github.com/docker/go-connections v0.4.0 // indirect
+	github.com/emicklei/go-restful v2.9.5+incompatible // indirect
+	github.com/evanphx/json-patch v4.11.0+incompatible // indirect
+	github.com/form3tech-oss/jwt-go v3.2.3+incompatible // indirect
+	github.com/fsnotify/fsnotify v1.4.9 // indirect
+	github.com/ghodss/yaml v1.0.0 // indirect
+	github.com/giantswarm/microerror v0.3.0 // indirect
+	github.com/go-errors/errors v1.0.1 // indirect
+	github.com/go-logr/logr v0.4.0 // indirect
+	github.com/go-logr/zapr v0.4.0 // indirect
+	github.com/go-openapi/jsonpointer v0.19.5 // indirect
+	github.com/go-openapi/jsonreference v0.19.5 // indirect
+	github.com/go-openapi/spec v0.19.5 // indirect
+	github.com/go-openapi/swag v0.19.14 // indirect
+	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/google/btree v1.0.1 // indirect
+	github.com/google/go-cmp v0.5.6 // indirect
+	github.com/google/gofuzz v1.1.0 // indirect
+	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
+	github.com/googleapis/gnostic v0.5.5 // indirect
+	github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7 // indirect
+	github.com/hashicorp/hcl v1.0.0 // indirect
+	github.com/huandu/xstrings v1.3.2 // indirect
+	github.com/imdario/mergo v0.3.12 // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/iovisor/gobpf v0.2.0 // indirect
+	github.com/josharian/intern v1.0.0 // indirect
+	github.com/json-iterator/go v1.1.11 // indirect
+	github.com/kr/text v0.2.0 // indirect
+	github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de // indirect
+	github.com/magiconair/properties v1.8.5 // indirect
+	github.com/mailru/easyjson v0.7.6 // indirect
+	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
+	github.com/mitchellh/copystructure v1.0.0 // indirect
+	github.com/mitchellh/mapstructure v1.4.2 // indirect
+	github.com/mitchellh/reflectwalk v1.0.0 // indirect
+	github.com/moby/spdystream v0.2.0 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.1 // indirect
+	github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 // indirect
+	github.com/nxadm/tail v1.4.8 // indirect
+	github.com/opencontainers/go-digest v1.0.0 // indirect
+	github.com/opencontainers/image-spec v1.0.2 // indirect
+	github.com/opencontainers/selinux v1.10.0 // indirect
+	github.com/pelletier/go-toml v1.9.3 // indirect
+	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/prometheus/client_golang v1.11.0 // indirect
+	github.com/prometheus/client_model v0.2.0 // indirect
+	github.com/prometheus/common v0.26.0 // indirect
+	github.com/prometheus/procfs v0.6.0 // indirect
+	github.com/rogpeppe/go-internal v1.6.1 // indirect
+	github.com/russross/blackfriday/v2 v2.1.0 // indirect
+	github.com/spf13/afero v1.6.0 // indirect
+	github.com/spf13/cast v1.3.1 // indirect
+	github.com/spf13/jwalterweatherman v1.1.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/stretchr/testify v1.7.0 // indirect
+	github.com/subosito/gotenv v1.2.0 // indirect
+	github.com/xlab/treeprint v0.0.0-20181112141820-a009c3971eca // indirect
+	go.starlark.net v0.0.0-20200306205701-8dd3e2ee1dd5 // indirect
+	go.uber.org/atomic v1.7.0 // indirect
+	go.uber.org/multierr v1.6.0 // indirect
+	go.uber.org/zap v1.19.0 // indirect
+	golang.org/x/crypto v0.0.0-20210506145944-38f3c27a63bf // indirect
+	golang.org/x/mod v0.4.2 // indirect
+	golang.org/x/net v0.0.0-20210520170846-37e1c6afe023 // indirect
+	golang.org/x/oauth2 v0.0.0-20210402161424-2e8d93401602 // indirect
+	golang.org/x/text v0.3.7 // indirect
+	golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac // indirect
+	golang.org/x/tools v0.1.5 // indirect
+	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
+	gomodules.xyz/jsonpatch/v2 v2.2.0 // indirect
+	google.golang.org/appengine v1.6.7 // indirect
+	google.golang.org/genproto v0.0.0-20210602131652-f16073e35f0c // indirect
+	gopkg.in/inf.v0 v0.9.1 // indirect
+	gopkg.in/ini.v1 v1.62.0 // indirect
+	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
+	k8s.io/component-base v0.22.3 // indirect
+	k8s.io/gengo v0.0.0-20201214224949-b6c5ce23f027 // indirect
+	k8s.io/klog/v2 v2.10.0 // indirect
+	k8s.io/kube-openapi v0.0.0-20210421082810-95288971da7e // indirect
+	k8s.io/utils v0.0.0-20210819203725-bdf08cb9a70a // indirect
+	sigs.k8s.io/kustomize/api v0.8.5 // indirect
+	sigs.k8s.io/kustomize/kyaml v0.10.15 // indirect
+	sigs.k8s.io/release-utils v0.3.0 // indirect
+	sigs.k8s.io/structured-merge-diff/v4 v4.1.2 // indirect
+)
 
 // avoid reports on CVE-2021-3121
 replace (

--- a/go.sum
+++ b/go.sum
@@ -101,7 +101,6 @@ github.com/Microsoft/hcsshim v0.8.15/go.mod h1:x38A4YbHbdxJtc0sF6oIz+RG0npwSCAvn
 github.com/Microsoft/hcsshim v0.8.16/go.mod h1:o5/SZqmR7x9JNKsW3pu+nqHm0MF8vbA+VxGOoXdC600=
 github.com/Microsoft/hcsshim v0.8.20/go.mod h1:+w2gRZ5ReXQhFOrvSQeNfhrYB/dg3oDwTOcER2fw4I4=
 github.com/Microsoft/hcsshim v0.8.22/go.mod h1:91uVCVzvX2QD16sMCenoxxXo6L1wJnLMX2PSufFMtF0=
-github.com/Microsoft/hcsshim v0.8.24/go.mod h1:4zegtUJth7lAvFyc6cH2gGQ5B3OFQim01nnU2M8jKDg=
 github.com/Microsoft/hcsshim/test v0.0.0-20201218223536-d3e5debf77da/go.mod h1:5hlzMzRKMLyo42nCZ9oml8AdTlq/0cvIaBv6tK1RehU=
 github.com/Microsoft/hcsshim/test v0.0.0-20210227013316-43a75bb4edd3/go.mod h1:mw7qgWloBUl75W/gVH3cQszUg1+gUITj7D6NY7ywVnY=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
@@ -167,11 +166,9 @@ github.com/bugsnag/osext v0.0.0-20130617224835-0dd3f918b21b/go.mod h1:obH5gd0Bsq
 github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0/go.mod h1:D/8v3kj0zr8ZAKg1AQ6crr+5VwKN5eIywRkfhyM/+dE=
 github.com/carolynvs/magex v0.5.0/go.mod h1:i4bMWEmwGw2+W/u/0cEs5FTEyLtaN5DEKvVLV+KOEsc=
 github.com/carolynvs/magex v0.6.0/go.mod h1:hqaEkr9TAv+kFb/5wgDiTdszF13rpe0Q+bWHmTe6N74=
-github.com/cenkalti/backoff/v4 v4.1.1/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/certifi/gocertifi v0.0.0-20191021191039-0944d244cd40/go.mod h1:sGbDF6GwGcLpkNXPUTkMRoywsNa/ol15pxFe6ERfguA=
 github.com/certifi/gocertifi v0.0.0-20200922220541-2c3bb06c6054/go.mod h1:sGbDF6GwGcLpkNXPUTkMRoywsNa/ol15pxFe6ERfguA=
-github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+qY=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
@@ -189,8 +186,6 @@ github.com/cilium/ebpf v0.0.0-20200702112145-1c8d4c9ef775/go.mod h1:7cR51M8ViRLI
 github.com/cilium/ebpf v0.2.0/go.mod h1:To2CFviqOWL/M0gIMsvSMlqe7em/l1ALkX1PyjrX2Qs=
 github.com/cilium/ebpf v0.4.0/go.mod h1:4tRaxcgiL706VnOzHOdBlY8IEAIdxINsQBcU4xJJXRs=
 github.com/cilium/ebpf v0.6.2/go.mod h1:4tRaxcgiL706VnOzHOdBlY8IEAIdxINsQBcU4xJJXRs=
-github.com/cilium/ebpf v0.8.2-0.20220329140945-23f447c3cb0c h1:eA5PLaUAWdnThvVxM4ix0GuMHotHTQ3XdOmPzvGyEpo=
-github.com/cilium/ebpf v0.8.2-0.20220329140945-23f447c3cb0c/go.mod h1:f5zLIM0FSNuAkSyLAN7X+Hy6yznlF1mNiWUMfxMtrgk=
 github.com/cilium/ebpf v0.8.2-0.20220502122259-96aa1a7a929f h1:6s/s6X7MyRPonDp/GFzpmUzwL7vY1yeAr7eajLDxwA4=
 github.com/cilium/ebpf v0.8.2-0.20220502122259-96aa1a7a929f/go.mod h1:+OhNOIXx/Fnu1IE8bJz2dzOA+VSfyTfdNUVdlQnxUFY=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
@@ -276,7 +271,6 @@ github.com/containerd/ttrpc v0.0.0-20190828172938-92c8520ef9f8/go.mod h1:PvCDdDG
 github.com/containerd/ttrpc v0.0.0-20191028202541-4f1b8fe65a5c/go.mod h1:LPm1u0xBw8r8NOKoOdNMeVHSawSsltak+Ihv+etqsE8=
 github.com/containerd/ttrpc v1.0.1/go.mod h1:UAxOpgT9ziI0gJrmKvgcZivgxOp8iFPSk8httJEt98Y=
 github.com/containerd/ttrpc v1.0.2/go.mod h1:UAxOpgT9ziI0gJrmKvgcZivgxOp8iFPSk8httJEt98Y=
-github.com/containerd/ttrpc v1.1.0/go.mod h1:XX4ZTnoOId4HklF4edwc4DcqskFZuvXB1Evzy5KFQpQ=
 github.com/containerd/typeurl v0.0.0-20180627222232-a93fcdb778cd/go.mod h1:Cm3kwCdlkCfMSHURc+r6fwoGH6/F1hH3S4sg0rLFWPc=
 github.com/containerd/typeurl v0.0.0-20190911142611-5eb25027c9fd/go.mod h1:GeKYzf2pQcqv7tJ0AoCuuhtnqhva5LNU3U+OyKxxJpk=
 github.com/containerd/typeurl v1.0.1/go.mod h1:TB1hUtrpaiO88KEK56ijojHS1+NeF0izUACaJW2mdXg=
@@ -401,7 +395,6 @@ github.com/form3tech-oss/jwt-go v3.2.3+incompatible h1:7ZaBxOI7TMoYBfyA3cQHErNNy
 github.com/form3tech-oss/jwt-go v3.2.3+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/frankban/quicktest v1.11.3/go.mod h1:wRf/ReqHper53s+kmmSZizM8NamnL3IM0I9ntUbOk+k=
 github.com/frankban/quicktest v1.14.0 h1:+cqqvzZV87b4adx/5ayVOaYZ2CrvM4ejQvUdBzPPUss=
-github.com/frankban/quicktest v1.14.0/go.mod h1:NeW+ay9A/U67EYXNFA1nPE8e/tnQv/09mUdL/ijj8og=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
@@ -949,7 +942,6 @@ github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6L
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.6.1 h1:/FiVV8dS/e+YqF2JvO3yXRFbBLTIuSDkuC7aBOAvL+k=
 github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
-github.com/russross/blackfriday v1.5.2 h1:HyvC0ARfnZBqnXwABFeSZHpKvJHJJfPz81GNueLj0oo=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
@@ -1398,12 +1390,10 @@ golang.org/x/sys v0.0.0-20210426230700-d19ff857e887/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210514084401-e8d321eab015/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210817190340-bfb29a6856f2/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210820121016-41cdb8703e55/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20210906170528-6f6e22806c34/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220307203707-22a9840ba4d7 h1:8IVLkfbr2cLhv0a/vKq4UFUcJym8RmDoDboxCFWEjYE=
 golang.org/x/sys v0.0.0-20220307203707-22a9840ba4d7/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
@@ -1760,7 +1750,6 @@ k8s.io/gengo v0.0.0-20201214224949-b6c5ce23f027/go.mod h1:FiNAH4ZV3gBg2Kwh89tzAE
 k8s.io/klog v0.0.0-20181102134211-b9b56d5dfc92/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
 k8s.io/klog v0.3.0/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
 k8s.io/klog v0.4.0/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
-k8s.io/klog v1.0.0 h1:Pt+yjF5aB1xDSVbau4VsWe+dQNzA0qv1LlXdC2dF6Q8=
 k8s.io/klog v1.0.0/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
 k8s.io/klog/v2 v2.0.0/go.mod h1:PBfzABfn139FHAV07az/IF9Wp1bkk3vpT2XSJ76fSDE=
 k8s.io/klog/v2 v2.2.0/go.mod h1:Od+F08eJP+W3HUb4pSrPpgp9DGU4GzlpG/TmITuYh/Y=
@@ -1809,7 +1798,6 @@ sigs.k8s.io/release-utils v0.3.0/go.mod h1:J9xpziRNRI4mAeMZxPRryDodQMoMudMu6yC1a
 sigs.k8s.io/security-profiles-operator v0.3.1-0.20211122222133-6e12fe5f2daa h1:8RzTe/SdkPzPHa+5+TET5+vgJLC0ncDwBMbWjeAaOtI=
 sigs.k8s.io/security-profiles-operator v0.3.1-0.20211122222133-6e12fe5f2daa/go.mod h1:/1WBPHbr4WhRu9fcU8IcuHkEq2QVun+VqJa+wOHINz4=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=
-sigs.k8s.io/structured-merge-diff v0.0.0-20190817042607-6149e4549fca h1:6dsH6AYQWbyZmtttJNe8Gq1cXOeS1BdV3eW37zHilAQ=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190817042607-6149e4549fca/go.mod h1:IIgPezJWb76P0hotTxzDbWsMYB8APh18qZnxkomBpxA=
 sigs.k8s.io/structured-merge-diff/v4 v4.0.2/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK1F7G282QMXDPYydCw=
 sigs.k8s.io/structured-merge-diff/v4 v4.0.3/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK1F7G282QMXDPYydCw=

--- a/hack/client-gen.sh
+++ b/hack/client-gen.sh
@@ -29,6 +29,7 @@ go mod init tmp
 
 echo "require k8s.io/code-generator v0.21.2" >> go.mod
 
+go get tmp/hack
 go mod vendor
 
 popd

--- a/pkg/gadgets/capabilities/tracer/core/tracer.go
+++ b/pkg/gadgets/capabilities/tracer/core/tracer.go
@@ -96,7 +96,8 @@ var capabilitiesNames = map[uint32]string{
 }
 
 func NewTracer(c *tracer.Config, resolver containercollection.ContainerResolver,
-	eventCallback func(types.Event), node string) (*Tracer, error) {
+	eventCallback func(types.Event), node string,
+) (*Tracer, error) {
 	t := &Tracer{
 		config:        c,
 		resolver:      resolver,

--- a/pkg/gadgets/execsnoop/tracer/core/tracer.go
+++ b/pkg/gadgets/execsnoop/tracer/core/tracer.go
@@ -52,7 +52,8 @@ type Tracer struct {
 }
 
 func NewTracer(config *tracer.Config, resolver containercollection.ContainerResolver,
-	eventCallback func(types.Event), node string) (*Tracer, error) {
+	eventCallback func(types.Event), node string,
+) (*Tracer, error) {
 	t := &Tracer{
 		config:        config,
 		resolver:      resolver,

--- a/pkg/gadgets/filetop/tracer/tracer.go
+++ b/pkg/gadgets/filetop/tracer/tracer.go
@@ -59,7 +59,8 @@ type Tracer struct {
 }
 
 func NewTracer(config *Config, resolver containercollection.ContainerResolver,
-	statsCallback func([]types.Stats), errorCallback func(error)) (*Tracer, error) {
+	statsCallback func([]types.Stats), errorCallback func(error),
+) (*Tracer, error) {
 	t := &Tracer{
 		config:        config,
 		resolver:      resolver,

--- a/pkg/gadgets/fsslower/tracer/core/tracer.go
+++ b/pkg/gadgets/fsslower/tracer/core/tracer.go
@@ -92,7 +92,8 @@ var fsConfMap = map[string]fsConf{
 }
 
 func NewTracer(config *tracer.Config, resolver containercollection.ContainerResolver,
-	eventCallback func(types.Event), node string) (*Tracer, error) {
+	eventCallback func(types.Event), node string,
+) (*Tracer, error) {
 	t := &Tracer{
 		config:        config,
 		resolver:      resolver,

--- a/pkg/gadgets/mountsnoop/tracer/core/tracer.go
+++ b/pkg/gadgets/mountsnoop/tracer/core/tracer.go
@@ -54,7 +54,8 @@ type Tracer struct {
 }
 
 func NewTracer(config *tracer.Config, resolver containercollection.ContainerResolver,
-	eventCallback func(types.Event), node string) (*Tracer, error) {
+	eventCallback func(types.Event), node string,
+) (*Tracer, error) {
 	t := &Tracer{config: config}
 
 	t.resolver = resolver

--- a/pkg/gadgets/opensnoop/tracer/core/tracer.go
+++ b/pkg/gadgets/opensnoop/tracer/core/tracer.go
@@ -54,7 +54,8 @@ type Tracer struct {
 }
 
 func NewTracer(config *tracer.Config, resolver containercollection.ContainerResolver,
-	eventCallback func(types.Event), node string) (*Tracer, error) {
+	eventCallback func(types.Event), node string,
+) (*Tracer, error) {
 	t := &Tracer{config: config}
 
 	t.resolver = resolver

--- a/pkg/gadgets/sigsnoop/tracer/core/tracer.go
+++ b/pkg/gadgets/sigsnoop/tracer/core/tracer.go
@@ -79,7 +79,8 @@ func signalIntToString(signal int) string {
 }
 
 func NewTracer(config *tracer.Config, resolver containercollection.ContainerResolver,
-	eventCallback func(types.Event), node string) (*Tracer, error) {
+	eventCallback func(types.Event), node string,
+) (*Tracer, error) {
 	t := &Tracer{
 		config:        config,
 		resolver:      resolver,

--- a/pkg/gadgets/standardtracerbase.go
+++ b/pkg/gadgets/standardtracerbase.go
@@ -40,7 +40,8 @@ type StandardTracerBase struct {
 }
 
 func NewStandardTracer(lineCallback func(string), mntnsmap *ebpf.Map, name string,
-	args ...string) (*StandardTracerBase, error) {
+	args ...string,
+) (*StandardTracerBase, error) {
 	t := &StandardTracerBase{
 		lineCallback: lineCallback,
 		done:         make(chan bool),

--- a/pkg/gadgets/tcpconnect/tracer/core/tracer.go
+++ b/pkg/gadgets/tcpconnect/tracer/core/tracer.go
@@ -87,7 +87,8 @@ type Tracer struct {
 }
 
 func NewTracer(config *tracer.Config, resolver containercollection.ContainerResolver,
-	eventCallback func(types.Event), node string) (*Tracer, error) {
+	eventCallback func(types.Event), node string,
+) (*Tracer, error) {
 	t := &Tracer{config: config}
 
 	t.resolver = resolver


### PR DESCRIPTION
# go: Update to version 1.18

Go 1.18 is useful because:
- it introduces generics (see #695)
- we depends on cilium/ebpf which requires Go 1.18

This PR updates to Go 1.18, update the GitHub Action with the cache feature from `setup-go` and add fixes required by Go 1.18.

## How to use

No changes.

## Testing done

None
