### PR TITLE
cmd: Manage JSON output mode outside of utils/trace

### DIFF
--- a/cmd/common/snapshot/process.go
+++ b/cmd/common/snapshot/process.go
@@ -87,7 +87,7 @@ func NewCommonProcessCmd(
 	return cmd
 }
 
-func (p *ProcessParser) TransformEvent(e *types.Event) string {
+func (p *ProcessParser) TransformToColumns(e *types.Event) string {
 	var sb strings.Builder
 
 	for _, col := range p.OutputConfig.CustomColumns {

--- a/cmd/common/snapshot/process.go
+++ b/cmd/common/snapshot/process.go
@@ -33,7 +33,7 @@ type ProcessFlags struct {
 }
 
 type ProcessParser struct {
-	commonutils.BaseParser
+	commonutils.BaseParser[types.Event]
 
 	processFlags *ProcessFlags
 }
@@ -46,7 +46,7 @@ func NewCommonProcessCmd(
 ) *cobra.Command {
 	processGadget := &SnapshotGadget[types.Event]{
 		parser: &ProcessParser{
-			BaseParser:   commonutils.NewBaseTabParser(availableColumns, outputConfig),
+			BaseParser:   commonutils.NewBaseTabParser[types.Event](availableColumns, outputConfig),
 			processFlags: processFlags,
 		},
 		customRun: customRun,

--- a/cmd/common/snapshot/snapshot.go
+++ b/cmd/common/snapshot/snapshot.go
@@ -43,9 +43,8 @@ type SnapshotParser[Event SnapshotEvent] interface {
 	// SortEvents sorts a slice of events based on a predefined prioritization.
 	SortEvents(*[]Event)
 
-	// TransformEvent is called to transform an event to columns
-	// format according to the parameters.
-	TransformEvent(*Event) string
+	// TransformToColumns is called to transform an event to columns.
+	TransformToColumns(*Event) string
 
 	// BuildColumnsHeader returns a header with the requested custom columns
 	// that exist in the predefined columns list. The columns are separated by
@@ -116,7 +115,7 @@ func (g *SnapshotGadget[Event]) Run() error {
 					continue
 				}
 
-				fmt.Fprintln(w, g.parser.TransformEvent(&e))
+				fmt.Fprintln(w, g.parser.TransformToColumns(&e))
 			}
 
 			w.Flush()

--- a/cmd/common/snapshot/socket.go
+++ b/cmd/common/snapshot/socket.go
@@ -95,7 +95,7 @@ func NewSocketCmd(
 	return cmd
 }
 
-func (s *SocketParser) TransformEvent(e *types.Event) string {
+func (s *SocketParser) TransformToColumns(e *types.Event) string {
 	var sb strings.Builder
 
 	for _, col := range s.OutputConfig.CustomColumns {

--- a/cmd/common/snapshot/socket.go
+++ b/cmd/common/snapshot/socket.go
@@ -34,7 +34,7 @@ type SocketFlags struct {
 }
 
 type SocketParser struct {
-	commonutils.BaseParser
+	commonutils.BaseParser[types.Event]
 
 	socketFlags *SocketFlags
 }
@@ -47,7 +47,7 @@ func NewSocketCmd(
 ) *cobra.Command {
 	socketGadget := &SnapshotGadget[types.Event]{
 		parser: &SocketParser{
-			BaseParser:  commonutils.NewBaseTabParser(availableColumns, outputConfig),
+			BaseParser:  commonutils.NewBaseTabParser[types.Event](availableColumns, outputConfig),
 			socketFlags: socketFlags,
 		},
 		customRun: customRun,

--- a/cmd/common/utils/parser_test.go
+++ b/cmd/common/utils/parser_test.go
@@ -19,89 +19,104 @@ import (
 	"testing"
 )
 
-func TestBaseParser(t *testing.T) {
+type MyElement struct {
+	Pid  uint32 `json:"pid,omitempty"`
+	Comm string `json:"pcomm,omitempty"`
+}
+
+func TestBaseParserBuildColumnsHeader(t *testing.T) {
 	table := []struct {
 		description    string
 		columnsWidth   map[string]int
-		useTabs        bool
+		useTaps        bool
 		outputConfig   *OutputConfig
 		expectedResult string
 	}{
 		{
-			description:  "empty CustomColumns",
-			outputConfig: &OutputConfig{},
+			description: "JSON output mode",
+			outputConfig: &OutputConfig{
+				OutputMode: OutputModeJSON,
+			},
 		},
 		{
 			description: "none valid column",
 			outputConfig: &OutputConfig{
 				CustomColumns: []string{"abc"},
+				OutputMode:    OutputModeCustomColumns,
 			},
 			columnsWidth: map[string]int{
 				"xyz": 0,
 			},
+			expectedResult: "",
 		},
 		{
 			description: "ignore invalid column using width",
 			outputConfig: &OutputConfig{
 				CustomColumns: []string{"abc", "xyz"},
+				OutputMode:    OutputModeCustomColumns,
 			},
 			columnsWidth: map[string]int{
 				"xyz": -10,
 			},
-			useTabs:        false,
+			useTaps:        false,
 			expectedResult: fmt.Sprintf("%-10s ", "XYZ"),
 		},
 		{
-			description: "ignore invalid column using tabs",
+			description: "ignore invalid column using taps",
 			outputConfig: &OutputConfig{
 				CustomColumns: []string{"abc", "xyz"},
+				OutputMode:    OutputModeCustomColumns,
 			},
 			columnsWidth: map[string]int{
 				"xyz": 0,
 			},
-			useTabs:        true,
+			useTaps:        true,
 			expectedResult: fmt.Sprintf("%s\t", "XYZ"),
 		},
 		{
 			description: "ignore multiple invalid columns using width",
 			outputConfig: &OutputConfig{
 				CustomColumns: []string{"abc", "dfe", "rst", "xyz"},
+				OutputMode:    OutputModeCustomColumns,
 			},
 			columnsWidth: map[string]int{
 				"xyz": -10,
 				"dfe": -5,
 			},
-			useTabs:        false,
+			useTaps:        false,
 			expectedResult: fmt.Sprintf("%-5s %-10s ", "DFE", "XYZ"),
 		},
 		{
-			description: "ignore multiple invalid column using tabs",
+			description: "ignore multiple invalid column using taps",
 			outputConfig: &OutputConfig{
 				CustomColumns: []string{"abc", "dfe", "rst", "xyz"},
+				OutputMode:    OutputModeCustomColumns,
 			},
 			columnsWidth: map[string]int{
 				"xyz": 0,
 				"dfe": 0,
 			},
-			useTabs:        true,
+			useTaps:        true,
 			expectedResult: fmt.Sprintf("%s\t%s\t", "DFE", "XYZ"),
 		},
 		{
-			description: "ignore columnWidth when using tabs",
+			description: "ignore columnWidth when using taps",
 			outputConfig: &OutputConfig{
 				CustomColumns: []string{"dfe", "xyz"},
+				OutputMode:    OutputModeCustomColumns,
 			},
 			columnsWidth: map[string]int{
 				"xyz": -5,
 				"dfe": -10,
 			},
-			useTabs:        true,
+			useTaps:        true,
 			expectedResult: fmt.Sprintf("%s\t%s\t", "DFE", "XYZ"),
 		},
 		{
 			description: "normal case using width",
 			outputConfig: &OutputConfig{
 				CustomColumns: []string{"abc", "dfe", "rst", "xyz"},
+				OutputMode:    OutputModeCustomColumns,
 			},
 			columnsWidth: map[string]int{
 				"abc": -7,
@@ -109,13 +124,14 @@ func TestBaseParser(t *testing.T) {
 				"rst": -1,
 				"xyz": -10,
 			},
-			useTabs:        false,
+			useTaps:        false,
 			expectedResult: fmt.Sprintf("%-7s %-5s %-1s %-10s ", "ABC", "DFE", "RST", "XYZ"),
 		},
 		{
-			description: "normal case using tabs",
+			description: "normal case using taps",
 			outputConfig: &OutputConfig{
 				CustomColumns: []string{"abc", "dfe", "rst", "xyz"},
+				OutputMode:    OutputModeCustomColumns,
 			},
 			columnsWidth: map[string]int{
 				"abc": 0,
@@ -123,13 +139,13 @@ func TestBaseParser(t *testing.T) {
 				"rst": 0,
 				"xyz": 0,
 			},
-			useTabs:        true,
+			useTaps:        true,
 			expectedResult: fmt.Sprintf("%s\t%s\t%s\t%s\t", "ABC", "DFE", "RST", "XYZ"),
 		},
 	}
 
 	for i, entry := range table {
-		p := NewBaseParser(entry.columnsWidth, entry.useTabs, entry.outputConfig)
+		p := newBaseParser[MyElement](entry.columnsWidth, entry.useTaps, entry.outputConfig)
 		result := p.BuildColumnsHeader()
 		if result != entry.expectedResult {
 			t.Fatalf("Failed test %q (index %d): result %q expected %q",

--- a/cmd/kubectl-gadget/audit/seccomp.go
+++ b/cmd/kubectl-gadget/audit/seccomp.go
@@ -81,11 +81,17 @@ func auditSeccompTransformLine(line string) string {
 	}
 
 	switch params.OutputMode {
+	case commonutils.OutputModeJSON:
+		b, err := json.Marshal(e)
+		if err != nil {
+			fmt.Fprint(os.Stderr, fmt.Sprint(commonutils.WrapInErrMarshalOutput(err)))
+			return ""
+		}
+		sb.WriteString(string(b))
 	case commonutils.OutputModeColumns:
 		sb.WriteString(fmt.Sprintf("%-16s %-16s %-16s %-16s %-16s %-6d %-16s %-16s",
 			e.Node, e.Namespace, e.Pod, e.Container,
 			e.Comm, e.Pid, e.Syscall, e.Code))
-
 	case commonutils.OutputModeCustomColumns:
 		for _, col := range params.CustomColumns {
 			switch col {

--- a/cmd/kubectl-gadget/profile/cpu.go
+++ b/cmd/kubectl-gadget/profile/cpu.go
@@ -211,6 +211,8 @@ func (p *CPUParser) TransformReport(report *types.Report) string {
 				} else {
 					fmt.Fprint(&sb, getReverseStringSlice(report.KernelStack), getReverseStringSlice(report.UserStack))
 				}
+			default:
+				continue
 			}
 
 			// Needed when field is larger than the predefined columnsWidth.

--- a/cmd/kubectl-gadget/profile/cpu.go
+++ b/cmd/kubectl-gadget/profile/cpu.go
@@ -32,7 +32,7 @@ type CPUFlags struct {
 }
 
 type CPUParser struct {
-	commonutils.BaseParser
+	commonutils.BaseParser[types.Report]
 
 	cpuFlags *CPUFlags
 }
@@ -95,7 +95,7 @@ func newCPUCmd() *cobra.Command {
 				commonFlags:   commonFlags,
 				inProgressMsg: "Capturing stack traces",
 				parser: &CPUParser{
-					BaseParser: commonutils.NewBaseWidthParser(columnsWidth, &commonFlags.OutputConfig),
+					BaseParser: commonutils.NewBaseWidthParser[types.Report](columnsWidth, &commonFlags.OutputConfig),
 					cpuFlags:   &cpuFlags,
 				},
 			}

--- a/cmd/kubectl-gadget/trace/bind.go
+++ b/cmd/kubectl-gadget/trace/bind.go
@@ -15,9 +15,7 @@
 package trace
 
 import (
-	"encoding/json"
 	"fmt"
-	"os"
 	"strconv"
 	"strings"
 
@@ -131,19 +129,9 @@ func NewBindParser(outputConfig *commonutils.OutputConfig) TraceParser[types.Eve
 }
 
 func (p *BindParser) TransformEvent(event *types.Event) string {
-	var sb strings.Builder
+	return p.Transform(event, func(event *types.Event) string {
+		var sb strings.Builder
 
-	switch p.OutputConfig.OutputMode {
-	case commonutils.OutputModeJSON:
-		b, err := json.Marshal(event)
-		if err != nil {
-			fmt.Fprint(os.Stderr, fmt.Sprint(commonutils.WrapInErrMarshalOutput(err)))
-			return ""
-		}
-		sb.WriteString(string(b))
-	case commonutils.OutputModeColumns:
-		fallthrough
-	case commonutils.OutputModeCustomColumns:
 		for _, col := range p.OutputConfig.CustomColumns {
 			switch col {
 			case "node":
@@ -173,7 +161,7 @@ func (p *BindParser) TransformEvent(event *types.Event) string {
 			// Needed when field is larger than the predefined columnsWidth.
 			sb.WriteRune(' ')
 		}
-	}
 
-	return sb.String()
+		return sb.String()
+	})
 }

--- a/cmd/kubectl-gadget/trace/bind.go
+++ b/cmd/kubectl-gadget/trace/bind.go
@@ -156,6 +156,8 @@ func (p *BindParser) TransformEvent(event *types.Event) string {
 				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Options))
 			case "if":
 				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Interface))
+			default:
+				continue
 			}
 
 			// Needed when field is larger than the predefined columnsWidth.

--- a/cmd/kubectl-gadget/trace/bind.go
+++ b/cmd/kubectl-gadget/trace/bind.go
@@ -28,7 +28,7 @@ import (
 )
 
 type BindParser struct {
-	commonutils.BaseParser
+	commonutils.BaseParser[types.Event]
 }
 
 func newBindCmd() *cobra.Command {
@@ -126,7 +126,7 @@ func NewBindParser(outputConfig *commonutils.OutputConfig) TraceParser[types.Eve
 	}
 
 	return &BindParser{
-		BaseParser: commonutils.NewBaseWidthParser(columnsWidth, outputConfig),
+		BaseParser: commonutils.NewBaseWidthParser[types.Event](columnsWidth, outputConfig),
 	}
 }
 

--- a/cmd/kubectl-gadget/trace/capabilities.go
+++ b/cmd/kubectl-gadget/trace/capabilities.go
@@ -113,6 +113,8 @@ func (p *CapabilitiesParser) TransformEvent(event *types.Event) string {
 				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.CapName))
 			case "audit":
 				sb.WriteString(fmt.Sprintf("%*d", p.ColumnsWidth[col], event.Audit))
+			default:
+				continue
 			}
 
 			// Needed when field is larger than the predefined columnsWidth.

--- a/cmd/kubectl-gadget/trace/capabilities.go
+++ b/cmd/kubectl-gadget/trace/capabilities.go
@@ -15,7 +15,9 @@
 package trace
 
 import (
+	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 
 	commonutils "github.com/kinvolk/inspektor-gadget/cmd/common/utils"
@@ -90,32 +92,44 @@ func NewCapabilitiesParser(outputConfig *commonutils.OutputConfig) TraceParser[t
 func (p *CapabilitiesParser) TransformEvent(event *types.Event) string {
 	var sb strings.Builder
 
-	for _, col := range p.OutputConfig.CustomColumns {
-		switch col {
-		case "node":
-			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Node))
-		case "namespace":
-			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Namespace))
-		case "pod":
-			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Pod))
-		case "container":
-			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Container))
-		case "pid":
-			sb.WriteString(fmt.Sprintf("%*d", p.ColumnsWidth[col], event.Pid))
-		case "uid":
-			sb.WriteString(fmt.Sprintf("%*d", p.ColumnsWidth[col], event.UID))
-		case "comm":
-			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Comm))
-		case "cap":
-			sb.WriteString(fmt.Sprintf("%*d", p.ColumnsWidth[col], event.Cap))
-		case "name":
-			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.CapName))
-		case "audit":
-			sb.WriteString(fmt.Sprintf("%*d", p.ColumnsWidth[col], event.Audit))
+	switch p.OutputConfig.OutputMode {
+	case commonutils.OutputModeJSON:
+		b, err := json.Marshal(event)
+		if err != nil {
+			fmt.Fprint(os.Stderr, fmt.Sprint(commonutils.WrapInErrMarshalOutput(err)))
+			return ""
 		}
+		sb.WriteString(string(b))
+	case commonutils.OutputModeColumns:
+		fallthrough
+	case commonutils.OutputModeCustomColumns:
+		for _, col := range p.OutputConfig.CustomColumns {
+			switch col {
+			case "node":
+				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Node))
+			case "namespace":
+				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Namespace))
+			case "pod":
+				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Pod))
+			case "container":
+				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Container))
+			case "pid":
+				sb.WriteString(fmt.Sprintf("%*d", p.ColumnsWidth[col], event.Pid))
+			case "uid":
+				sb.WriteString(fmt.Sprintf("%*d", p.ColumnsWidth[col], event.UID))
+			case "comm":
+				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Comm))
+			case "cap":
+				sb.WriteString(fmt.Sprintf("%*d", p.ColumnsWidth[col], event.Cap))
+			case "name":
+				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.CapName))
+			case "audit":
+				sb.WriteString(fmt.Sprintf("%*d", p.ColumnsWidth[col], event.Audit))
+			}
 
