### PR TITLE
kubectl-gadget/deploy: Use quotes to avoid incorrect parsing

### DIFF
--- a/cmd/kubectl-gadget/deploy.go
+++ b/cmd/kubectl-gadget/deploy.go
@@ -189,8 +189,8 @@ spec:
       containers:
       - name: gadget
         terminationMessagePolicy: FallbackToLogsOnError
-        image: {{.Image}}
-        imagePullPolicy: {{.ImagePullPolicy}}
+        image: "{{.Image}}"
+        imagePullPolicy: "{{.ImagePullPolicy}}"
         command: [ "/entrypoint.sh" ]
         lifecycle:
           preStop:
@@ -228,9 +228,9 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
           - name: GADGET_IMAGE
-            value: {{.Image}}
+            value: "{{.Image}}"
           - name: INSPEKTOR_GADGET_VERSION
-            value: {{.Version}}
+            value: "{{.Version}}"
           - name: INSPEKTOR_GADGET_OPTION_HOOK_MODE
             value: "{{.HookMode}}"
           - name: INSPEKTOR_GADGET_OPTION_FALLBACK_POD_INFORMER


### PR DESCRIPTION
# Use quotes to avoid incorrect parsing

Use quotes to ensure that string fields are parsed as a string and avoid the following error when the values could be also parsed as a number, e.g. `8510575` or `47704e5` (which is read as `4770400000`).

```bash
$ kubectl-gadget deploy $GADGET_IMAGE_FLAG | kubectl apply -f -
Error from server (BadRequest): error when creating "STDIN": DaemonSetin version "v1" cannot be handled as a DaemonSet: v1.DaemonSet.Spec:v1.DaemonSetSpec.Template: v1.PodTemplateSpec.Spec:v1.PodSpec.Containers: []v1.Container: v1.Container.Env: []v1.EnvVar:v1.EnvVar.Value: ReadString: expects " or n, but found 8, error found in #10 byte of ...|,"value":8510575},{"|..., bigger context...|-re"},{"name":"INSPEKTOR_GADGET_VERSION","value":8510575},{"name":"INSPEKTOR_GADGET_OPTION_HOOK_MODE|...
```

This issue was making the CI fails. Some examples:

- https://github.com/kinvolk/inspektor-gadget/runs/7030503378?check_suite_focus=true
- https://github.com/kinvolk/inspektor-gadget/runs/7089051572?check_suite_focus=true

## Testing done

### Before this PR
```bash
$ make kubectl-gadget VERSION=12345678
export GO111MODULE=on CGO_ENABLED=0 && \
export GOOS=linux GOARCH=amd64 && \
go build -ldflags "-X main.version=12345678 -X main.gadgetimage=192.168.1.105:5000/gadget:latest -extldflags '-static'" \
        -o kubectl-gadget-${GOOS}-${GOARCH} \
        github.com/kinvolk/inspektor-gadget/cmd/kubectl-gadget
mv kubectl-gadget-linux-amd64 kubectl-gadget

$ ./kubectl-gadget deploy | grep INSPEKTOR_GADGET_VERSION -C 2
          - name: GADGET_IMAGE
            value: 192.168.1.105:5000/gadget:latest
          - name: INSPEKTOR_GADGET_VERSION
            value: 12345678
          - name: INSPEKTOR_GADGET_OPTION_HOOK_MODE

$ ./kubectl-gadget deploy | k apply -f -
customresourcedefinition.apiextensions.k8s.io/traces.gadget.kinvolk.io created
namespace/gadget created
serviceaccount/gadget created
role.rbac.authorization.k8s.io/gadget-role created
rolebinding.rbac.authorization.k8s.io/gadget-role-binding created
clusterrole.rbac.authorization.k8s.io/gadget-cluster-role created
clusterrolebinding.rbac.authorization.k8s.io/gadget-cluster-role-binding created
Error from server (BadRequest): error when creating "STDIN": DaemonSet in version "v1" cannot be handled as a DaemonSet: v1.DaemonSet.Spec: v1.DaemonSetSpec.Template: v1.PodTemplateSpec.Spec: v1.PodSpec.Containers: []v1.Container: v1.Container.Env: []v1.EnvVar: v1.EnvVar.Value: ReadString: expects " or n, but found 1, error found in #10 byte of ...|,"value":12345678},{|..., bigger context ...|est"},{"name":"INSPEKTOR_GADGET_VERSION","value":12345678},{"name":"INSPEKTOR_GADGET_OPTION_HOOK_MOD|...
```


### After this PR
```bash
$ make kubectl-gadget VERSION=12345678
export GO111MODULE=on CGO_ENABLED=0 && \
export GOOS=linux GOARCH=amd64 && \
go build -ldflags "-X main.version=12345678 -X main.gadgetimage=192.168.1.105:5000/gadget:jose-fix-deploy-issue -extldflags '-static'" \
        -o kubectl-gadget-${GOOS}-${GOARCH} \
        github.com/kinvolk/inspektor-gadget/cmd/kubectl-gadget
mv kubectl-gadget-linux-amd64 kubectl-gadget

$ ./kubectl-gadget deploy | grep INSPEKTOR_GADGET_VERSION -C 2
          - name: GADGET_IMAGE
            value: "192.168.1.105:5000/gadget:jose-fix-deploy-issue"
          - name: INSPEKTOR_GADGET_VERSION
            value: "12345678"
          - name: INSPEKTOR_GADGET_OPTION_HOOK_MODE

$ ./kubectl-gadget deploy | k apply -f -
customresourcedefinition.apiextensions.k8s.io/traces.gadget.kinvolk.io created
namespace/gadget created
serviceaccount/gadget created
role.rbac.authorization.k8s.io/gadget-role created
rolebinding.rbac.authorization.k8s.io/gadget-role-binding created
clusterrole.rbac.authorization.k8s.io/gadget-cluster-role created
clusterrolebinding.rbac.authorization.k8s.io/gadget-cluster-role-binding created
daemonset.apps/gadget created
```
