### PR TITLE
cmd/common: Merge `BaseSnapshot` and `commonutils.BaseParser`

### DIFF
--- a/cmd/common/snapshot/process.go
+++ b/cmd/common/snapshot/process.go
@@ -33,23 +33,20 @@ type ProcessFlags struct {
 }
 
 type ProcessParser struct {
-	BaseSnapshotParser
+	commonutils.BaseParser
 
 	processFlags *ProcessFlags
 }
 
 func NewCommonProcessCmd(
 	processFlags *ProcessFlags,
-	availableColumns map[string]struct{},
+	availableColumns []string,
 	outputConfig *commonutils.OutputConfig,
 	customRun func(callback func(traceOutputMode string, results []string) error) error,
 ) *cobra.Command {
 	processGadget := &SnapshotGadget[types.Event]{
 		parser: &ProcessParser{
-			BaseSnapshotParser: BaseSnapshotParser{
-				AvailableColumns: availableColumns,
-				OutputConfig:     outputConfig,
-			},
+			BaseParser:   commonutils.NewBaseTabParser(availableColumns, outputConfig),
 			processFlags: processFlags,
 		},
 		customRun: customRun,

--- a/cmd/common/snapshot/socket.go
+++ b/cmd/common/snapshot/socket.go
@@ -34,23 +34,20 @@ type SocketFlags struct {
 }
 
 type SocketParser struct {
-	BaseSnapshotParser
+	commonutils.BaseParser
 
 	socketFlags *SocketFlags
 }
 
 func NewSocketCmd(
 	socketFlags *SocketFlags,
-	availableColumns map[string]struct{},
+	availableColumns []string,
 	outputConfig *commonutils.OutputConfig,
 	customRun func(callback func(traceOutputMode string, results []string) error) error,
 ) *cobra.Command {
 	socketGadget := &SnapshotGadget[types.Event]{
 		parser: &SocketParser{
-			BaseSnapshotParser: BaseSnapshotParser{
-				AvailableColumns: availableColumns,
-				OutputConfig:     outputConfig,
-			},
+			BaseParser:  commonutils.NewBaseTabParser(availableColumns, outputConfig),
 			socketFlags: socketFlags,
 		},
 		customRun: customRun,

--- a/cmd/common/utils/parser.go
+++ b/cmd/common/utils/parser.go
@@ -19,24 +19,76 @@ import (
 	"strings"
 )
 
-// BaseParser is a base for a TraceParser to reuse the shared fields and
-// methods.
+// BaseParser is a base for a parser that implements the most common methods.
 type BaseParser struct {
+	// ColumnsWidth are the columns that can be configured to be printed with
+	// the width to be used.
 	ColumnsWidth map[string]int
+
+	// SeparateWithTabs defines whether the columns has to be separated with the
+	// width defined in ColumnsWidth (if false), or with tabs ignoring the width
+	// defined in ColumnsWidth (if true).
+	SeparateWithTabs bool
+
+	// OutputConfig provides to the parser the flags that describes how to print
+	// the gadget's output.
 	OutputConfig *OutputConfig
 }
 
-func (p *BaseParser) PrintColumnsHeader() {
+func NewBaseParser(columnsWidth map[string]int, useTabs bool, outputConfig *OutputConfig) BaseParser {
+	return BaseParser{
+		ColumnsWidth:     columnsWidth,
+		SeparateWithTabs: useTabs,
+		OutputConfig:     outputConfig,
+	}
+}
+
+// NewBaseTabParser returns a BaseParser configured to print columns separated
+// by tabs.
+func NewBaseTabParser(availableColumns []string, outputConfig *OutputConfig) BaseParser {
+	// Adapt an availableColumns slice to be passed to NewBaseParser. Given that
+	// NewBaseParser will be called with useTabs=true, the columns will be
+	// separated by tabs and the width values will be just ignored. Therefore,
+	// the width values used here don't matter at all.
+	adaptedColumns := make(map[string]int, len(availableColumns))
+	for _, v := range availableColumns {
+		adaptedColumns[v] = 0
+	}
+
+	return NewBaseParser(adaptedColumns, true, outputConfig)
+}
+
+// NewBaseWidthParser returns a BaseParser configured to print columns separated
+// by their predefined with.
+func NewBaseWidthParser(columnsWidth map[string]int, outputConfig *OutputConfig) BaseParser {
+	return NewBaseParser(columnsWidth, false, outputConfig)
+}
+
+func (p *BaseParser) BuildColumnsHeader() string {
 	var sb strings.Builder
 
 	for _, col := range p.OutputConfig.CustomColumns {
-		if width, ok := p.ColumnsWidth[col]; ok {
-			sb.WriteString(fmt.Sprintf("%*s", width, strings.ToUpper(col)))
+		width, ok := p.ColumnsWidth[col]
+		if !ok {
+			// Ignore invalid columns
+			continue
 		}
 
-		// Needed when field is larger than the predefined columnsWidth.
-		sb.WriteRune(' ')
+		if p.SeparateWithTabs {
+			// In this case, the generated header is expected to be printed
+			// using a tabwriter. See example of usage on the snapshot gadgets
+			// or the list-containers command of local-gadget.
+			sb.WriteString(strings.ToUpper(col) + "\t")
+		} else {
+			// Additional space is needed when field is larger than the
+			// predefined ColumnsWidth, see TransformEvent methods.
+			sb.WriteString(fmt.Sprintf("%*s ", width, strings.ToUpper(col)))
+		}
 	}
 
-	fmt.Println(sb.String())
+	return sb.String()
+}
+
+func (p *BaseParser) GetOutputConfig() *OutputConfig {
+	return p.OutputConfig
 }

--- a/cmd/common/utils/parser_test.go
+++ b/cmd/common/utils/parser_test.go
@@ -1,0 +1,139 @@
+// Copyright 2022 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestBaseParser(t *testing.T) {
+	table := []struct {
+		description    string
+		columnsWidth   map[string]int
+		useTabs        bool
+		outputConfig   *OutputConfig
+		expectedResult string
+	}{
+		{
+			description:  "empty CustomColumns",
+			outputConfig: &OutputConfig{},
+		},
+		{
+			description: "none valid column",
+			outputConfig: &OutputConfig{
+				CustomColumns: []string{"abc"},
+			},
+			columnsWidth: map[string]int{
+				"xyz": 0,
+			},
+		},
+		{
+			description: "ignore invalid column using width",
+			outputConfig: &OutputConfig{
+				CustomColumns: []string{"abc", "xyz"},
+			},
+			columnsWidth: map[string]int{
+				"xyz": -10,
+			},
+			useTabs:        false,
+			expectedResult: fmt.Sprintf("%-10s ", "XYZ"),
+		},
+		{
+			description: "ignore invalid column using tabs",
+			outputConfig: &OutputConfig{
+				CustomColumns: []string{"abc", "xyz"},
+			},
+			columnsWidth: map[string]int{
+				"xyz": 0,
+			},
+			useTabs:        true,
+			expectedResult: fmt.Sprintf("%s\t", "XYZ"),
+		},
+		{
+			description: "ignore multiple invalid columns using width",
+			outputConfig: &OutputConfig{
+				CustomColumns: []string{"abc", "dfe", "rst", "xyz"},
+			},
+			columnsWidth: map[string]int{
+				"xyz": -10,
+				"dfe": -5,
+			},
+			useTabs:        false,
+			expectedResult: fmt.Sprintf("%-5s %-10s ", "DFE", "XYZ"),
+		},
+		{
+			description: "ignore multiple invalid column using tabs",
+			outputConfig: &OutputConfig{
+				CustomColumns: []string{"abc", "dfe", "rst", "xyz"},
+			},
+			columnsWidth: map[string]int{
+				"xyz": 0,
+				"dfe": 0,
+			},
+			useTabs:        true,
+			expectedResult: fmt.Sprintf("%s\t%s\t", "DFE", "XYZ"),
+		},
+		{
+			description: "ignore columnWidth when using tabs",
+			outputConfig: &OutputConfig{
+				CustomColumns: []string{"dfe", "xyz"},
+			},
+			columnsWidth: map[string]int{
+				"xyz": -5,
+				"dfe": -10,
+			},
+			useTabs:        true,
+			expectedResult: fmt.Sprintf("%s\t%s\t", "DFE", "XYZ"),
+		},
+		{
+			description: "normal case using width",
+			outputConfig: &OutputConfig{
+				CustomColumns: []string{"abc", "dfe", "rst", "xyz"},
+			},
+			columnsWidth: map[string]int{
+				"abc": -7,
+				"dfe": -5,
+				"rst": -1,
+				"xyz": -10,
+			},
+			useTabs:        false,
+			expectedResult: fmt.Sprintf("%-7s %-5s %-1s %-10s ", "ABC", "DFE", "RST", "XYZ"),
+		},
+		{
+			description: "normal case using tabs",
+			outputConfig: &OutputConfig{
+				CustomColumns: []string{"abc", "dfe", "rst", "xyz"},
+			},
+			columnsWidth: map[string]int{
+				"abc": 0,
+				"dfe": 0,
+				"rst": 0,
+				"xyz": 0,
+			},
+			useTabs:        true,
+			expectedResult: fmt.Sprintf("%s\t%s\t%s\t%s\t", "ABC", "DFE", "RST", "XYZ"),
+		},
+	}
+
+	for i, entry := range table {
+		p := NewBaseParser(entry.columnsWidth, entry.useTabs, entry.outputConfig)
+		result := p.BuildColumnsHeader()
+		if result != entry.expectedResult {
+			t.Fatalf("Failed test %q (index %d): result %q expected %q",
+				entry.description, i, result, entry.expectedResult)
+		}
+	}
+}

--- a/cmd/kubectl-gadget/profile/cpu.go
+++ b/cmd/kubectl-gadget/profile/cpu.go
@@ -95,11 +95,8 @@ func newCPUCmd() *cobra.Command {
 				commonFlags:   commonFlags,
 				inProgressMsg: "Capturing stack traces",
 				parser: &CPUParser{
-					BaseParser: commonutils.BaseParser{
-						ColumnsWidth: columnsWidth,
-						OutputConfig: &commonFlags.OutputConfig,
-					},
-					cpuFlags: &cpuFlags,
+					BaseParser: commonutils.NewBaseWidthParser(columnsWidth, &commonFlags.OutputConfig),
+					cpuFlags:   &cpuFlags,
 				},
 			}
 
@@ -148,7 +145,7 @@ func (p *CPUParser) DisplayResultsCallback(traceOutputMode string, results []str
 			}
 		}
 
-		p.PrintColumnsHeader()
+		fmt.Println(p.BuildColumnsHeader())
 
 		// Add it back in the same position
 		if col == "stack" {

--- a/cmd/kubectl-gadget/snapshot/process.go
+++ b/cmd/kubectl-gadget/snapshot/process.go
@@ -41,14 +41,14 @@ func newProcessCmd() *cobra.Command {
 		},
 	}
 
-	availableColumns := map[string]struct{}{
-		"node":      {},
-		"namespace": {},
-		"pod":       {},
-		"container": {},
-		"comm":      {},
-		"tgid":      {},
-		"pid":       {},
+	availableColumns := []string{
+		"node",
+		"namespace",
+		"pod",
+		"container",
+		"comm",
+		"tgid",
+		"pid",
 	}
 
 	customRun := func(callback func(traceOutputMode string, results []string) error) error {

--- a/cmd/kubectl-gadget/snapshot/socket.go
+++ b/cmd/kubectl-gadget/snapshot/socket.go
@@ -42,15 +42,15 @@ func newSocketCmd() *cobra.Command {
 		},
 	}
 
-	availableColumns := map[string]struct{}{
-		"node":      {},
-		"namespace": {},
-		"pod":       {},
-		"protocol":  {},
-		"local":     {},
-		"remote":    {},
-		"status":    {},
-		"inode":     {},
+	availableColumns := []string{
+		"node",
+		"namespace",
+		"pod",
+		"protocol",
+		"local",
+		"remote",
+		"status",
+		"inode",
 	}
 
 	customRun := func(callback func(traceOutputMode string, results []string) error) error {

--- a/cmd/kubectl-gadget/trace/bind.go
+++ b/cmd/kubectl-gadget/trace/bind.go
@@ -124,10 +124,7 @@ func NewBindParser(outputConfig *commonutils.OutputConfig) TraceParser[types.Eve
 	}
 
 	return &BindParser{
-		BaseParser: commonutils.BaseParser{
-			ColumnsWidth: columnsWidth,
-			OutputConfig: outputConfig,
-		},
+		BaseParser: commonutils.NewBaseWidthParser(columnsWidth, outputConfig),
 	}
 }
 

--- a/cmd/kubectl-gadget/trace/capabilities.go
+++ b/cmd/kubectl-gadget/trace/capabilities.go
@@ -83,10 +83,7 @@ func NewCapabilitiesParser(outputConfig *commonutils.OutputConfig) TraceParser[t
 	}
 
 	return &CapabilitiesParser{
-		BaseParser: commonutils.BaseParser{
-			ColumnsWidth: columnsWidth,
-			OutputConfig: outputConfig,
-		},
+		BaseParser: commonutils.NewBaseWidthParser(columnsWidth, outputConfig),
 	}
 }
 

--- a/cmd/kubectl-gadget/trace/dns.go
+++ b/cmd/kubectl-gadget/trace/dns.go
@@ -75,10 +75,7 @@ func NewDNSParser(outputConfig *commonutils.OutputConfig) TraceParser[types.Even
 	}
 
 	return &DNSParser{
-		BaseParser: commonutils.BaseParser{
-			ColumnsWidth: columnsWidth,
-			OutputConfig: outputConfig,
-		},
+		BaseParser: commonutils.NewBaseWidthParser(columnsWidth, outputConfig),
 	}
 }
 

--- a/cmd/kubectl-gadget/trace/exec.go
+++ b/cmd/kubectl-gadget/trace/exec.go
@@ -81,10 +81,7 @@ func NewExecParser(outputConfig *commonutils.OutputConfig) TraceParser[types.Eve
 	}
 
 	return &ExecParser{
-		BaseParser: commonutils.BaseParser{
-			ColumnsWidth: columnsWidth,
-			OutputConfig: outputConfig,
-		},
+		BaseParser: commonutils.NewBaseWidthParser(columnsWidth, outputConfig),
 	}
 }
 

--- a/cmd/kubectl-gadget/trace/fsslower.go
+++ b/cmd/kubectl-gadget/trace/fsslower.go
@@ -128,10 +128,7 @@ func NewFsslowerParser(outputConfig *commonutils.OutputConfig) TraceParser[types
 	}
 
 	return &FsslowerParser{
-		BaseParser: commonutils.BaseParser{
-			ColumnsWidth: columnsWidth,
-			OutputConfig: outputConfig,
-		},
+		BaseParser: commonutils.NewBaseWidthParser(columnsWidth, outputConfig),
 	}
 }
 

--- a/cmd/kubectl-gadget/trace/mount.go
+++ b/cmd/kubectl-gadget/trace/mount.go
@@ -89,10 +89,7 @@ func NewMountParser(outputConfig *commonutils.OutputConfig) TraceParser[types.Ev
 	}
 
 	return &MountParser{
-		BaseParser: commonutils.BaseParser{
-			ColumnsWidth: columnsWidth,
-			OutputConfig: outputConfig,
-		},
+		BaseParser: commonutils.NewBaseWidthParser(columnsWidth, outputConfig),
 	}
 }
 

--- a/cmd/kubectl-gadget/trace/network.go
+++ b/cmd/kubectl-gadget/trace/network.go
@@ -77,10 +77,7 @@ func NewNetworkParser(outputConfig *commonutils.OutputConfig) TraceParser[types.
 	}
 
 	return &NetworkParser{
-		BaseParser: commonutils.BaseParser{
-			ColumnsWidth: columnsWidth,
-			OutputConfig: outputConfig,
-		},
+		BaseParser: commonutils.NewBaseWidthParser(columnsWidth, outputConfig),
 	}
 }
 

