### PR TITLE
cmd/kubectl-gadget: Remove requestedColumns parameter from TransformEvent()

### DIFF
--- a/cmd/kubectl-gadget/trace/bind.go
+++ b/cmd/kubectl-gadget/trace/bind.go
@@ -130,10 +130,10 @@ func NewBindParser(outputConfig *utils.OutputConfig) TraceParser[types.Event] {
 	}
 }
 
-func (p *BindParser) TransformEvent(event *types.Event, requestedColumns []string) string {
+func (p *BindParser) TransformEvent(event *types.Event) string {
 	var sb strings.Builder
 
-	for _, col := range requestedColumns {
+	for _, col := range p.OutputConfig.CustomColumns {
 		switch col {
 		case "node":
 			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Node))

--- a/cmd/kubectl-gadget/trace/capabilities.go
+++ b/cmd/kubectl-gadget/trace/capabilities.go
@@ -89,10 +89,10 @@ func NewCapabilitiesParser(outputConfig *utils.OutputConfig) TraceParser[types.E
 	}
 }
 
-func (p *CapabilitiesParser) TransformEvent(event *types.Event, requestedColumns []string) string {
+func (p *CapabilitiesParser) TransformEvent(event *types.Event) string {
 	var sb strings.Builder
 
-	for _, col := range requestedColumns {
+	for _, col := range p.OutputConfig.CustomColumns {
 		switch col {
 		case "node":
 			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Node))

--- a/cmd/kubectl-gadget/trace/dns.go
+++ b/cmd/kubectl-gadget/trace/dns.go
@@ -81,10 +81,10 @@ func NewDNSParser(outputConfig *utils.OutputConfig) TraceParser[types.Event] {
 	}
 }
 
-func (p *DNSParser) TransformEvent(event *types.Event, requestedColumns []string) string {
+func (p *DNSParser) TransformEvent(event *types.Event) string {
 	var sb strings.Builder
 
-	for _, col := range requestedColumns {
+	for _, col := range p.OutputConfig.CustomColumns {
 		switch col {
 		case "node":
 			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Node))

--- a/cmd/kubectl-gadget/trace/exec.go
+++ b/cmd/kubectl-gadget/trace/exec.go
@@ -87,10 +87,10 @@ func NewExecParser(outputConfig *utils.OutputConfig) TraceParser[types.Event] {
 	}
 }
 
-func (p *ExecParser) TransformEvent(event *types.Event, requestedColumns []string) string {
+func (p *ExecParser) TransformEvent(event *types.Event) string {
 	var sb strings.Builder
 
-	for _, col := range requestedColumns {
+	for _, col := range p.OutputConfig.CustomColumns {
 		switch col {
 		case "node":
 			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Node))

--- a/cmd/kubectl-gadget/trace/fsslower.go
+++ b/cmd/kubectl-gadget/trace/fsslower.go
@@ -134,7 +134,7 @@ func NewFsslowerParser(outputConfig *utils.OutputConfig) TraceParser[types.Event
 	}
 }
 
-func (p *FsslowerParser) TransformEvent(event *types.Event, requestedColumns []string) string {
+func (p *FsslowerParser) TransformEvent(event *types.Event) string {
 	var sb strings.Builder
 
 	// TODO: what to print in this case?
@@ -142,7 +142,7 @@ func (p *FsslowerParser) TransformEvent(event *types.Event, requestedColumns []s
 		event.Bytes = 0
 	}
 
-	for _, col := range requestedColumns {
+	for _, col := range p.OutputConfig.CustomColumns {
 		switch col {
 		case "node":
 			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Node))

--- a/cmd/kubectl-gadget/trace/mount.go
+++ b/cmd/kubectl-gadget/trace/mount.go
@@ -109,10 +109,10 @@ func getCall(e *types.Event) string {
 	return ""
 }
 
-func (p *MountParser) TransformEvent(event *types.Event, requestedColumns []string) string {
+func (p *MountParser) TransformEvent(event *types.Event) string {
 	var sb strings.Builder
 
-	for _, col := range requestedColumns {
+	for _, col := range p.OutputConfig.CustomColumns {
 		switch col {
 		case "node":
 			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Node))

--- a/cmd/kubectl-gadget/trace/network.go
+++ b/cmd/kubectl-gadget/trace/network.go
@@ -83,7 +83,7 @@ func NewNetworkParser(outputConfig *utils.OutputConfig) TraceParser[types.Event]
 	}
 }
 
-func (p *NetworkParser) TransformEvent(event *types.Event, requestedColumns []string) string {
+func (p *NetworkParser) TransformEvent(event *types.Event) string {
 	var sb strings.Builder
 
 	if event.Pod == "" {
@@ -103,7 +103,7 @@ func (p *NetworkParser) TransformEvent(event *types.Event, requestedColumns []st
 		remote = fmt.Sprintf("? %s", event.Debug)
 	}
 
-	for _, col := range requestedColumns {
+	for _, col := range p.OutputConfig.CustomColumns {
 		switch col {
 		case "node":
 			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Node))

--- a/cmd/kubectl-gadget/trace/oomkill.go
+++ b/cmd/kubectl-gadget/trace/oomkill.go
@@ -86,10 +86,10 @@ func NewOOMKillParser(outputConfig *utils.OutputConfig) TraceParser[types.Event]
 	}
 }
 
-func (p *OOMKillParser) TransformEvent(event *types.Event, requestedColumns []string) string {
+func (p *OOMKillParser) TransformEvent(event *types.Event) string {
 	var sb strings.Builder
 
-	for _, col := range requestedColumns {
+	for _, col := range p.OutputConfig.CustomColumns {
 		switch col {
 		case "node":
 			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Node))

--- a/cmd/kubectl-gadget/trace/open.go
+++ b/cmd/kubectl-gadget/trace/open.go
@@ -87,10 +87,10 @@ func NewOpenParser(outputConfig *utils.OutputConfig) TraceParser[types.Event] {
 	}
 }
 
-func (p *OpenParser) TransformEvent(event *types.Event, requestedColumns []string) string {
+func (p *OpenParser) TransformEvent(event *types.Event) string {
 	var sb strings.Builder
 
-	for _, col := range requestedColumns {
+	for _, col := range p.OutputConfig.CustomColumns {
 		switch col {
 		case "node":
 			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Node))

--- a/cmd/kubectl-gadget/trace/signal.go
+++ b/cmd/kubectl-gadget/trace/signal.go
@@ -122,10 +122,10 @@ func NewSignalParser(outputConfig *utils.OutputConfig) TraceParser[types.Event] 
 	}
 }
 
-func (p *SignalParser) TransformEvent(event *types.Event, requestedColumns []string) string {
+func (p *SignalParser) TransformEvent(event *types.Event) string {
 	var sb strings.Builder
 
-	for _, col := range requestedColumns {
+	for _, col := range p.OutputConfig.CustomColumns {
 		switch col {
 		case "node":
 			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Node))

--- a/cmd/kubectl-gadget/trace/sni.go
+++ b/cmd/kubectl-gadget/trace/sni.go
@@ -77,10 +77,10 @@ func NewSNIParser(outputConfig *utils.OutputConfig) TraceParser[types.Event] {
 	}
 }
 
-func (p *SNIParser) TransformEvent(event *types.Event, requestedColumns []string) string {
+func (p *SNIParser) TransformEvent(event *types.Event) string {
 	var sb strings.Builder
 
-	for _, col := range requestedColumns {
+	for _, col := range p.OutputConfig.CustomColumns {
 		switch col {
 		case "node":
 			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Node))

--- a/cmd/kubectl-gadget/trace/tcp.go
+++ b/cmd/kubectl-gadget/trace/tcp.go
@@ -108,10 +108,10 @@ func getOperationShort(operation string) string {
 	return "U"
 }
 
-func (p *TCPParser) TransformEvent(event *types.Event, requestedColumns []string) string {
+func (p *TCPParser) TransformEvent(event *types.Event) string {
 	var sb strings.Builder
 
-	for _, col := range requestedColumns {
+	for _, col := range p.OutputConfig.CustomColumns {
 		switch col {
 		case "node":
 			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Node))

--- a/cmd/kubectl-gadget/trace/tcpconnect.go
+++ b/cmd/kubectl-gadget/trace/tcpconnect.go
@@ -89,10 +89,10 @@ func NewTcpconnectParser(outputConfig *utils.OutputConfig) TraceParser[types.Eve
 	}
 }
 
-func (p *TcpconnectParser) TransformEvent(event *types.Event, requestedColumns []string) string {
+func (p *TcpconnectParser) TransformEvent(event *types.Event) string {
 	var sb strings.Builder
 
-	for _, col := range requestedColumns {
+	for _, col := range p.OutputConfig.CustomColumns {
 		switch col {
 		case "node":
 			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Node))

--- a/cmd/kubectl-gadget/trace/trace.go
+++ b/cmd/kubectl-gadget/trace/trace.go
@@ -40,7 +40,7 @@ type TraceEvent interface {
 // implement.
 type TraceParser[Event TraceEvent] interface {
 	// TransformEvent is called to transform an event to columns format.
-	TransformEvent(event *Event, requestedColumns []string) string
+	TransformEvent(event *Event) string
 
 	// PrintColumnsHeader prints the header with the requested custom columns
 	// that exist in the columnsWidth struct.
@@ -91,7 +91,7 @@ func (g *TraceGadget[Event]) Run() error {
 			return ""
 		}
 
-		return g.parser.TransformEvent(&e, g.commonFlags.CustomColumns)
+		return g.parser.TransformEvent(&e)
 	}
 
 	if err := utils.RunTraceAndPrintStream(config, transformEvent); err != nil {


### PR DESCRIPTION
The implementations of TraceParser already have this information when
they are instantiated. (BaseParser on this case). Hence, remove that
parameter to make this interface simpler.