-		// Needed when field is larger than the predefined columnsWidth.
-		sb.WriteRune(' ')
+			// Needed when field is larger than the predefined columnsWidth.
+			sb.WriteRune(' ')
+		}
 	}
 
 	return sb.String()

--- a/cmd/kubectl-gadget/trace/capabilities.go
+++ b/cmd/kubectl-gadget/trace/capabilities.go
@@ -28,7 +28,7 @@ import (
 )
 
 type CapabilitiesParser struct {
-	commonutils.BaseParser
+	commonutils.BaseParser[types.Event]
 }
 
 func newCapabilitiesCmd() *cobra.Command {
@@ -85,7 +85,7 @@ func NewCapabilitiesParser(outputConfig *commonutils.OutputConfig) TraceParser[t
 	}
 
 	return &CapabilitiesParser{
-		BaseParser: commonutils.NewBaseWidthParser(columnsWidth, outputConfig),
+		BaseParser: commonutils.NewBaseWidthParser[types.Event](columnsWidth, outputConfig),
 	}
 }
 

--- a/cmd/kubectl-gadget/trace/capabilities.go
+++ b/cmd/kubectl-gadget/trace/capabilities.go
@@ -15,9 +15,7 @@
 package trace
 
 import (
-	"encoding/json"
 	"fmt"
-	"os"
 	"strings"
 
 	commonutils "github.com/kinvolk/inspektor-gadget/cmd/common/utils"
@@ -90,19 +88,9 @@ func NewCapabilitiesParser(outputConfig *commonutils.OutputConfig) TraceParser[t
 }
 
 func (p *CapabilitiesParser) TransformEvent(event *types.Event) string {
-	var sb strings.Builder
+	return p.Transform(event, func(event *types.Event) string {
+		var sb strings.Builder
 
-	switch p.OutputConfig.OutputMode {
-	case commonutils.OutputModeJSON:
-		b, err := json.Marshal(event)
-		if err != nil {
-			fmt.Fprint(os.Stderr, fmt.Sprint(commonutils.WrapInErrMarshalOutput(err)))
-			return ""
-		}
-		sb.WriteString(string(b))
-	case commonutils.OutputModeColumns:
-		fallthrough
-	case commonutils.OutputModeCustomColumns:
 		for _, col := range p.OutputConfig.CustomColumns {
 			switch col {
 			case "node":
@@ -130,7 +118,7 @@ func (p *CapabilitiesParser) TransformEvent(event *types.Event) string {
 			// Needed when field is larger than the predefined columnsWidth.
 			sb.WriteRune(' ')
 		}
-	}
 
-	return sb.String()
+		return sb.String()
+	})
 }

--- a/cmd/kubectl-gadget/trace/dns.go
+++ b/cmd/kubectl-gadget/trace/dns.go
@@ -97,6 +97,8 @@ func (p *DNSParser) TransformEvent(event *types.Event) string {
 				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.QType))
 			case "name":
 				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.DNSName))