--- a/cmd/kubectl-gadget/trace/oomkill.go
+++ b/cmd/kubectl-gadget/trace/oomkill.go
@@ -81,10 +81,7 @@ func NewOOMKillParser(outputConfig *commonutils.OutputConfig) TraceParser[types.
 	}
 
 	return &OOMKillParser{
-		BaseParser: commonutils.BaseParser{
-			ColumnsWidth: columnsWidth,
-			OutputConfig: outputConfig,
-		},
+		BaseParser: commonutils.NewBaseWidthParser(columnsWidth, outputConfig),
 	}
 }
 

--- a/cmd/kubectl-gadget/trace/open.go
+++ b/cmd/kubectl-gadget/trace/open.go
@@ -81,10 +81,7 @@ func NewOpenParser(outputConfig *commonutils.OutputConfig) TraceParser[types.Eve
 	}
 
 	return &OpenParser{
-		BaseParser: commonutils.BaseParser{
-			ColumnsWidth: columnsWidth,
-			OutputConfig: outputConfig,
-		},
+		BaseParser: commonutils.NewBaseWidthParser(columnsWidth, outputConfig),
 	}
 }
 

--- a/cmd/kubectl-gadget/trace/signal.go
+++ b/cmd/kubectl-gadget/trace/signal.go
@@ -116,10 +116,7 @@ func NewSignalParser(outputConfig *commonutils.OutputConfig) TraceParser[types.E
 	}
 
 	return &SignalParser{
-		BaseParser: commonutils.BaseParser{
-			ColumnsWidth: columnsWidth,
-			OutputConfig: outputConfig,
-		},
+		BaseParser: commonutils.NewBaseWidthParser(columnsWidth, outputConfig),
 	}
 }
 

