### PR TITLE
cmd/kubeclt-gadget: Do not try to print empty results in profile/block-io

### DIFF
--- a/cmd/kubectl-gadget/profile/block-io.go
+++ b/cmd/kubectl-gadget/profile/block-io.go
@@ -130,8 +130,12 @@ func reportToString(report types.Report) string {
 }
 
 func (p *BlockIOParser) DisplayResultsCallback(traceOutputMode string, results []string) error {
-	if len(results) > 1 {
+	l := len(results)
+	if l > 1 {
 		return errors.New("there should be only one result because biolatency runs on one node at a time")
+	} else if l == 0 {
+		// Nothing to print, errors/warnings were already printed
+		return nil
 	}
 
 	var output string


### PR DESCRIPTION
# Do not try to print empty results in profile/block-io

This PR fixes the following error (full logs [here](https://github.com/kinvolk/inspektor-gadget/runs/7330130963?check_suite_focus=true)) introduced in PR https://github.com/kinvolk/inspektor-gadget/pull/746:

```bash
--- FAIL: TestBiolatency (15.54s)
    command.go:378: Run command(RunBiolatencyGadget):
        $KUBECTL_GADGET profile block-io --node $(kubectl get node --no-headers | cut -d' ' -f1 | head -1) --timeout 15
    command.go:380: Command returned(RunBiolatencyGadget):
        Error: failed to run gadget on node "fv-az135-470": Not started
        panic: runtime error: index out of range [0] with length 0
        goroutine 1 [running]:
        github.com/kinvolk/inspektor-gadget/cmd/kubectl-gadget/profile.(*BlockIOParser).DisplayResultsCallback(0xc0003f3320?, {0xc0001a7a28?, 0x44b6b2?}, {0x25de840, 0x0, 0x9?})
        	/home/runner/work/inspektor-gadget/inspektor-gadget/cmd/kubectl-gadget/profile/block-io.go:143 +0x1f5
        github.com/kinvolk/inspektor-gadget/cmd/kubectl-gadget/utils.PrintTraceOutputFromStatus({0xc0003f3320?, 0x10?}, {0x17bffe2?, 0x4?}, 0xc0001a7d08)
        	/home/runner/work/inspektor-gadget/inspektor-gadget/cmd/kubectl-gadget/utils/trace.go:720 +0xc9
        github.com/kinvolk/inspektor-gadget/cmd/kubectl-gadget/profile.(*ProfileGadget).Run(0xc0001c1d40)
        	/home/runner/work/inspektor-gadget/inspektor-gadget/cmd/kubectl-gadget/profile/profile.go:92 +0x4c9
        github.com/kinvolk/inspektor-gadget/cmd/kubectl-gadget/profile.newBlockIOCmd.func2(0xc00021bb80?, {0xc00009da00?, 0x4?, 0x4?})
        	/home/runner/work/inspektor-gadget/inspektor-gadget/cmd/kubectl-gadget/profile/block-io.go:65 +0xd7
        github.com/spf13/cobra.(*Command).execute(0xc00021bb80, {0xc00009d9c0, 0x4, 0x4})
        	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.2.1/command.go:856 +0x67c
        github.com/spf13/cobra.(*Command).ExecuteC(0x2593c00)
        	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.2.1/command.go:974 +0x3b4
        github.com/spf13/cobra.(*Command).Execute(...)
        	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.2.1/command.go:902
        main.main()
        	/home/runner/work/inspektor-gadget/inspektor-gadget/cmd/kubectl-gadget/main.go:52 +0x25
        Tracing block device I/O...
```

This situation happens when the gadget fails so the `results` slice is empty and we still try to print it. 