+			default:
+				continue
 			}
 
 			// Needed when field is larger than the predefined columnsWidth.

--- a/cmd/kubectl-gadget/trace/dns.go
+++ b/cmd/kubectl-gadget/trace/dns.go
@@ -28,7 +28,7 @@ import (
 )
 
 type DNSParser struct {
-	commonutils.BaseParser
+	commonutils.BaseParser[types.Event]
 }
 
 func newDNSCmd() *cobra.Command {
@@ -77,7 +77,7 @@ func NewDNSParser(outputConfig *commonutils.OutputConfig) TraceParser[types.Even
 	}
 
 	return &DNSParser{
-		BaseParser: commonutils.NewBaseWidthParser(columnsWidth, outputConfig),
+		BaseParser: commonutils.NewBaseWidthParser[types.Event](columnsWidth, outputConfig),
 	}
 }
 

--- a/cmd/kubectl-gadget/trace/dns.go
+++ b/cmd/kubectl-gadget/trace/dns.go
@@ -15,9 +15,7 @@
 package trace
 
 import (
-	"encoding/json"
 	"fmt"
-	"os"
 	"strings"
 
 	commonutils "github.com/kinvolk/inspektor-gadget/cmd/common/utils"
@@ -82,19 +80,9 @@ func NewDNSParser(outputConfig *commonutils.OutputConfig) TraceParser[types.Even
 }
 
 func (p *DNSParser) TransformEvent(event *types.Event) string {
-	var sb strings.Builder
+	return p.Transform(event, func(event *types.Event) string {
+		var sb strings.Builder
 
-	switch p.OutputConfig.OutputMode {
-	case commonutils.OutputModeJSON:
-		b, err := json.Marshal(event)
-		if err != nil {
-			fmt.Fprint(os.Stderr, fmt.Sprint(commonutils.WrapInErrMarshalOutput(err)))
-			return ""
-		}
-		sb.WriteString(string(b))
-	case commonutils.OutputModeColumns:
-		fallthrough
-	case commonutils.OutputModeCustomColumns:
 		for _, col := range p.OutputConfig.CustomColumns {
 			switch col {
 			case "node":
@@ -114,7 +102,7 @@ func (p *DNSParser) TransformEvent(event *types.Event) string {
 			// Needed when field is larger than the predefined columnsWidth.
 			sb.WriteRune(' ')
 		}
-	}
 
-	return sb.String()
+		return sb.String()
+	})
 }

--- a/cmd/kubectl-gadget/trace/dns.go
+++ b/cmd/kubectl-gadget/trace/dns.go
@@ -15,7 +15,9 @@
 package trace
 
 import (
+	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 
 	commonutils "github.com/kinvolk/inspektor-gadget/cmd/common/utils"
@@ -82,24 +84,36 @@ func NewDNSParser(outputConfig *commonutils.OutputConfig) TraceParser[types.Even
 func (p *DNSParser) TransformEvent(event *types.Event) string {
 	var sb strings.Builder
 
-	for _, col := range p.OutputConfig.CustomColumns {
-		switch col {
-		case "node":
-			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Node))
-		case "namespace":
-			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Namespace))
-		case "pod":
-			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Pod))
-		case "type":
-			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.PktType))
-		case "qtype":
-			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.QType))
-		case "name":
-			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.DNSName))
+	switch p.OutputConfig.OutputMode {
+	case commonutils.OutputModeJSON:
+		b, err := json.Marshal(event)
+		if err != nil {
+			fmt.Fprint(os.Stderr, fmt.Sprint(commonutils.WrapInErrMarshalOutput(err)))
+			return ""
 		}
+		sb.WriteString(string(b))
+	case commonutils.OutputModeColumns:
+		fallthrough
+	case commonutils.OutputModeCustomColumns:
+		for _, col := range p.OutputConfig.CustomColumns {
+			switch col {
+			case "node":
+				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Node))
+			case "namespace":
+				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Namespace))
+			case "pod":
+				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Pod))
+			case "type":
+				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.PktType))
+			case "qtype":
+				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.QType))
+			case "name":
+				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.DNSName))
+			}
 
-		// Needed when field is larger than the predefined columnsWidth.
-		sb.WriteRune(' ')
+			// Needed when field is larger than the predefined columnsWidth.
+			sb.WriteRune(' ')
+		}
 	}
 
 	return sb.String()

--- a/cmd/kubectl-gadget/trace/exec.go
+++ b/cmd/kubectl-gadget/trace/exec.go
@@ -28,7 +28,7 @@ import (
 )
 
 type ExecParser struct {
-	commonutils.BaseParser
+	commonutils.BaseParser[types.Event]
 }
 
 func newExecCmd() *cobra.Command {
@@ -83,7 +83,7 @@ func NewExecParser(outputConfig *commonutils.OutputConfig) TraceParser[types.Eve
 	}
 
 	return &ExecParser{
-		BaseParser: commonutils.NewBaseWidthParser(columnsWidth, outputConfig),
+		BaseParser: commonutils.NewBaseWidthParser[types.Event](columnsWidth, outputConfig),
 	}
 }
 

--- a/cmd/kubectl-gadget/trace/exec.go
+++ b/cmd/kubectl-gadget/trace/exec.go
@@ -111,6 +111,8 @@ func (p *ExecParser) TransformEvent(event *types.Event) string {
 				for _, arg := range event.Args {
 					sb.WriteString(fmt.Sprintf("%s ", arg))
 				}
+			default:
+				continue
 			}
 
 			// Needed when field is larger than the predefined columnsWidth.

