### PR TITLE
gadgets/network-graph: Fix eBPF code compilation

### DIFF
--- a/pkg/gadgets/network-graph/tracer/bpf/graph.h
+++ b/pkg/gadgets/network-graph/tracer/bpf/graph.h
@@ -4,7 +4,15 @@
 #ifndef GADGET_NETWORK_GRAPH_H
 #define GADGET_NETWORK_GRAPH_H
 
-#include "../../../../vmlinux/vmlinux-cgo.h"
+#ifdef __TARGET_ARCH_arm64
+#include "../../../../arm64/vmlinux/vmlinux-cgo.h"
+#else
+// In several case (e.g. make test), we compile this file without having set
+// BPF_ARCH, so we default to include amd64 vmlinux.h.
+// For other architecture, like arm64, we use __TARGET_ARCH_arch to
+// differentiate.
+#include "../../../../amd64/vmlinux/vmlinux-cgo.h"
+#endif
 
 #define MAX_ENTRIES	10240
 


### PR DESCRIPTION
This commit fixes a compilation issue when building the eBPF programs
of the network-graph gadget:

```
In file included from [...]pkg/gadgets/network-graph/tracer/bpf/graphmap.c:4:
In file included from ./bpf/graphmap.h:10:
./bpf/graph.h:7:10: fatal error: '../../../../vmlinux/vmlinux-cgo.h' file not found
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
Error: clang: exit status 1
exit status 1
tracer.go:30: running "bash": exit status 1
```

This uses the same approach as in the audit-seccomp gadget.