--- a/cmd/kubectl-gadget/trace/sni.go
+++ b/cmd/kubectl-gadget/trace/sni.go
@@ -71,10 +71,7 @@ func NewSNIParser(outputConfig *commonutils.OutputConfig) TraceParser[types.Even
 	}
 
 	return &SNIParser{
-		BaseParser: commonutils.BaseParser{
-			ColumnsWidth: columnsWidth,
-			OutputConfig: outputConfig,
-		},
+		BaseParser: commonutils.NewBaseWidthParser(columnsWidth, outputConfig),
 	}
 }
 

--- a/cmd/kubectl-gadget/trace/tcp.go
+++ b/cmd/kubectl-gadget/trace/tcp.go
@@ -87,10 +87,7 @@ func NewTCPParser(outputConfig *commonutils.OutputConfig) TraceParser[types.Even
 	}
 
 	return &TCPParser{
-		BaseParser: commonutils.BaseParser{
-			ColumnsWidth: columnsWidth,
-			OutputConfig: outputConfig,
-		},
+		BaseParser: commonutils.NewBaseWidthParser(columnsWidth, outputConfig),
 	}
 }
 

--- a/cmd/kubectl-gadget/trace/tcpconnect.go
+++ b/cmd/kubectl-gadget/trace/tcpconnect.go
@@ -83,10 +83,7 @@ func NewTcpconnectParser(outputConfig *commonutils.OutputConfig) TraceParser[typ
 	}
 
 	return &TcpconnectParser{
-		BaseParser: commonutils.BaseParser{
-			ColumnsWidth: columnsWidth,
-			OutputConfig: outputConfig,
-		},
+		BaseParser: commonutils.NewBaseWidthParser(columnsWidth, outputConfig),
 	}
 }
 