--- a/cmd/kubectl-gadget/trace/exec.go
+++ b/cmd/kubectl-gadget/trace/exec.go
@@ -15,9 +15,7 @@
 package trace
 
 import (
-	"encoding/json"
 	"fmt"
-	"os"
 	"strings"
 
 	commonutils "github.com/kinvolk/inspektor-gadget/cmd/common/utils"
@@ -88,19 +86,9 @@ func NewExecParser(outputConfig *commonutils.OutputConfig) TraceParser[types.Eve
 }
 
 func (p *ExecParser) TransformEvent(event *types.Event) string {
-	var sb strings.Builder
+	return p.Transform(event, func(event *types.Event) string {
+		var sb strings.Builder
 
-	switch p.OutputConfig.OutputMode {
-	case commonutils.OutputModeJSON:
-		b, err := json.Marshal(event)
-		if err != nil {
-			fmt.Fprint(os.Stderr, fmt.Sprint(commonutils.WrapInErrMarshalOutput(err)))
-			return ""
-		}
-		sb.WriteString(string(b))
-	case commonutils.OutputModeColumns:
-		fallthrough
-	case commonutils.OutputModeCustomColumns:
 		for _, col := range p.OutputConfig.CustomColumns {
 			switch col {
 			case "node":
@@ -128,7 +116,7 @@ func (p *ExecParser) TransformEvent(event *types.Event) string {
 			// Needed when field is larger than the predefined columnsWidth.
 			sb.WriteRune(' ')
 		}
-	}
 
-	return sb.String()
+		return sb.String()
+	})
 }

--- a/cmd/kubectl-gadget/trace/fsslower.go
+++ b/cmd/kubectl-gadget/trace/fsslower.go
@@ -165,6 +165,8 @@ func (p *FsslowerParser) TransformEvent(event *types.Event) string {
 				sb.WriteString(fmt.Sprintf("%*.2f", p.ColumnsWidth[col], float64(event.Latency)/1000.0))
 			case "file":
 				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.File))
+			default:
+				continue
 			}
 
 			// Needed when field is larger than the predefined columnsWidth.

--- a/cmd/kubectl-gadget/trace/fsslower.go
+++ b/cmd/kubectl-gadget/trace/fsslower.go
@@ -30,7 +30,7 @@ import (
 )
 
 type FsslowerParser struct {
-	commonutils.BaseParser
+	commonutils.BaseParser[types.Event]
 }
 
 func newFsSlowerCmd() *cobra.Command {
@@ -130,7 +130,7 @@ func NewFsslowerParser(outputConfig *commonutils.OutputConfig) TraceParser[types
 	}
 
 	return &FsslowerParser{
-		BaseParser: commonutils.NewBaseWidthParser(columnsWidth, outputConfig),
+		BaseParser: commonutils.NewBaseWidthParser[types.Event](columnsWidth, outputConfig),
 	}
 }
 

--- a/cmd/kubectl-gadget/trace/fsslower.go
+++ b/cmd/kubectl-gadget/trace/fsslower.go
@@ -15,10 +15,8 @@
 package trace
 
 import (
-	"encoding/json"
 	"fmt"
 	"math"
-	"os"
 	"strconv"
 	"strings"
 
@@ -135,24 +133,14 @@ func NewFsslowerParser(outputConfig *commonutils.OutputConfig) TraceParser[types
 }
 
 func (p *FsslowerParser) TransformEvent(event *types.Event) string {
-	var sb strings.Builder
+	return p.Transform(event, func(event *types.Event) string {
+		var sb strings.Builder
 
-	// TODO: what to print in this case?
-	if event.Bytes == math.MaxInt64 {
-		event.Bytes = 0
-	}
-
-	switch p.OutputConfig.OutputMode {
-	case commonutils.OutputModeJSON:
-		b, err := json.Marshal(event)
-		if err != nil {
-			fmt.Fprint(os.Stderr, fmt.Sprint(commonutils.WrapInErrMarshalOutput(err)))
-			return ""
+		// TODO: what to print in this case?
+		if event.Bytes == math.MaxInt64 {
+			event.Bytes = 0
 		}
-		sb.WriteString(string(b))
-	case commonutils.OutputModeColumns:
-		fallthrough
-	case commonutils.OutputModeCustomColumns:
+
 		for _, col := range p.OutputConfig.CustomColumns {
 			switch col {
 			case "node":
@@ -182,7 +170,7 @@ func (p *FsslowerParser) TransformEvent(event *types.Event) string {
 			// Needed when field is larger than the predefined columnsWidth.
 			sb.WriteRune(' ')
 		}
-	}
 
-	return sb.String()
+		return sb.String()
+	})
 }

--- a/cmd/kubectl-gadget/trace/mount.go
+++ b/cmd/kubectl-gadget/trace/mount.go
@@ -15,7 +15,9 @@
 package trace
 
 import (
+	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 
 	commonutils "github.com/kinvolk/inspektor-gadget/cmd/common/utils"
@@ -110,46 +112,58 @@ func getCall(e *types.Event) string {
 func (p *MountParser) TransformEvent(event *types.Event) string {
 	var sb strings.Builder
 
-	for _, col := range p.OutputConfig.CustomColumns {
-		switch col {
-		case "node":
-			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Node))
-		case "namespace":
-			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Namespace))
-		case "pod":
-			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Pod))
-		case "container":
-			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Container))
-		case "pid":
-			sb.WriteString(fmt.Sprintf("%*d", p.ColumnsWidth[col], event.Pid))
-		case "tid":
-			sb.WriteString(fmt.Sprintf("%*d", p.ColumnsWidth[col], event.Tid))
-		case "mnt_ns":
-			sb.WriteString(fmt.Sprintf("%*d", p.ColumnsWidth[col], event.MountNsID))
-		case "comm":
-			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Comm))
-		case "op":
-			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Operation))
-		case "ret":
-			sb.WriteString(fmt.Sprintf("%*d", p.ColumnsWidth[col], event.Retval))
-		case "lat":
-			sb.WriteString(fmt.Sprintf("%*d", p.ColumnsWidth[col], event.Latency/1000))
-		case "fs":
-			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Fs))
-		case "src":
-			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Source))
-		case "target":
-			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Target))
-		case "data":
-			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Data))
-		case "call":
-			sb.WriteString(fmt.Sprintf("%-*s", p.ColumnsWidth[col], getCall(event)))
-		case "flags":
-			sb.WriteString(fmt.Sprintf("%s", strings.Join(event.Flags, " | ")))
+	switch p.OutputConfig.OutputMode {
+	case commonutils.OutputModeJSON:
+		b, err := json.Marshal(event)
+		if err != nil {
+			fmt.Fprint(os.Stderr, fmt.Sprint(commonutils.WrapInErrMarshalOutput(err)))
+			return ""
 		}
+		sb.WriteString(string(b))
+	case commonutils.OutputModeColumns:
+		fallthrough
+	case commonutils.OutputModeCustomColumns:
+		for _, col := range p.OutputConfig.CustomColumns {
+			switch col {
+			case "node":
+				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Node))
+			case "namespace":
+				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Namespace))
+			case "pod":
+				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Pod))
+			case "container":
+				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Container))
+			case "pid":
+				sb.WriteString(fmt.Sprintf("%*d", p.ColumnsWidth[col], event.Pid))
+			case "tid":
+				sb.WriteString(fmt.Sprintf("%*d", p.ColumnsWidth[col], event.Tid))
+			case "mnt_ns":
+				sb.WriteString(fmt.Sprintf("%*d", p.ColumnsWidth[col], event.MountNsID))
+			case "comm":
+				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Comm))
+			case "op":
+				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Operation))
+			case "ret":
+				sb.WriteString(fmt.Sprintf("%*d", p.ColumnsWidth[col], event.Retval))
+			case "lat":
+				sb.WriteString(fmt.Sprintf("%*d", p.ColumnsWidth[col], event.Latency/1000))
+			case "fs":
+				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Fs))
+			case "src":
+				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Source))
+			case "target":
+				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Target))
+			case "data":
+				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Data))
+			case "call":
+				sb.WriteString(fmt.Sprintf("%-*s", p.ColumnsWidth[col], getCall(event)))
+			case "flags":
+				sb.WriteString(fmt.Sprintf("%s", strings.Join(event.Flags, " | ")))
+			}
 
-		// Needed when field is larger than the predefined columnsWidth.
-		sb.WriteRune(' ')
+			// Needed when field is larger than the predefined columnsWidth.
+			sb.WriteRune(' ')
+		}
 	}
 
 	return sb.String()

--- a/cmd/kubectl-gadget/trace/mount.go
+++ b/cmd/kubectl-gadget/trace/mount.go
@@ -15,9 +15,7 @@
 package trace
 
 import (
-	"encoding/json"
 	"fmt"
-	"os"
 	"strings"
 
 	commonutils "github.com/kinvolk/inspektor-gadget/cmd/common/utils"
@@ -110,19 +108,9 @@ func getCall(e *types.Event) string {
 }
 
 func (p *MountParser) TransformEvent(event *types.Event) string {
-	var sb strings.Builder
+	return p.Transform(event, func(event *types.Event) string {
+		var sb strings.Builder
 
-	switch p.OutputConfig.OutputMode {
-	case commonutils.OutputModeJSON:
-		b, err := json.Marshal(event)
-		if err != nil {
-			fmt.Fprint(os.Stderr, fmt.Sprint(commonutils.WrapInErrMarshalOutput(err)))
-			return ""
-		}
-		sb.WriteString(string(b))
-	case commonutils.OutputModeColumns:
-		fallthrough
-	case commonutils.OutputModeCustomColumns:
 		for _, col := range p.OutputConfig.CustomColumns {
 			switch col {
 			case "node":
@@ -164,7 +152,7 @@ func (p *MountParser) TransformEvent(event *types.Event) string {
 			// Needed when field is larger than the predefined columnsWidth.
 			sb.WriteRune(' ')
 		}
-	}
 
-	return sb.String()
+		return sb.String()
+	})
 }

--- a/cmd/kubectl-gadget/trace/mount.go
+++ b/cmd/kubectl-gadget/trace/mount.go
@@ -28,7 +28,7 @@ import (
 )
 
 type MountParser struct {
-	commonutils.BaseParser
+	commonutils.BaseParser[types.Event]
 }
 
 func newMountCmd() *cobra.Command {
@@ -91,7 +91,7 @@ func NewMountParser(outputConfig *commonutils.OutputConfig) TraceParser[types.Ev
 	}
 
 	return &MountParser{
-		BaseParser: commonutils.NewBaseWidthParser(columnsWidth, outputConfig),
+		BaseParser: commonutils.NewBaseWidthParser[types.Event](columnsWidth, outputConfig),
 	}
 }
 

--- a/cmd/kubectl-gadget/trace/mount.go
+++ b/cmd/kubectl-gadget/trace/mount.go
@@ -147,6 +147,8 @@ func (p *MountParser) TransformEvent(event *types.Event) string {
 				sb.WriteString(fmt.Sprintf("%-*s", p.ColumnsWidth[col], getCall(event)))
 			case "flags":
 				sb.WriteString(fmt.Sprintf("%s", strings.Join(event.Flags, " | ")))
+			default:
+				continue
 			}
 
 			// Needed when field is larger than the predefined columnsWidth.

--- a/cmd/kubectl-gadget/trace/network.go
+++ b/cmd/kubectl-gadget/trace/network.go
@@ -118,6 +118,8 @@ func (p *NetworkParser) TransformEvent(event *types.Event) string {
 				sb.WriteString(fmt.Sprintf("%*d", p.ColumnsWidth[col], event.Port))
 			case "remote":
 				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], remote))
+			default:
+				continue
 			}
 
 			// Needed when field is larger than the predefined columnsWidth.

