### PR TITLE
cmd/local-gadget: Enrich list-containers with ID and Runtime information

### DIFF
--- a/cmd/local-gadget/containers/containers.go
+++ b/cmd/local-gadget/containers/containers.go
@@ -15,34 +15,177 @@
 package containers
 
 import (
+	"encoding/json"
 	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"text/tabwriter"
 
-	"github.com/kinvolk/inspektor-gadget/cmd/local-gadget/utils"
-	localgadgetmanager "github.com/kinvolk/inspektor-gadget/pkg/local-gadget-manager"
 	"github.com/spf13/cobra"
+
+	commonutils "github.com/kinvolk/inspektor-gadget/cmd/common/utils"
+	"github.com/kinvolk/inspektor-gadget/cmd/local-gadget/utils"
+	containercollection "github.com/kinvolk/inspektor-gadget/pkg/container-collection"
+	localgadgetmanager "github.com/kinvolk/inspektor-gadget/pkg/local-gadget-manager"
 )
 
+type ContainerFlags struct {
+	noTrunc bool
+}
+
+type ContainerParser struct {
+	commonutils.BaseParser
+
+	containerFlags *ContainerFlags
+}
+
 func NewListContainersCmd() *cobra.Command {
-	var commonFlags utils.CommonFlags
+	var containerFlags ContainerFlags
+
+	availableColumns := []string{
+		"runtime",
+		"id",
+		"name",
+		"pid",
+		"mntns",
+		"netns",
+		"namespace",
+		"podname",
+		"poduid",
+		"cgrouppath",
+		"cgroupid",
+		"cgroupv1",
+		"cgroupv2",
+	}
+
+	commonFlags := &utils.CommonFlags{
+		OutputConfig: commonutils.OutputConfig{
+			// The columns that will be used in case the user does not specify
+			// which specific columns they want to print.
+			CustomColumns: []string{
+				"runtime",
+				"id",
+				"name",
+			},
+		},
+	}
 
 	cmd := &cobra.Command{
 		Use:   "list-containers",
 		Short: "List all containers",
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(*cobra.Command, []string) error {
 			localGadgetManager, err := localgadgetmanager.NewManager(commonFlags.RuntimeConfigs)
 			if err != nil {
 				return fmt.Errorf("failed to initialize manager: %w", err)
 			}
 			defer localGadgetManager.Close()
 
-			for _, n := range localGadgetManager.ListContainers() {
-				fmt.Println(n)
+			parser := &ContainerParser{
+				BaseParser:     commonutils.NewBaseTabParser(availableColumns, &commonFlags.OutputConfig),
+				containerFlags: &containerFlags,
+			}
+
+			containers := localGadgetManager.GetContainersBySelector(&containercollection.ContainerSelector{
+				Name: commonFlags.Containername,
+			})
+
+			parser.SortContainers(containers)
+
+			switch commonFlags.OutputMode {
+			case commonutils.OutputModeJSON:
+				b, err := json.MarshalIndent(containers, "", "  ")
+				if err != nil {
+					return commonutils.WrapInErrMarshalOutput(err)
+				}
+
+				fmt.Printf("%s\n", b)
+			case commonutils.OutputModeColumns:
+				fallthrough
+			case commonutils.OutputModeCustomColumns:
+				w := tabwriter.NewWriter(os.Stdout, 0, 0, 4, ' ', 0)
+
+				fmt.Fprintln(w, parser.BuildColumnsHeader())
+
+				for _, c := range containers {
+					fmt.Fprintln(w, parser.TransformContainerToColumns(c))
+				}
+
+				w.Flush()
+			default:
+				return commonutils.WrapInErrOutputModeNotSupported(commonFlags.OutputMode)
 			}
 
 			return nil
 		},
 	}
 
-	utils.AddCommonFlags(cmd, &commonFlags)
+	cmd.PersistentFlags().BoolVar(
+		&containerFlags.noTrunc,
+		"no-trunc",
+		false,
+		"Don't truncate container ID",
+	)
+
+	utils.AddCommonFlags(cmd, commonFlags)
+
 	return cmd
+}
+
+func (p *ContainerParser) SortContainers(containers []*containercollection.Container) {
+	sort.Slice(containers, func(i, j int) bool {
+		si, sj := (containers)[i], (containers)[j]
+		switch {
+		case si.Runtime != sj.Runtime:
+			return si.Runtime < sj.Runtime
+		case si.Name != sj.Name:
+			return si.Name < sj.Name
+		default:
+			return si.ID < sj.ID
+		}
+	})
+}
+
+func (p *ContainerParser) TransformContainerToColumns(c *containercollection.Container) string {
+	var sb strings.Builder
+
+	for _, col := range p.OutputConfig.CustomColumns {
+		switch col {
+		case "runtime":
+			sb.WriteString(fmt.Sprintf("%s", c.Runtime))
+		case "id":
+			if p.containerFlags.noTrunc {
+				sb.WriteString(fmt.Sprintf("%s", c.ID))
+			} else {
+				sb.WriteString(fmt.Sprintf("%.13s", c.ID))
+			}
+		case "name":
+			sb.WriteString(fmt.Sprintf("%s", c.Name))
+		case "pid":
+			sb.WriteString(fmt.Sprintf("%d", c.Pid))
+		case "mntns":
+			sb.WriteString(fmt.Sprintf("%d", c.Mntns))
+		case "netns":
+			sb.WriteString(fmt.Sprintf("%d", c.Netns))
+		case "namespace":
+			sb.WriteString(fmt.Sprintf("%s", c.Namespace))
+		case "podname":
+			sb.WriteString(fmt.Sprintf("%s", c.Podname))
+		case "poduid":
+			sb.WriteString(fmt.Sprintf("%s", c.PodUID))
+		case "cgrouppath":
+			sb.WriteString(fmt.Sprintf("%s", c.CgroupPath))
+		case "cgroupid":
+			sb.WriteString(fmt.Sprintf("%d", c.CgroupID))
+		case "cgroupv1":
+			sb.WriteString(fmt.Sprintf("%s", c.CgroupV1))
+		case "cgroupv2":
+			sb.WriteString(fmt.Sprintf("%s", c.CgroupV2))
+		default:
+			continue
+		}
+		sb.WriteRune('\t')
+	}
+
+	return sb.String()
 }

--- a/pkg/container-collection/containers.go
+++ b/pkg/container-collection/containers.go
@@ -54,6 +54,9 @@ type Container struct {
 	// annotations to help users to identify the workflow of the profile.
 	OwnerReference *OwnerReference
 	PodUID         string
+
+	// Container Runtime metadata
+	Runtime string
 }
 
 type OwnerReference struct {

--- a/pkg/container-collection/options.go
+++ b/pkg/container-collection/options.go
@@ -54,6 +54,8 @@ func containerRuntimeEnricher(
 	}
 
 	container.Name = c.Name
+	container.Runtime = c.Runtime
+	container.ID = c.ID
 	// Some gadgets require the namespace and pod name to be set
 	container.Namespace = "default"
 	container.Podname = container.Name
@@ -139,9 +141,10 @@ func WithContainerRuntimeEnrichment(runtime *containerutils.RuntimeConfig) Conta
 
 			cc.initialContainers = append(cc.initialContainers,
 				&Container{
-					ID:   container.ID,
-					Pid:  uint32(pid),
-					Name: container.Name,
+					ID:      container.ID,
+					Pid:     uint32(pid),
+					Name:    container.Name,
+					Runtime: container.Runtime,
 
 					// Some gadgets require the namespace and pod name to be set
 					Namespace: "default",

--- a/pkg/container-utils/docker/docker.go
+++ b/pkg/container-utils/docker/docker.go
@@ -116,11 +116,7 @@ func (c *DockerClient) GetContainers() ([]*runtimeclient.ContainerData, error) {
 	ret := make([]*runtimeclient.ContainerData, len(containers))
 
 	for i, container := range containers {
-		ret[i] = &runtimeclient.ContainerData{
-			ID:      container.ID,
-			Name:    strings.TrimPrefix(containers[i].Names[0], "/"),
-			Running: container.State == "running",
-		}
+		ret[i] = DockerContainerToContainerData(&container)
 	}
 
 	return ret, nil
@@ -143,11 +139,16 @@ func (c *DockerClient) GetContainer(containerID string) (*runtimeclient.Containe
 			len(containers), containerID, containers)
 	}
 
+	return DockerContainerToContainerData(&containers[0]), nil
+}
+
+func DockerContainerToContainerData(container *dockertypes.Container) *runtimeclient.ContainerData {
 	return &runtimeclient.ContainerData{
-		ID:      containers[0].ID,
-		Name:    strings.TrimPrefix(containers[0].Names[0], "/"),
-		Running: containers[0].State == "running",
-	}, nil
+		ID:      container.ID,
+		Name:    strings.TrimPrefix(container.Names[0], "/"),
+		Running: container.State == "running",
+		Runtime: Name,
+	}
 }
 
 func (c *DockerClient) Close() error {


### PR DESCRIPTION
# Enrich `list-containers` with ID and Runtime information

This PR enriches the `list-containers` command to show the ID and the name of the runtime managing the container:

```bash
$ sudo local-gadget list-containers
RUNTIME       ID               NAME
containerd    7766d32caded4    calico-kube-controllers
containerd    2e3e4968b456f    calico-node
containerd    d3be7741b94ff    coredns
containerd    e7be3e4dc1bb4    coredns
containerd    fb4fe41921f30    etcd
containerd    136e7944d2077    kube-apiserver
containerd    ad8709a2c2ded    kube-controller-manager
containerd    66cf05654a47f    kube-proxy
containerd    a68bed42aa6b2    kube-scheduler
docker        95b814bb82b9e    myContainer
```

The flag `--no-trunc` was also implemented:

```bash
$ sudo local-gadget list-containers --no-trunc
RUNTIME       ID                                                                  NAME
containerd    34e68b2dd2f9f1ac516ec695de79f2a6489213c54131e3de20128bd94251e5f7    calico-kube-controllers
containerd    b66b5c2a756fc48a3056b8754704121bd4f1f71ee85d609b920c13a7995796e9    calico-node
...
```

Notice that now that the `list-containers` uses the `BaseParser`, it also supports JSON and custom-columns output mode. In addition, it supports the `--containername` flag.

Before reviewing this PR, please review https://github.com/kinvolk/inspektor-gadget/pull/762 as it introduces changes used by this PR.
