### PR TITLE
go: Update to version 1.18 in Dockerfiles

### DIFF
--- a/gadget-core.Dockerfile
+++ b/gadget-core.Dockerfile
@@ -22,8 +22,8 @@ RUN set -ex; \
 	add-apt-repository -y ppa:tuxinvader/kernel-build-tools && \
 	apt-add-repository -y ppa:longsleep/golang-backports && \
 	apt-get update && \
-	apt-get install -y libbpf-dev golang-1.17 && \
-	ln -s /usr/lib/go-1.17/bin/go /bin/go
+	apt-get install -y libbpf-dev golang-1.18 && \
+	ln -s /usr/lib/go-1.18/bin/go /bin/go
 
 # Download BTFHub files
 COPY ./tools /btf-tools

--- a/gadget-default.Dockerfile
+++ b/gadget-default.Dockerfile
@@ -22,8 +22,8 @@ RUN set -ex; \
 	add-apt-repository -y ppa:tuxinvader/kernel-build-tools && \
 	apt-add-repository -y ppa:longsleep/golang-backports && \
 	apt-get update && \
-	apt-get install -y libbpf-dev golang-1.17 && \
-	ln -s /usr/lib/go-1.17/bin/go /bin/go
+	apt-get install -y libbpf-dev golang-1.18 && \
+	ln -s /usr/lib/go-1.18/bin/go /bin/go
 
 # Download BTFHub files
 COPY ./tools /btf-tools

--- a/integration/Dockerfile
+++ b/integration/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.14-alpine AS build_base
+FROM golang:1.18-alpine AS build_base
 RUN apk add --no-cache git
 WORKDIR /build
 RUN go get -d -v github.com/kr/pretty

--- a/integration/Dockerfile
+++ b/integration/Dockerfile
@@ -1,8 +1,11 @@
 FROM golang:1.18-alpine AS build_base
 RUN apk add --no-cache git
 WORKDIR /build
-RUN go get -d -v github.com/kr/pretty
-RUN go install -v github.com/kr/pretty
+
+# Cache go modules so they won't be downloaded at each build
+COPY go.mod go.sum /build/
+RUN cd /build && go mod download
+
 COPY . .
 RUN go test -c -o gadget-integration.test ./...
 

--- a/integration/Makefile
+++ b/integration/Makefile
@@ -1,5 +1,5 @@
 CONTAINER_REPO ?= docker.io/kinvolk/gadget
-IMAGE_TAG ?= $(shell ./tools/image-tag branch)
+IMAGE_TAG ?= $(shell ../tools/image-tag branch)
 
 TESTS_DOCKER_ARGS ?= -e KUBECONFIG=/opt/kubeconfig/config -v $(HOME)/.kube:/opt/kubeconfig
 

--- a/integration/go.mod
+++ b/integration/go.mod
@@ -1,0 +1,10 @@
+module integration
+
+go 1.18
+
+require github.com/kr/pretty v0.3.0
+
+require (
+	github.com/kr/text v0.2.0 // indirect
+	github.com/rogpeppe/go-internal v1.6.1 // indirect
+)

--- a/integration/go.sum
+++ b/integration/go.sum
@@ -1,0 +1,12 @@
+github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
+github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
+github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=
+github.com/kr/pretty v0.3.0/go.mod h1:640gp4NfQd8pI5XOwp5fnNeVWj67G7CFk/SaSQn7NBk=
+github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
+github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
+github.com/rogpeppe/go-internal v1.6.1 h1:/FiVV8dS/e+YqF2JvO3yXRFbBLTIuSDkuC7aBOAvL+k=
+github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
+gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=

--- a/local-gadget-linux-arm64.Dockerfile
+++ b/local-gadget-linux-arm64.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17 AS builder
+FROM golang:1.18 AS builder
 
 RUN \
 	dpkg --add-architecture arm64 && \


### PR DESCRIPTION
The Dockerfiles were forgotten in the previous update to Go 1.18

Follow-up to https://github.com/kinvolk/inspektor-gadget/pull/696