--- a/cmd/kubectl-gadget/trace/network.go
+++ b/cmd/kubectl-gadget/trace/network.go
@@ -15,9 +15,7 @@
 package trace
 
 import (
-	"encoding/json"
 	"fmt"
-	"os"
 	"strings"
 
 	commonutils "github.com/kinvolk/inspektor-gadget/cmd/common/utils"
@@ -84,24 +82,14 @@ func NewNetworkParser(outputConfig *commonutils.OutputConfig) TraceParser[types.
 }
 
 func (p *NetworkParser) TransformEvent(event *types.Event) string {
-	var sb strings.Builder
+	return p.Transform(event, func(event *types.Event) string {
+		var sb strings.Builder
 
-	if event.Pod == "" {
-		// ignore events on host netns for now
-		return ""
-	}
-
-	switch p.OutputConfig.OutputMode {
-	case commonutils.OutputModeJSON:
-		b, err := json.Marshal(event)
-		if err != nil {
-			fmt.Fprint(os.Stderr, fmt.Sprint(commonutils.WrapInErrMarshalOutput(err)))
+		if event.Pod == "" {
+			// ignore events on host netns for now
 			return ""
 		}
-		sb.WriteString(string(b))
-	case commonutils.OutputModeColumns:
-		fallthrough
-	case commonutils.OutputModeCustomColumns:
+
 		remote := ""
 		switch event.RemoteKind {
 		case "pod":
@@ -135,7 +123,7 @@ func (p *NetworkParser) TransformEvent(event *types.Event) string {
 			// Needed when field is larger than the predefined columnsWidth.
 			sb.WriteRune(' ')
 		}
-	}
 
-	return sb.String()
+		return sb.String()
+	})
 }

--- a/cmd/kubectl-gadget/trace/network.go
+++ b/cmd/kubectl-gadget/trace/network.go
@@ -28,7 +28,7 @@ import (
 )
 
 type NetworkParser struct {
-	commonutils.BaseParser
+	commonutils.BaseParser[types.Event]
 }
 
 func newNetworkCmd() *cobra.Command {
@@ -79,7 +79,7 @@ func NewNetworkParser(outputConfig *commonutils.OutputConfig) TraceParser[types.
 	}
 
 	return &NetworkParser{
-		BaseParser: commonutils.NewBaseWidthParser(columnsWidth, outputConfig),
+		BaseParser: commonutils.NewBaseWidthParser[types.Event](columnsWidth, outputConfig),
 	}
 }
 

--- a/cmd/kubectl-gadget/trace/oomkill.go
+++ b/cmd/kubectl-gadget/trace/oomkill.go
@@ -15,7 +15,9 @@
 package trace
 
 import (
+	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 
 	commonutils "github.com/kinvolk/inspektor-gadget/cmd/common/utils"
@@ -88,30 +90,42 @@ func NewOOMKillParser(outputConfig *commonutils.OutputConfig) TraceParser[types.
 func (p *OOMKillParser) TransformEvent(event *types.Event) string {
 	var sb strings.Builder
 
-	for _, col := range p.OutputConfig.CustomColumns {
-		switch col {
-		case "node":
-			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Node))
-		case "namespace":
-			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Namespace))
-		case "pod":
-			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Pod))
-		case "container":
-			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Container))
-		case "kpid":
-			sb.WriteString(fmt.Sprintf("%*d", p.ColumnsWidth[col], event.KilledPid))
-		case "kcomm":
-			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.KilledComm))
-		case "pages":
-			sb.WriteString(fmt.Sprintf("%*d", p.ColumnsWidth[col], event.Pages))
-		case "tpid":
-			sb.WriteString(fmt.Sprintf("%*d", p.ColumnsWidth[col], event.TriggeredPid))
-		case "tcomm":
-			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.TriggeredComm))
+	switch p.OutputConfig.OutputMode {
+	case commonutils.OutputModeJSON:
+		b, err := json.Marshal(event)
+		if err != nil {
+			fmt.Fprint(os.Stderr, fmt.Sprint(commonutils.WrapInErrMarshalOutput(err)))
+			return ""
 		}
+		sb.WriteString(string(b))
+	case commonutils.OutputModeColumns:
+		fallthrough
+	case commonutils.OutputModeCustomColumns:
+		for _, col := range p.OutputConfig.CustomColumns {
+			switch col {
+			case "node":
+				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Node))
+			case "namespace":
+				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Namespace))
+			case "pod":
+				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Pod))
+			case "container":
+				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Container))
+			case "kpid":
+				sb.WriteString(fmt.Sprintf("%*d", p.ColumnsWidth[col], event.KilledPid))
+			case "kcomm":
+				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.KilledComm))
+			case "pages":
+				sb.WriteString(fmt.Sprintf("%*d", p.ColumnsWidth[col], event.Pages))
+			case "tpid":
+				sb.WriteString(fmt.Sprintf("%*d", p.ColumnsWidth[col], event.TriggeredPid))
+			case "tcomm":
+				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.TriggeredComm))
+			}
 
-		// Needed when field is larger than the predefined columnsWidth.
-		sb.WriteRune(' ')
+			// Needed when field is larger than the predefined columnsWidth.
+			sb.WriteRune(' ')
+		}
 	}
 
 	return sb.String()

--- a/cmd/kubectl-gadget/trace/oomkill.go
+++ b/cmd/kubectl-gadget/trace/oomkill.go
@@ -28,7 +28,7 @@ import (
 )
 
 type OOMKillParser struct {
-	commonutils.BaseParser
+	commonutils.BaseParser[types.Event]
 }
 
 func newOOMKillCmd() *cobra.Command {
@@ -83,7 +83,7 @@ func NewOOMKillParser(outputConfig *commonutils.OutputConfig) TraceParser[types.
 	}
 
 	return &OOMKillParser{
-		BaseParser: commonutils.NewBaseWidthParser(columnsWidth, outputConfig),
+		BaseParser: commonutils.NewBaseWidthParser[types.Event](columnsWidth, outputConfig),
 	}
 }
 

--- a/cmd/kubectl-gadget/trace/oomkill.go
+++ b/cmd/kubectl-gadget/trace/oomkill.go
@@ -15,9 +15,7 @@
 package trace
 
 import (
-	"encoding/json"
 	"fmt"
-	"os"
 	"strings"
 
 	commonutils "github.com/kinvolk/inspektor-gadget/cmd/common/utils"
@@ -88,19 +86,9 @@ func NewOOMKillParser(outputConfig *commonutils.OutputConfig) TraceParser[types.
 }
 
 func (p *OOMKillParser) TransformEvent(event *types.Event) string {
-	var sb strings.Builder
+	return p.Transform(event, func(event *types.Event) string {
+		var sb strings.Builder
 
-	switch p.OutputConfig.OutputMode {
-	case commonutils.OutputModeJSON:
-		b, err := json.Marshal(event)
-		if err != nil {
-			fmt.Fprint(os.Stderr, fmt.Sprint(commonutils.WrapInErrMarshalOutput(err)))
-			return ""
-		}
-		sb.WriteString(string(b))
-	case commonutils.OutputModeColumns:
-		fallthrough
-	case commonutils.OutputModeCustomColumns:
 		for _, col := range p.OutputConfig.CustomColumns {
 			switch col {
 			case "node":
@@ -126,7 +114,7 @@ func (p *OOMKillParser) TransformEvent(event *types.Event) string {
 			// Needed when field is larger than the predefined columnsWidth.
 			sb.WriteRune(' ')
 		}
-	}
 
-	return sb.String()
+		return sb.String()
+	})
 }

--- a/cmd/kubectl-gadget/trace/oomkill.go
+++ b/cmd/kubectl-gadget/trace/oomkill.go
@@ -109,6 +109,8 @@ func (p *OOMKillParser) TransformEvent(event *types.Event) string {
 				sb.WriteString(fmt.Sprintf("%*d", p.ColumnsWidth[col], event.TriggeredPid))
 			case "tcomm":
 				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.TriggeredComm))
+			default:
+				continue
 			}
 
 			// Needed when field is larger than the predefined columnsWidth.

--- a/cmd/kubectl-gadget/trace/open.go
+++ b/cmd/kubectl-gadget/trace/open.go
@@ -28,7 +28,7 @@ import (
 )
 
 type OpenParser struct {
-	commonutils.BaseParser
+	commonutils.BaseParser[types.Event]
 }
 
 func newOpenCmd() *cobra.Command {
@@ -83,7 +83,7 @@ func NewOpenParser(outputConfig *commonutils.OutputConfig) TraceParser[types.Eve
 	}
 
 	return &OpenParser{
-		BaseParser: commonutils.NewBaseWidthParser(columnsWidth, outputConfig),
+		BaseParser: commonutils.NewBaseWidthParser[types.Event](columnsWidth, outputConfig),
 	}
 }
 

--- a/cmd/kubectl-gadget/trace/open.go
+++ b/cmd/kubectl-gadget/trace/open.go
@@ -15,9 +15,7 @@
 package trace
 
 import (
-	"encoding/json"
 	"fmt"
-	"os"
 	"strings"
 
 	commonutils "github.com/kinvolk/inspektor-gadget/cmd/common/utils"
@@ -88,19 +86,9 @@ func NewOpenParser(outputConfig *commonutils.OutputConfig) TraceParser[types.Eve
 }
 
 func (p *OpenParser) TransformEvent(event *types.Event) string {
-	var sb strings.Builder
+	return p.Transform(event, func(event *types.Event) string {
+		var sb strings.Builder
 
-	switch p.OutputConfig.OutputMode {
-	case commonutils.OutputModeJSON:
-		b, err := json.Marshal(event)
-		if err != nil {
-			fmt.Fprint(os.Stderr, fmt.Sprint(commonutils.WrapInErrMarshalOutput(err)))
-			return ""
-		}
-		sb.WriteString(string(b))
-	case commonutils.OutputModeColumns:
-		fallthrough
-	case commonutils.OutputModeCustomColumns:
 		for _, col := range p.OutputConfig.CustomColumns {
 			switch col {
 			case "node":
@@ -126,7 +114,7 @@ func (p *OpenParser) TransformEvent(event *types.Event) string {
 			// Needed when field is larger than the predefined columnsWidth.
 			sb.WriteRune(' ')
 		}
-	}
 
-	return sb.String()
+		return sb.String()
+	})
 }

--- a/cmd/kubectl-gadget/trace/open.go
+++ b/cmd/kubectl-gadget/trace/open.go
@@ -15,7 +15,9 @@
 package trace
 
 import (
+	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 
 	commonutils "github.com/kinvolk/inspektor-gadget/cmd/common/utils"
@@ -88,30 +90,42 @@ func NewOpenParser(outputConfig *commonutils.OutputConfig) TraceParser[types.Eve
 func (p *OpenParser) TransformEvent(event *types.Event) string {
 	var sb strings.Builder
 
-	for _, col := range p.OutputConfig.CustomColumns {
-		switch col {
-		case "node":
-			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Node))
-		case "namespace":
-			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Namespace))
-		case "pod":
-			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Pod))
-		case "container":
-			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Container))
-		case "pid":
-			sb.WriteString(fmt.Sprintf("%*d", p.ColumnsWidth[col], event.Pid))
-		case "comm":
-			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Comm))
-		case "fd":
-			sb.WriteString(fmt.Sprintf("%*d", p.ColumnsWidth[col], event.Fd))
-		case "err":
-			sb.WriteString(fmt.Sprintf("%*d", p.ColumnsWidth[col], event.Err))
-		case "path":
-			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Path))
+	switch p.OutputConfig.OutputMode {
+	case commonutils.OutputModeJSON:
+		b, err := json.Marshal(event)
+		if err != nil {
+			fmt.Fprint(os.Stderr, fmt.Sprint(commonutils.WrapInErrMarshalOutput(err)))
+			return ""
 		}
+		sb.WriteString(string(b))
+	case commonutils.OutputModeColumns:
+		fallthrough
+	case commonutils.OutputModeCustomColumns:
+		for _, col := range p.OutputConfig.CustomColumns {
+			switch col {
+			case "node":
+				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Node))
+			case "namespace":
+				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Namespace))
+			case "pod":
+				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Pod))
+			case "container":
+				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Container))
+			case "pid":
+				sb.WriteString(fmt.Sprintf("%*d", p.ColumnsWidth[col], event.Pid))
+			case "comm":
+				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Comm))
+			case "fd":
+				sb.WriteString(fmt.Sprintf("%*d", p.ColumnsWidth[col], event.Fd))
+			case "err":
+				sb.WriteString(fmt.Sprintf("%*d", p.ColumnsWidth[col], event.Err))
+			case "path":
+				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Path))
+			}
 