--- a/cmd/kubectl-gadget/trace/trace.go
+++ b/cmd/kubectl-gadget/trace/trace.go
@@ -42,9 +42,10 @@ type TraceParser[Event TraceEvent] interface {
 	// TransformEvent is called to transform an event to columns format.
 	TransformEvent(event *Event) string
 
-	// PrintColumnsHeader prints the header with the requested custom columns
-	// that exist in the columnsWidth struct.
-	PrintColumnsHeader()
+	// BuildColumnsHeader returns a header with the requested custom columns
+	// that exist in the predefined columns list. The columns are separated by
+	// the predefined width.
+	BuildColumnsHeader() string
 }
 
 // TraceGadget represents a gadget belonging to the trace category.
@@ -74,7 +75,7 @@ func (g *TraceGadget[Event]) Run() error {
 	case commonutils.OutputModeColumns:
 		fallthrough
 	case commonutils.OutputModeCustomColumns:
-		g.parser.PrintColumnsHeader()
+		fmt.Println(g.parser.BuildColumnsHeader())
 	}
 
 	transformEvent := func(line string) string {

--- a/cmd/local-gadget/snapshot/process.go
+++ b/cmd/local-gadget/snapshot/process.go
@@ -38,11 +38,11 @@ func newProcessCmd() *cobra.Command {
 		},
 	}
 
