### PR TITLE
Makefile: support containerd in minikube-install target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -173,7 +173,8 @@ lint:
 	docker run --rm -v $(shell pwd):/app -w /app golangci/golangci-lint:v1.46.2 golangci-lint run --fix
 
 # minikube
-LIVENESS_PROBE_INITIAL_DELAY_SECONDS ?= 10
+LIVENESS_PROBE_INITIAL_DELAY_SECONDS ?= 60
+LIVENESS_PROBE ?= true
 .PHONY: minikube-install
 minikube-install: gadget-default-container kubectl-gadget
 	@echo "Image on the host:"
@@ -194,8 +195,9 @@ minikube-install: gadget-default-container kubectl-gadget
 	# Remove all resources created by Inspektor Gadget.
 	./kubectl-gadget undeploy || true
 	./kubectl-gadget deploy --hook-mode=auto \
+		--liveness-probe=$(LIVENESS_PROBE) \
 		--image-pull-policy=Never | \
-		sed 's/initialDelaySeconds: 10/initialDelaySeconds: '$(LIVENESS_PROBE_INITIAL_DELAY_SECONDS)'/g' | \
+		sed 's/initialDelaySeconds: [0-9]*/initialDelaySeconds: '$(LIVENESS_PROBE_INITIAL_DELAY_SECONDS)'/g' | \
 		kubectl apply -f -
 	kubectl rollout status daemonset -n gadget gadget --timeout 30s
 	@echo "Image used by the gadget pod:"


### PR DESCRIPTION
# Makefile: support containerd in minikube-install target

The minikube-install target was using 'minikube docker-env', which only
works with the docker container runtime. Also support 'minikube image
load' for other container runtimes.

## How to use

```
$ minikube start --container-runtime=containerd --cni=calico
...
$ make minikube-install
...
Image on the host:
docker image list --format "table {{.ID}}\t{{.Repository}}:{{.Tag}}\t{{.Size}}" |grep albantest.azurecr.io/gadget:alban_minikube_containerd
dbda06991888   albantest.azurecr.io/gadget:alban_minikube_containerd                        805MB

...
Image in Minikube:
minikube image ls --format=table | grep "albantest.azurecr.io/gadget\s*|\s*alban_minikube_containerd" || true
| albantest.azurecr.io/gadget             | alban_minikube_containerd | sha256:dbda06 | 354MB  |

...
kubectl rollout status daemonset -n gadget gadget --timeout 30s
Waiting for daemon set "gadget" rollout to finish: 0 of 1 updated pods are available...
daemon set "gadget" successfully rolled out
Image used by the gadget pod:
kubectl get pod -n gadget -o yaml|grep imageID:
      imageID: sha256:dbda06991888a342f38c19938cd62f953f450cd7a76824e723da730d6e171447
```

## Testing done

Tested with `minikube start --container-runtime=containerd --cni=calico`