-		// Needed when field is larger than the predefined columnsWidth.
-		sb.WriteRune(' ')
+			// Needed when field is larger than the predefined columnsWidth.
+			sb.WriteRune(' ')
+		}
 	}
 
 	return sb.String()

--- a/cmd/kubectl-gadget/trace/open.go
+++ b/cmd/kubectl-gadget/trace/open.go
@@ -109,6 +109,8 @@ func (p *OpenParser) TransformEvent(event *types.Event) string {
 				sb.WriteString(fmt.Sprintf("%*d", p.ColumnsWidth[col], event.Err))
 			case "path":
 				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Path))
+			default:
+				continue
 			}
 
 			// Needed when field is larger than the predefined columnsWidth.

--- a/cmd/kubectl-gadget/trace/signal.go
+++ b/cmd/kubectl-gadget/trace/signal.go
@@ -144,6 +144,8 @@ func (p *SignalParser) TransformEvent(event *types.Event) string {
 				sb.WriteString(fmt.Sprintf("%*d", p.ColumnsWidth[col], event.TargetPid))
 			case "ret":
 				sb.WriteString(fmt.Sprintf("%*d", p.ColumnsWidth[col], event.Retval))
+			default:
+				continue
 			}
 
 			// Needed when field is larger than the predefined columnsWidth.

--- a/cmd/kubectl-gadget/trace/signal.go
+++ b/cmd/kubectl-gadget/trace/signal.go
@@ -15,7 +15,9 @@
 package trace
 
 import (
+	"encoding/json"
 	"fmt"
+	"os"
 	"strconv"
 	"strings"
 
@@ -123,30 +125,42 @@ func NewSignalParser(outputConfig *commonutils.OutputConfig) TraceParser[types.E
 func (p *SignalParser) TransformEvent(event *types.Event) string {
 	var sb strings.Builder
 
-	for _, col := range p.OutputConfig.CustomColumns {
-		switch col {
-		case "node":
-			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Node))
-		case "namespace":
-			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Namespace))
-		case "pod":
-			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Pod))
-		case "container":
-			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Container))
-		case "pid":
-			sb.WriteString(fmt.Sprintf("%*d", p.ColumnsWidth[col], event.Pid))
-		case "comm":
-			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Comm))
-		case "signal":
-			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Signal))
-		case "tpid":
-			sb.WriteString(fmt.Sprintf("%*d", p.ColumnsWidth[col], event.TargetPid))
-		case "ret":
-			sb.WriteString(fmt.Sprintf("%*d", p.ColumnsWidth[col], event.Retval))
+	switch p.OutputConfig.OutputMode {
+	case commonutils.OutputModeJSON:
+		b, err := json.Marshal(event)
+		if err != nil {
+			fmt.Fprint(os.Stderr, fmt.Sprint(commonutils.WrapInErrMarshalOutput(err)))
+			return ""
 		}
+		sb.WriteString(string(b))
+	case commonutils.OutputModeColumns:
+		fallthrough
+	case commonutils.OutputModeCustomColumns:
+		for _, col := range p.OutputConfig.CustomColumns {
+			switch col {
+			case "node":
+				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Node))
+			case "namespace":
+				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Namespace))
+			case "pod":
+				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Pod))
+			case "container":
+				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Container))
+			case "pid":
+				sb.WriteString(fmt.Sprintf("%*d", p.ColumnsWidth[col], event.Pid))
+			case "comm":
+				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Comm))
+			case "signal":
+				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Signal))
+			case "tpid":
+				sb.WriteString(fmt.Sprintf("%*d", p.ColumnsWidth[col], event.TargetPid))
+			case "ret":
+				sb.WriteString(fmt.Sprintf("%*d", p.ColumnsWidth[col], event.Retval))
+			}
 
-		// Needed when field is larger than the predefined columnsWidth.
-		sb.WriteRune(' ')
+			// Needed when field is larger than the predefined columnsWidth.
+			sb.WriteRune(' ')
+		}
 	}
 
 	return sb.String()

--- a/cmd/kubectl-gadget/trace/signal.go
+++ b/cmd/kubectl-gadget/trace/signal.go
@@ -15,9 +15,7 @@
 package trace
 
 import (
-	"encoding/json"
 	"fmt"
-	"os"
 	"strconv"
 	"strings"
 
@@ -123,19 +121,9 @@ func NewSignalParser(outputConfig *commonutils.OutputConfig) TraceParser[types.E
 }
 
 func (p *SignalParser) TransformEvent(event *types.Event) string {
-	var sb strings.Builder
+	return p.Transform(event, func(event *types.Event) string {
+		var sb strings.Builder
 
-	switch p.OutputConfig.OutputMode {
-	case commonutils.OutputModeJSON:
-		b, err := json.Marshal(event)
-		if err != nil {
-			fmt.Fprint(os.Stderr, fmt.Sprint(commonutils.WrapInErrMarshalOutput(err)))
-			return ""
-		}
-		sb.WriteString(string(b))
-	case commonutils.OutputModeColumns:
-		fallthrough
-	case commonutils.OutputModeCustomColumns:
 		for _, col := range p.OutputConfig.CustomColumns {
 			switch col {
 			case "node":
@@ -161,7 +149,7 @@ func (p *SignalParser) TransformEvent(event *types.Event) string {
 			// Needed when field is larger than the predefined columnsWidth.
 			sb.WriteRune(' ')
 		}
-	}
 
-	return sb.String()
+		return sb.String()
+	})
 }

--- a/cmd/kubectl-gadget/trace/signal.go
+++ b/cmd/kubectl-gadget/trace/signal.go
@@ -29,7 +29,7 @@ import (
 )
 
 type SignalParser struct {
-	commonutils.BaseParser
+	commonutils.BaseParser[types.Event]
 }
 
 func newSignalCmd() *cobra.Command {
@@ -118,7 +118,7 @@ func NewSignalParser(outputConfig *commonutils.OutputConfig) TraceParser[types.E
 	}
 
 	return &SignalParser{
-		BaseParser: commonutils.NewBaseWidthParser(columnsWidth, outputConfig),
+		BaseParser: commonutils.NewBaseWidthParser[types.Event](columnsWidth, outputConfig),
 	}
 }
 

--- a/cmd/kubectl-gadget/trace/sni.go
+++ b/cmd/kubectl-gadget/trace/sni.go
@@ -15,7 +15,9 @@
 package trace
 
 import (
+	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 
 	commonutils "github.com/kinvolk/inspektor-gadget/cmd/common/utils"
@@ -78,20 +80,32 @@ func NewSNIParser(outputConfig *commonutils.OutputConfig) TraceParser[types.Even
 func (p *SNIParser) TransformEvent(event *types.Event) string {
 	var sb strings.Builder
 
-	for _, col := range p.OutputConfig.CustomColumns {
-		switch col {
-		case "node":
-			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Node))
-		case "namespace":
-			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Namespace))
-		case "pod":
-			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Pod))
-		case "name":
-			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Name))
+	switch p.OutputConfig.OutputMode {
+	case commonutils.OutputModeJSON:
+		b, err := json.Marshal(event)
+		if err != nil {
+			fmt.Fprint(os.Stderr, fmt.Sprint(commonutils.WrapInErrMarshalOutput(err)))
+			return ""
 		}
+		sb.WriteString(string(b))
+	case commonutils.OutputModeColumns:
+		fallthrough
+	case commonutils.OutputModeCustomColumns:
+		for _, col := range p.OutputConfig.CustomColumns {
+			switch col {
+			case "node":
+				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Node))
+			case "namespace":
+				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Namespace))
+			case "pod":
+				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Pod))
+			case "name":
+				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Name))
+			}
 
-		// Needed when field is larger than the predefined columnsWidth.
-		sb.WriteRune(' ')
+			// Needed when field is larger than the predefined columnsWidth.
+			sb.WriteRune(' ')
+		}
 	}
 
 	return sb.String()