-	availableColumns := map[string]struct{}{
-		"container": {},
-		"comm":      {},
-		"tgid":      {},
-		"pid":       {},
+	availableColumns := []string{
+		"container",
+		"comm",
+		"tgid",
+		"pid",
 	}
 
 	customRun := func(callback func(string, []string) error) error {

--- a/cmd/local-gadget/snapshot/socket.go
+++ b/cmd/local-gadget/snapshot/socket.go
@@ -40,13 +40,13 @@ func newSocketCmd() *cobra.Command {
 		},
 	}
 
-	availableColumns := map[string]struct{}{
-		"pod":      {},
-		"protocol": {},
-		"local":    {},
-		"remote":   {},
-		"status":   {},
-		"inode":    {},
+	availableColumns := []string{
+		"pod",
+		"protocol",
+		"local",
+		"remote",
+		"status",
+		"inode",
 	}
 
 	customRun := func(callback func(string, []string) error) error {


### PR DESCRIPTION
# Merge `BaseSnapshot` and `commonutils.BaseParser`

When working on https://github.com/kinvolk/inspektor-gadget/pull/763, I wanted to reuse the logic already implemented for snapshot gadgets to print columns separated by taps. Therefore, I thought to move the `BaseSnapshot` implementation to the common utils library. However, once there, I realized that it was pretty similar to the already existing `BaseParser` used by other gadgets (trace category and profile/cpu gadget). The only difference is that one uses tabs and the other uses a predefined width. Therefore, I decided to [merge them](https://github.com/kinvolk/inspektor-gadget/blob/661aab572fa2554d3b158d9bac6561cba41a095b/cmd/common/utils/parser.go#L22-L36) and add a `SeparateWithTabs` which allows specifying whether the parser has to print using tabs or the predefined width.

## How to use

Tests gadgets using `BaseParser` (profile/cpu and all the traces) and the gadgets that were previously using the `BaseSnapshot` (snapshot category).

