### PR TITLE
kubectl-gadget: Remove trace CR dependency from CLI code

### DIFF
--- a/cmd/kubectl-gadget/advise/seccomp-profile.go
+++ b/cmd/kubectl-gadget/advise/seccomp-profile.go
@@ -23,7 +23,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/kinvolk/inspektor-gadget/cmd/kubectl-gadget/utils"
-	gadgetv1alpha1 "github.com/kinvolk/inspektor-gadget/pkg/apis/gadget/v1alpha1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -180,9 +179,9 @@ func runSeccompAdvisorStop(cmd *cobra.Command, args []string) error {
 
 	traceID := args[0]
 
-	callback := func(results []gadgetv1alpha1.Trace) error {
-		for _, i := range results {
-			if i.Spec.OutputMode == "ExternalResource" {
+	callback := func(traceOutputMode string, results []string) error {
+		for _, r := range results {
+			if traceOutputMode == "ExternalResource" {
 				profilesName, err := getSeccompProfilesName(traceID)
 				if err != nil {
 					return err
@@ -198,8 +197,8 @@ func runSeccompAdvisorStop(cmd *cobra.Command, args []string) error {
 				return nil
 			}
 
-			if i.Status.Output != "" {
-				fmt.Printf("%v\n", i.Status.Output)
+			if r != "" {
+				fmt.Printf("%v\n", r)
 			}
 		}
 

--- a/cmd/kubectl-gadget/profile/block-io.go
+++ b/cmd/kubectl-gadget/profile/block-io.go
@@ -26,7 +26,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/kinvolk/inspektor-gadget/cmd/kubectl-gadget/utils"
-	gadgetv1alpha1 "github.com/kinvolk/inspektor-gadget/pkg/apis/gadget/v1alpha1"
 	"github.com/kinvolk/inspektor-gadget/pkg/gadgets/biolatency/types"
 )
 
@@ -159,18 +158,18 @@ func runBiolatency(cmd *cobra.Command, args []string) error {
 		return utils.WrapInErrStopGadget(err)
 	}
 
-	displayResultsCallback := func(results []gadgetv1alpha1.Trace) error {
-		if len(results) != 1 {
+	displayResultsCallback := func(traceOutputMode string, results []string) error {
+		if len(results) > 1 {
 			return errors.New("there should be only one result because biolatency runs on one node at a time")
 		}
 
 		var output string
 		if params.OutputMode == utils.OutputModeJSON {
-			output = results[0].Status.Output
+			output = results[0]
 		} else {
 			var report types.Report
-			if err := json.Unmarshal([]byte(results[0].Status.Output), &report); err != nil {
-				return utils.WrapInErrUnmarshalOutput(err, results[0].Status.Output)
+			if err := json.Unmarshal([]byte(results[0]), &report); err != nil {
+				return utils.WrapInErrUnmarshalOutput(err, results[0])
 			}
 
 			output = reportToString(report)

--- a/cmd/kubectl-gadget/profile/cpu.go
+++ b/cmd/kubectl-gadget/profile/cpu.go
@@ -23,7 +23,6 @@ import (
 	"time"
 
 	"github.com/kinvolk/inspektor-gadget/cmd/kubectl-gadget/utils"
-	gadgetv1alpha1 "github.com/kinvolk/inspektor-gadget/pkg/apis/gadget/v1alpha1"
 	"github.com/kinvolk/inspektor-gadget/pkg/gadgets/profile/types"
 
 	"github.com/spf13/cobra"
@@ -153,7 +152,7 @@ func runProfileCPU(cmd *cobra.Command, args []string) error {
 		return utils.WrapInErrStopGadget(err)
 	}
 
-	displayResultsCallback := func(traces []gadgetv1alpha1.Trace) error {
+	displayResultsCallback := func(traceOutputMode string, results []string) error {
 		// print header
 		switch params.OutputMode {
 		case utils.OutputModeCustomColumns:
@@ -163,10 +162,10 @@ func runProfileCPU(cmd *cobra.Command, args []string) error {
 				"NODE", "NAMESPACE", "POD", "CONTAINER", "COMM", "PID", "COUNT")
 		}
 
-		for _, trace := range traces {
+		for _, r := range results {
 			var reports []types.Report
-			if err := json.Unmarshal([]byte(trace.Status.Output), &reports); err != nil {
-				return utils.WrapInErrUnmarshalOutput(err, trace.Status.Output)
+			if err := json.Unmarshal([]byte(r), &reports); err != nil {
+				return utils.WrapInErrUnmarshalOutput(err, r)
 			}
 
 			for _, report := range reports {

--- a/cmd/kubectl-gadget/snapshot/snapshot.go
+++ b/cmd/kubectl-gadget/snapshot/snapshot.go
@@ -24,7 +24,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/kinvolk/inspektor-gadget/cmd/kubectl-gadget/utils"
-	gadgetv1alpha1 "github.com/kinvolk/inspektor-gadget/pkg/apis/gadget/v1alpha1"
 	processcollectortypes "github.com/kinvolk/inspektor-gadget/pkg/gadgets/process-collector/types"
 	socketcollectortypes "github.com/kinvolk/inspektor-gadget/pkg/gadgets/socket-collector/types"
 	eventtypes "github.com/kinvolk/inspektor-gadget/pkg/types"
@@ -100,17 +99,17 @@ func (g *SnapshotGadget[Event]) Run() error {
 	// This callback function be called when a snapshot gadget finishes without
 	// errors and generates a list of results per node. It merges, sorts and
 	// print all of them in the requested mode.
-	callback := func(results []gadgetv1alpha1.Trace) error {
+	callback := func(traceOutputMode string, results []string) error {
 		allEvents := []Event{}
 
-		for _, i := range results {
-			if len(i.Status.Output) == 0 {
+		for _, r := range results {
+			if len(r) == 0 {
 				continue
 			}
 
 			var events []Event
-			if err := json.Unmarshal([]byte(i.Status.Output), &events); err != nil {
-				return utils.WrapInErrUnmarshalOutput(err, i.Status.Output)
+			if err := json.Unmarshal([]byte(r), &events); err != nil {
+				return utils.WrapInErrUnmarshalOutput(err, r)
 			}
 			allEvents = append(allEvents, events...)
 		}


### PR DESCRIPTION
# Remove trace CR dependency from CLI code

This PR removes the dependency of the Trace CR from the CLI-specific code. Now, the only code that imports `gadgetv1alpha1` is [utils/trace](https://github.com/kinvolk/inspektor-gadget/blob/d31164c5726530fd81eb50bbb4156b92ab474fad/cmd/kubectl-gadget/utils/trace.go#L40) which is indeed the module in charge of transforming the user request (through the CLI) to a Trace CR to communicate with the gadget pod.

## Implementation details

The advise-seccomp gadget could be still improved to use `PrintTraceOutputFromStatus` only when it is using the `Status` output mode. It would also allow to remove the `traceOutputMode` from the callback, see [here](https://github.com/kinvolk/inspektor-gadget/blob/da286f7ed1ed3769840d402cada5f4172bb9cd03/cmd/kubectl-gadget/utils/trace.go#L716-L719).

## How to use

It does not have any impact on the client-side.