--- a/cmd/kubectl-gadget/trace/sni.go
+++ b/cmd/kubectl-gadget/trace/sni.go
@@ -28,7 +28,7 @@ import (
 )
 
 type SNIParser struct {
-	commonutils.BaseParser
+	commonutils.BaseParser[types.Event]
 }
 
 func newSNICmd() *cobra.Command {
@@ -73,7 +73,7 @@ func NewSNIParser(outputConfig *commonutils.OutputConfig) TraceParser[types.Even
 	}
 
 	return &SNIParser{
-		BaseParser: commonutils.NewBaseWidthParser(columnsWidth, outputConfig),
+		BaseParser: commonutils.NewBaseWidthParser[types.Event](columnsWidth, outputConfig),
 	}
 }
 

--- a/cmd/kubectl-gadget/trace/sni.go
+++ b/cmd/kubectl-gadget/trace/sni.go
@@ -15,9 +15,7 @@
 package trace
 
 import (
-	"encoding/json"
 	"fmt"
-	"os"
 	"strings"
 
 	commonutils "github.com/kinvolk/inspektor-gadget/cmd/common/utils"
@@ -78,19 +76,9 @@ func NewSNIParser(outputConfig *commonutils.OutputConfig) TraceParser[types.Even
 }
 
 func (p *SNIParser) TransformEvent(event *types.Event) string {
-	var sb strings.Builder
+	return p.Transform(event, func(event *types.Event) string {
+		var sb strings.Builder
 
-	switch p.OutputConfig.OutputMode {
-	case commonutils.OutputModeJSON:
-		b, err := json.Marshal(event)
-		if err != nil {
-			fmt.Fprint(os.Stderr, fmt.Sprint(commonutils.WrapInErrMarshalOutput(err)))
-			return ""
-		}
-		sb.WriteString(string(b))
-	case commonutils.OutputModeColumns:
-		fallthrough
-	case commonutils.OutputModeCustomColumns:
 		for _, col := range p.OutputConfig.CustomColumns {
 			switch col {
 			case "node":
@@ -106,7 +94,7 @@ func (p *SNIParser) TransformEvent(event *types.Event) string {
 			// Needed when field is larger than the predefined columnsWidth.
 			sb.WriteRune(' ')
 		}
-	}
 
-	return sb.String()
+		return sb.String()
+	})
 }

--- a/cmd/kubectl-gadget/trace/sni.go
+++ b/cmd/kubectl-gadget/trace/sni.go
@@ -89,6 +89,8 @@ func (p *SNIParser) TransformEvent(event *types.Event) string {
 				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Pod))
 			case "name":
 				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Name))
+			default:
+				continue
 			}
 
 			// Needed when field is larger than the predefined columnsWidth.

--- a/cmd/kubectl-gadget/trace/tcp.go
+++ b/cmd/kubectl-gadget/trace/tcp.go
@@ -15,7 +15,9 @@
 package trace
 
 import (
+	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 
 	commonutils "github.com/kinvolk/inspektor-gadget/cmd/common/utils"
@@ -109,36 +111,48 @@ func getOperationShort(operation string) string {
 func (p *TCPParser) TransformEvent(event *types.Event) string {
 	var sb strings.Builder
 
-	for _, col := range p.OutputConfig.CustomColumns {
-		switch col {
-		case "node":
-			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Node))
-		case "namespace":
-			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Namespace))
-		case "pod":
-			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Pod))
-		case "container":
-			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Container))
-		case "t":
-			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], getOperationShort(event.Operation)))
-		case "pid":
-			sb.WriteString(fmt.Sprintf("%*d", p.ColumnsWidth[col], event.Pid))
-		case "comm":
-			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Comm))
-		case "ip":
-			sb.WriteString(fmt.Sprintf("%*d", p.ColumnsWidth[col], event.IPVersion))
-		case "saddr":
-			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Saddr))
-		case "daddr":
-			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Daddr))
-		case "sport":
-			sb.WriteString(fmt.Sprintf("%*d", p.ColumnsWidth[col], event.Sport))
-		case "dport":
-			sb.WriteString(fmt.Sprintf("%*d", p.ColumnsWidth[col], event.Dport))
+	switch p.OutputConfig.OutputMode {
+	case commonutils.OutputModeJSON:
+		b, err := json.Marshal(event)
+		if err != nil {
+			fmt.Fprint(os.Stderr, fmt.Sprint(commonutils.WrapInErrMarshalOutput(err)))
+			return ""
 		}
+		sb.WriteString(string(b))
+	case commonutils.OutputModeColumns:
+		fallthrough
+	case commonutils.OutputModeCustomColumns:
+		for _, col := range p.OutputConfig.CustomColumns {
+			switch col {
+			case "node":
+				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Node))
+			case "namespace":
+				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Namespace))
+			case "pod":
+				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Pod))
+			case "container":
+				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Container))
+			case "t":
+				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], getOperationShort(event.Operation)))
+			case "pid":
+				sb.WriteString(fmt.Sprintf("%*d", p.ColumnsWidth[col], event.Pid))
+			case "comm":
+				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Comm))
+			case "ip":
+				sb.WriteString(fmt.Sprintf("%*d", p.ColumnsWidth[col], event.IPVersion))
+			case "saddr":
+				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Saddr))
+			case "daddr":
+				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Daddr))
+			case "sport":
+				sb.WriteString(fmt.Sprintf("%*d", p.ColumnsWidth[col], event.Sport))
+			case "dport":
+				sb.WriteString(fmt.Sprintf("%*d", p.ColumnsWidth[col], event.Dport))
+			}
 
-		// Needed when field is larger than the predefined columnsWidth.
-		sb.WriteRune(' ')
+			// Needed when field is larger than the predefined columnsWidth.
+			sb.WriteRune(' ')
+		}
 	}
 
 	return sb.String()

--- a/cmd/kubectl-gadget/trace/tcp.go
+++ b/cmd/kubectl-gadget/trace/tcp.go
@@ -28,7 +28,7 @@ import (
 )
 
 type TCPParser struct {
-	commonutils.BaseParser
+	commonutils.BaseParser[types.Event]
 }
 
 func newTCPCmd() *cobra.Command {
@@ -89,7 +89,7 @@ func NewTCPParser(outputConfig *commonutils.OutputConfig) TraceParser[types.Even
 	}
 
 	return &TCPParser{
-		BaseParser: commonutils.NewBaseWidthParser(columnsWidth, outputConfig),
+		BaseParser: commonutils.NewBaseWidthParser[types.Event](columnsWidth, outputConfig),
 	}
 }
 

--- a/cmd/kubectl-gadget/trace/tcp.go
+++ b/cmd/kubectl-gadget/trace/tcp.go
@@ -136,6 +136,8 @@ func (p *TCPParser) TransformEvent(event *types.Event) string {
 				sb.WriteString(fmt.Sprintf("%*d", p.ColumnsWidth[col], event.Sport))
 			case "dport":
 				sb.WriteString(fmt.Sprintf("%*d", p.ColumnsWidth[col], event.Dport))
+			default:
+				continue
 			}
 
 			// Needed when field is larger than the predefined columnsWidth.

--- a/cmd/kubectl-gadget/trace/tcp.go
+++ b/cmd/kubectl-gadget/trace/tcp.go
@@ -15,9 +15,7 @@
 package trace
 
 import (
-	"encoding/json"
 	"fmt"
-	"os"
 	"strings"
 
 	commonutils "github.com/kinvolk/inspektor-gadget/cmd/common/utils"
@@ -109,19 +107,9 @@ func getOperationShort(operation string) string {
 }
 
 func (p *TCPParser) TransformEvent(event *types.Event) string {
-	var sb strings.Builder
+	return p.Transform(event, func(event *types.Event) string {
+		var sb strings.Builder
 
-	switch p.OutputConfig.OutputMode {
-	case commonutils.OutputModeJSON:
-		b, err := json.Marshal(event)
-		if err != nil {
-			fmt.Fprint(os.Stderr, fmt.Sprint(commonutils.WrapInErrMarshalOutput(err)))
-			return ""
-		}
-		sb.WriteString(string(b))
-	case commonutils.OutputModeColumns:
-		fallthrough
-	case commonutils.OutputModeCustomColumns:
 		for _, col := range p.OutputConfig.CustomColumns {
 			switch col {
 			case "node":
@@ -153,7 +141,7 @@ func (p *TCPParser) TransformEvent(event *types.Event) string {
 			// Needed when field is larger than the predefined columnsWidth.
 			sb.WriteRune(' ')
 		}
-	}
 
-	return sb.String()
+		return sb.String()
+	})
 }

--- a/cmd/kubectl-gadget/trace/tcpconnect.go
+++ b/cmd/kubectl-gadget/trace/tcpconnect.go
@@ -28,7 +28,7 @@ import (
 )
 
 type TcpconnectParser struct {
-	commonutils.BaseParser
+	commonutils.BaseParser[types.Event]
 }
 
 func newTcpconnectCmd() *cobra.Command {
@@ -85,7 +85,7 @@ func NewTcpconnectParser(outputConfig *commonutils.OutputConfig) TraceParser[typ
 	}
 
 	return &TcpconnectParser{
-		BaseParser: commonutils.NewBaseWidthParser(columnsWidth, outputConfig),
+		BaseParser: commonutils.NewBaseWidthParser[types.Event](columnsWidth, outputConfig),
 	}
 }
 

--- a/cmd/kubectl-gadget/trace/tcpconnect.go
+++ b/cmd/kubectl-gadget/trace/tcpconnect.go
@@ -15,7 +15,9 @@
 package trace
 
 import (
+	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 
 	commonutils "github.com/kinvolk/inspektor-gadget/cmd/common/utils"
@@ -90,32 +92,44 @@ func NewTcpconnectParser(outputConfig *commonutils.OutputConfig) TraceParser[typ
 func (p *TcpconnectParser) TransformEvent(event *types.Event) string {
 	var sb strings.Builder
 
-	for _, col := range p.OutputConfig.CustomColumns {
-		switch col {
-		case "node":
-			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Node))
-		case "namespace":
-			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Namespace))
-		case "pod":
-			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Pod))
-		case "container":
-			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Container))
-		case "pid":
-			sb.WriteString(fmt.Sprintf("%*d", p.ColumnsWidth[col], event.Pid))
-		case "comm":
-			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Comm))
-		case "ip":
-			sb.WriteString(fmt.Sprintf("%*d", p.ColumnsWidth[col], event.IPVersion))
-		case "saddr":
-			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Saddr))
-		case "daddr":
-			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Daddr))
-		case "dport":
-			sb.WriteString(fmt.Sprintf("%*d", p.ColumnsWidth[col], event.Dport))
+	switch p.OutputConfig.OutputMode {
+	case commonutils.OutputModeJSON:
+		b, err := json.Marshal(event)
+		if err != nil {
+			fmt.Fprint(os.Stderr, fmt.Sprint(commonutils.WrapInErrMarshalOutput(err)))
+			return ""
 		}
+		sb.WriteString(string(b))
+	case commonutils.OutputModeColumns:
+		fallthrough
+	case commonutils.OutputModeCustomColumns:
+		for _, col := range p.OutputConfig.CustomColumns {
+			switch col {
+			case "node":
+				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Node))
+			case "namespace":
+				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Namespace))
+			case "pod":
+				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Pod))
+			case "container":
+				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Container))
+			case "pid":
+				sb.WriteString(fmt.Sprintf("%*d", p.ColumnsWidth[col], event.Pid))
+			case "comm":
+				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Comm))
+			case "ip":
+				sb.WriteString(fmt.Sprintf("%*d", p.ColumnsWidth[col], event.IPVersion))
+			case "saddr":
+				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Saddr))
+			case "daddr":
+				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Daddr))
+			case "dport":
+				sb.WriteString(fmt.Sprintf("%*d", p.ColumnsWidth[col], event.Dport))
+			}
 
