### PR TITLE
ci/integration-tests: Update to the use new version of SPO/CertManager

### DIFF
--- a/docs/guides/advise/seccomp-profile.md
+++ b/docs/guides/advise/seccomp-profile.md
@@ -260,25 +260,15 @@ operations need to take place to bring up the pod.
 
 ### Integration with Kubernetes Security Profiles Operator
 
-We can use the output stored in the trace to create the seccomp policy for
-our pod. But instead of copying it manually, we can also use the
-integration with the [Kubernetes Security Profiles
-Operator](https://github.com/kubernetes-sigs/security-profiles-operator).
-
-To install the operator, use the following commands:
-
-<!--
-In our code, we include seccompprofile/v1beta1, thus we apply from v0.4.0 to
-ensure operator.yaml applies on our code.
--->
-```bash
-$ kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.6.0/cert-manager.yaml
-$ kubectl --namespace cert-manager wait --for condition=ready pod -l app.kubernetes.io/instance=cert-manager
-$ kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/security-profiles-operator/v0.4.0/deploy/operator.yaml
-```
-
-Once installed, the seccomp gadget can generate `seccompprofile` resources
-that can be used directly by our pods.
+We can use the output stored in the trace to create the seccomp policy for our
+pod. But instead of copying it manually, we can also use the integration with
+the [Kubernetes Security Profiles Operator
+(SPO)](https://github.com/kubernetes-sigs/security-profiles-operator). Notice
+the seccomp gadget uses the seccomp profile API `v1beta1`, so at least SPO
+v0.4.0 is required. Check the [SPO
+documentation](https://github.com/kubernetes-sigs/security-profiles-operator/blob/main/installation-usage.md#install-operator)
+for details about installation. Once the SPO is installed, the seccomp gadget
+can generate `seccompprofile` resources that can be used directly by our pods.
 
 We need to use the `--output-mode` (or simply `-m`) option to create the
 `SeccompProfile` resource instead of printing the policy in the terminal

--- a/integration/command.go
+++ b/integration/command.go
@@ -90,9 +90,9 @@ var waitUntilInspektorGadgetPodsDeployed *command = &command{
 
 func deploySPO(limitReplicas, bestEffortResourceMgmt bool) *command {
 	cmdStr := fmt.Sprintf(`
-kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.7.2/cert-manager.yaml
+kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.8.0/cert-manager.yaml
 kubectl --namespace cert-manager wait --for condition=ready pod -l app.kubernetes.io/instance=cert-manager
-curl https://raw.githubusercontent.com/kubernetes-sigs/security-profiles-operator/v0.4.2/deploy/operator.yaml | \
+curl https://raw.githubusercontent.com/kubernetes-sigs/security-profiles-operator/v0.4.3/deploy/operator.yaml | \
   if [ %v = true ] ; then
     sed 's/replicas: 3/replicas: 1/' | grep -v cpu:
   else
@@ -139,7 +139,7 @@ fi
 # At this point, the webhook and daemon were created, wait til they are ready.
 kubectl -n security-profiles-operator wait deploy security-profiles-operator-webhook --for condition=available || \
   (kubectl get pod -n security-profiles-operator ; kubectl get events -n security-profiles-operator ; false)
-kubectl rollout status -n security-profiles-operator ds spod --timeout=120s || \
+kubectl rollout status -n security-profiles-operator ds spod --timeout=180s || \
   (kubectl get pod -n security-profiles-operator ; kubectl get events -n security-profiles-operator ; false)
 `, limitReplicas, bestEffortResourceMgmt)
 	return &command{
@@ -166,8 +166,8 @@ var cleanupSPO *command = &command{
 	name: "RemoveSecurityProfilesOperator",
 	cmd: `
 	kubectl delete seccompprofile -n security-profiles-operator --all
-	kubectl delete -f https://raw.githubusercontent.com/kubernetes-sigs/security-profiles-operator/v0.4.2/deploy/operator.yaml
-	kubectl delete -f https://github.com/jetstack/cert-manager/releases/download/v1.7.2/cert-manager.yaml
+	kubectl delete -f https://raw.githubusercontent.com/kubernetes-sigs/security-profiles-operator/v0.4.3/deploy/operator.yaml
+	kubectl delete -f https://github.com/jetstack/cert-manager/releases/download/v1.8.0/cert-manager.yaml
 	`,
 	cleanup: true,
 }


### PR DESCRIPTION
# Update to use the new version of SPO/CertManager

The SPO releases [v0.4.3](https://github.com/kubernetes-sigs/security-profiles-operator/releases/tag/v0.4.3). From [the installation usage](https://github.com/kubernetes-sigs/security-profiles-operator/blob/v0.4.3/installation-usage.md), it says that it is necessary to install the CertManager v1.8.0.

After some local tests, I noticed that the installation takes almost 2 min (which is also our timeout), so I increased the timeout.

## Testing done

CI tests passed.