-		// Needed when field is larger than the predefined columnsWidth.
-		sb.WriteRune(' ')
+			// Needed when field is larger than the predefined columnsWidth.
+			sb.WriteRune(' ')
+		}
 	}
 
 	return sb.String()

--- a/cmd/kubectl-gadget/trace/tcpconnect.go
+++ b/cmd/kubectl-gadget/trace/tcpconnect.go
@@ -15,9 +15,7 @@
 package trace
 
 import (
-	"encoding/json"
 	"fmt"
-	"os"
 	"strings"
 
 	commonutils "github.com/kinvolk/inspektor-gadget/cmd/common/utils"
@@ -90,19 +88,9 @@ func NewTcpconnectParser(outputConfig *commonutils.OutputConfig) TraceParser[typ
 }
 
 func (p *TcpconnectParser) TransformEvent(event *types.Event) string {
-	var sb strings.Builder
+	return p.Transform(event, func(event *types.Event) string {
+		var sb strings.Builder
 
-	switch p.OutputConfig.OutputMode {
-	case commonutils.OutputModeJSON:
-		b, err := json.Marshal(event)
-		if err != nil {
-			fmt.Fprint(os.Stderr, fmt.Sprint(commonutils.WrapInErrMarshalOutput(err)))
-			return ""
-		}
-		sb.WriteString(string(b))
-	case commonutils.OutputModeColumns:
-		fallthrough
-	case commonutils.OutputModeCustomColumns:
 		for _, col := range p.OutputConfig.CustomColumns {
 			switch col {
 			case "node":
@@ -130,7 +118,7 @@ func (p *TcpconnectParser) TransformEvent(event *types.Event) string {
 			// Needed when field is larger than the predefined columnsWidth.
 			sb.WriteRune(' ')
 		}
-	}
 
-	return sb.String()
+		return sb.String()
+	})
 }

--- a/cmd/kubectl-gadget/trace/tcpconnect.go
+++ b/cmd/kubectl-gadget/trace/tcpconnect.go
@@ -113,6 +113,8 @@ func (p *TcpconnectParser) TransformEvent(event *types.Event) string {
 				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Daddr))
 			case "dport":
 				sb.WriteString(fmt.Sprintf("%*d", p.ColumnsWidth[col], event.Dport))
+			default:
+				continue
 			}
 
 			// Needed when field is larger than the predefined columnsWidth.

--- a/cmd/kubectl-gadget/trace/trace.go
+++ b/cmd/kubectl-gadget/trace/trace.go
@@ -39,7 +39,8 @@ type TraceEvent interface {
 // TraceParser defines the interface that every trace-gadget parser has to
 // implement.
 type TraceParser[Event TraceEvent] interface {
-	// TransformEvent is called to transform an event to columns format.
+	// TransformEvent is called to transform an event to the requested output
+	// format.
 	TransformEvent(event *Event) string
 
 	// BuildColumnsHeader returns a header with the requested custom columns

--- a/cmd/kubectl-gadget/utils/trace.go
+++ b/cmd/kubectl-gadget/utils/trace.go
@@ -691,7 +691,7 @@ func PrintTraceOutputFromStream(traceID string, expectedState string, params *Co
 		return err
 	}
 
-	return genericStreamsDisplay(params, traces, transformLine)
+	return genericStreams(params, traces, nil, transformLine)
 }
 
 // PrintTraceOutputFromStatus is used to print trace output using function
@@ -917,21 +917,6 @@ func RunTraceAndPrintStatusOutput(
 	defer DeleteTrace(traceID)
 
 	return PrintTraceOutputFromStatus(traceID, config.TraceOutputState, customResultsDisplay)
-}
-
-func genericStreamsDisplay(
-	params *CommonFlags,
-	results *gadgetv1alpha1.TraceList,
-	transformLine func(string) string,
-) error {
-	transform := func(line string) string {
-		if params.OutputMode == commonutils.OutputModeJSON {
-			return line
-		}
-		return transformLine(line)
-	}
-
-	return genericStreams(params, results, nil, transform)
 }
 
 func genericStreams(

--- a/cmd/local-gadget/containers/containers.go
+++ b/cmd/local-gadget/containers/containers.go
@@ -108,7 +108,7 @@ func NewListContainersCmd() *cobra.Command {
 				fmt.Fprintln(w, parser.BuildColumnsHeader())
 
 				for _, c := range containers {
-					fmt.Fprintln(w, parser.TransformContainerToColumns(c))
+					fmt.Fprintln(w, parser.TransformToColumns(c))
 				}
 
 				w.Flush()
@@ -146,7 +146,7 @@ func (p *ContainerParser) SortContainers(containers []*containercollection.Conta
 	})
 }
 
-func (p *ContainerParser) TransformContainerToColumns(c *containercollection.Container) string {
+func (p *ContainerParser) TransformToColumns(c *containercollection.Container) string {
 	var sb strings.Builder
 
 	for _, col := range p.OutputConfig.CustomColumns {

--- a/cmd/local-gadget/containers/containers.go
+++ b/cmd/local-gadget/containers/containers.go
@@ -35,7 +35,7 @@ type ContainerFlags struct {
 }
 
 type ContainerParser struct {
-	commonutils.BaseParser
+	commonutils.BaseParser[containercollection.Container]
 
 	containerFlags *ContainerFlags
 }
@@ -82,7 +82,7 @@ func NewListContainersCmd() *cobra.Command {
 			defer localGadgetManager.Close()
 
 			parser := &ContainerParser{
-				BaseParser:     commonutils.NewBaseTabParser(availableColumns, &commonFlags.OutputConfig),
+				BaseParser:     commonutils.NewBaseTabParser[containercollection.Container](availableColumns, &commonFlags.OutputConfig),
 				containerFlags: &containerFlags,
 			}
 


### PR DESCRIPTION
# Manage JSON output mode outside of utils/trace

Before this PR, all the gadgets using `RunTraceAndPrintStream` don't have the full control over the JSON output mode because this function was internally managing that case [here](https://github.com/kinvolk/inspektor-gadget/blob/0f5fd1688e67494beb52dd995d2dbb69f2e4ad53/cmd/kubectl-gadget/utils/trace.go#L928-L930). However, with the introduction of the gadget parsers, keeping this logic on the utils/trace doesn't make sense anymore. The full management of the output format must be controlled by the parsers.

In this PR, the logic to print the received lines was moved from [cmd/kubectl-gadget/utils/trace.go](https://github.com/kinvolk/inspektor-gadget/blob/0f5fd1688e67494beb52dd995d2dbb69f2e4ad53/cmd/kubectl-gadget/utils/trace.go#L928-L930) to [cmd/common/utils/parser.go](https://github.com/kinvolk/inspektor-gadget/blob/bcf4267b548c712193a42800dd9a6e53f4fdbdbd/cmd/common/utils/parser.go#L83-L90). However, it was done in two steps:

1. Move the logic from the utils/trace to the gadgets
2. Move the logic from the gadgets to parsers. In particular, to the `BaseParser` to avoid duplicated code on all the gadgets.

This PR also introduce some tests for the `BaseParser`. However, additional tests need to be added for every gadget parser.

## How to use

This PR does not introduce any change for the users.

## Testing done

Integration tests for all the gadgets using the `BaseParser` are passing.

## TODO in future PRs

Modify the Audit and Top categories to take advantage of the `BaseParser`. Once it is done, we will be easier to implement common features like: combine the `OutputModeColumns` and `OutputModeCustomColumns`, print the available columns that can be used with `-o custom-columns` (see https://github.com/kinvolk/inspektor-gadget/pull/664#discussion_r923422310).
