### PR TITLE
Cleanup resolver interface

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -581,7 +581,7 @@ func TestNetworkpolicy(t *testing.T) {
 					sleep 10
 					kill $!
 					head networktrace-client.log | sort | uniq`, nsClient),
-			expectedRegexp: fmt.Sprintf(`{"type":"normal","node":".*","namespace":"%s","pod":"test-pod","pkt_type":"OUTGOING","proto":"tcp","ip":".*","port":9090,"remote_kind":"svc","pod_host_ip":".*","pod_ip":".*","pod_labels":{"run":"test-pod"},"remote_svc_namespace":"%s","remote_svc_name":"test-pod","remote_svc_label_selector":{"run":"test-pod"}}`, nsClient, nsServer),
+			expectedRegexp: fmt.Sprintf(`{"node":".*","namespace":"%s","pod":"test-pod","type":"normal","pkt_type":"OUTGOING","proto":"tcp","ip":".*","port":9090,"remote_kind":"svc","pod_host_ip":".*","pod_ip":".*","pod_labels":{"run":"test-pod"},"remote_svc_namespace":"%s","remote_svc_name":"test-pod","remote_svc_label_selector":{"run":"test-pod"}}`, nsClient, nsServer),
 		},
 		{
 			// Docker bridge does not preserve source IP :-(
@@ -593,7 +593,7 @@ func TestNetworkpolicy(t *testing.T) {
 					kill $!
 					head networktrace-server.log | sort | uniq
 					kubectl get node -o jsonpath='{.items[0].status.nodeInfo.containerRuntimeVersion}'|grep -q docker && echo SKIP_TEST || true`, nsServer),
-			expectedRegexp: fmt.Sprintf(`SKIP_TEST|{"type":"normal","node":".*","namespace":"%s","pod":"test-pod","pkt_type":"HOST","proto":"tcp","ip":".*","port":9090,"remote_kind":"pod","pod_host_ip":".*","pod_ip":".*","pod_labels":{"run":"test-pod"},"remote_pod_namespace":"%s","remote_pod_name":"test-pod","remote_pod_labels":{"run":"test-pod"}}`, nsServer, nsClient),
+			expectedRegexp: fmt.Sprintf(`SKIP_TEST|{"node":".*","namespace":"%s","pod":"test-pod","type":"normal","pkt_type":"HOST","proto":"tcp","ip":".*","port":9090,"remote_kind":"pod","pod_host_ip":".*","pod_ip":".*","pod_labels":{"run":"test-pod"},"remote_pod_namespace":"%s","remote_pod_name":"test-pod","remote_pod_labels":{"run":"test-pod"}}`, nsServer, nsClient),
 		},
 		{
 			name: "RunNetworkPolicyReportClient",

--- a/pkg/container-collection/match_test.go
+++ b/pkg/container-collection/match_test.go
@@ -132,7 +132,7 @@ func TestSelector(t *testing.T) {
 	}
 }
 
-func TestResolver(t *testing.T) {
+func TestContainerResolver(t *testing.T) {
 	opts := []ContainerCollectionOption{}
 
 	cc := &ContainerCollection{}

--- a/pkg/gadget-collection/gadgets/interface.go
+++ b/pkg/gadget-collection/gadgets/interface.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cilium/ebpf"
 	gadgetv1alpha1 "github.com/kinvolk/inspektor-gadget/pkg/apis/gadget/v1alpha1"
 	containercollection "github.com/kinvolk/inspektor-gadget/pkg/container-collection"
+	"github.com/kinvolk/inspektor-gadget/pkg/gadgets"
 
 	log "github.com/sirupsen/logrus"
 	apimachineryruntime "k8s.io/apimachinery/pkg/runtime"
@@ -75,6 +76,7 @@ type TraceOperation struct {
 
 type Resolver interface {
 	containercollection.ContainerResolver
+	gadgets.DataEnricher
 
 	PublishEvent(tracerID string, line string) error
 	TracerMountNsMap(tracerID string) (*ebpf.Map, error)

--- a/pkg/gadget-collection/gadgets/interface.go
+++ b/pkg/gadget-collection/gadgets/interface.go
@@ -28,10 +28,10 @@ import (
 )
 
 type TraceFactory interface {
-	// Initialize gives the Resolver and the Client to the gadget. Gadgets
+	// Initialize gives the Helpers and the Client to the gadget. Gadgets
 	// don't need to implement this method if they use BaseFactory as an
 	// anonymous field.
-	Initialize(Resolver Resolver, Client client.Client)
+	Initialize(Helpers GadgetHelpers, Client client.Client)
 
 	// Delete request a gadget to release the information it has about a
 	// trace. BaseFactory implements this method, so gadgets who embed
@@ -74,7 +74,9 @@ type TraceOperation struct {
 	Order int
 }
 
-type Resolver interface {
+// GadgetHelpers provides different functions that are used in the
+// gadgets implementation.
+type GadgetHelpers interface {
 	containercollection.ContainerResolver
 	gadgets.DataEnricher
 
@@ -84,8 +86,8 @@ type Resolver interface {
 }
 
 type BaseFactory struct {
-	Resolver Resolver
-	Client   client.Client
+	Helpers GadgetHelpers
+	Client  client.Client
 
 	// DeleteTrace is optionally set by gadgets if they need to do
 	// specialised clean up. Example:
@@ -101,8 +103,8 @@ type BaseFactory struct {
 	traces map[string]interface{}
 }
 
-func (f *BaseFactory) Initialize(r Resolver, c client.Client) {
-	f.Resolver = r
+func (f *BaseFactory) Initialize(r GadgetHelpers, c client.Client) {
+	f.Helpers = r
 	f.Client = c
 }
 

--- a/pkg/gadget-collection/gadgets/profile/block-io/gadget.go
+++ b/pkg/gadget-collection/gadgets/profile/block-io/gadget.go
@@ -29,7 +29,7 @@ import (
 )
 
 type Trace struct {
-	resolver gadgets.Resolver
+	helpers gadgets.GadgetHelpers
 
 	started bool
 	tracer  profile.Tracer

--- a/pkg/gadget-collection/gadgets/profile/cpu/gadget.go
+++ b/pkg/gadget-collection/gadgets/profile/cpu/gadget.go
@@ -30,7 +30,7 @@ import (
 )
 
 type Trace struct {
-	resolver gadgets.Resolver
+	helpers gadgets.GadgetHelpers
 
 	started bool
 	tracer  profile.Tracer
@@ -66,7 +66,7 @@ func deleteTrace(name string, t interface{}) {
 func (f *TraceFactory) Operations() map[string]gadgets.TraceOperation {
 	n := func() interface{} {
 		return &Trace{
-			resolver: f.Resolver,
+			helpers: f.Helpers,
 		}
 	}
 
@@ -94,7 +94,7 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 
 	traceName := gadgets.TraceName(trace.ObjectMeta.Namespace, trace.ObjectMeta.Name)
 
-	mountNsMap, err := t.resolver.TracerMountNsMap(traceName)
+	mountNsMap, err := t.helpers.TracerMountNsMap(traceName)
 	if err != nil {
 		trace.Status.OperationError = fmt.Sprintf("failed to find tracer's mount ns map: %s", err)
 		return
@@ -108,7 +108,7 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 		KernelStackOnly: kernelStackOnly,
 	}
 
-	t.tracer, err = tracer.NewTracer(t.resolver, config, trace.Spec.Node)
+	t.tracer, err = tracer.NewTracer(t.helpers, config, trace.Spec.Node)
 	if err != nil {
 		trace.Status.OperationWarning = fmt.Sprint("failed to create core tracer. Falling back to standard one")
 

--- a/pkg/gadget-collection/gadgets/snapshot/process/gadget.go
+++ b/pkg/gadget-collection/gadgets/snapshot/process/gadget.go
@@ -24,7 +24,7 @@ import (
 )
 
 type Trace struct {
-	resolver gadgets.Resolver
+	helpers gadgets.GadgetHelpers
 }
 
 type TraceFactory struct {
@@ -48,7 +48,7 @@ func (f *TraceFactory) OutputModesSupported() map[string]struct{} {
 func (f *TraceFactory) Operations() map[string]gadgets.TraceOperation {
 	n := func() interface{} {
 		return &Trace{
-			resolver: f.Resolver,
+			helpers: f.Helpers,
 		}
 	}
 
@@ -66,12 +66,12 @@ func (f *TraceFactory) Operations() map[string]gadgets.TraceOperation {
 
 func (t *Trace) Collect(trace *gadgetv1alpha1.Trace) {
 	traceName := gadgets.TraceName(trace.ObjectMeta.Namespace, trace.ObjectMeta.Name)
-	mountNsMap, err := t.resolver.TracerMountNsMap(traceName)
+	mountNsMap, err := t.helpers.TracerMountNsMap(traceName)
 	if err != nil {
 		trace.Status.OperationError = fmt.Sprintf("failed to find tracer's mount ns map: %s", err)
 		return
 	}
-	events, err := tracer.RunCollector(t.resolver, trace.Spec.Node, mountNsMap)
+	events, err := tracer.RunCollector(t.helpers, trace.Spec.Node, mountNsMap)
 	if err != nil {
 		trace.Status.OperationError = err.Error()
 		return

--- a/pkg/gadget-collection/gadgets/snapshot/socket/gadget.go
+++ b/pkg/gadget-collection/gadgets/snapshot/socket/gadget.go
@@ -27,7 +27,7 @@ import (
 )
 
 type Trace struct {
-	resolver gadgets.Resolver
+	helpers gadgets.GadgetHelpers
 }
 
 type TraceFactory struct {
@@ -51,7 +51,7 @@ func (f *TraceFactory) OutputModesSupported() map[string]struct{} {
 func (f *TraceFactory) Operations() map[string]gadgets.TraceOperation {
 	n := func() interface{} {
 		return &Trace{
-			resolver: f.Resolver,
+			helpers: f.Helpers,
 		}
 	}
 
@@ -74,7 +74,7 @@ func (t *Trace) Collect(trace *gadgetv1alpha1.Trace) {
 	}
 
 	selector := gadgets.ContainerSelectorFromContainerFilter(trace.Spec.Filter)
-	filteredContainers := t.resolver.GetContainersBySelector(selector)
+	filteredContainers := t.helpers.GetContainersBySelector(selector)
 	if len(filteredContainers) == 0 {
 		trace.Status.OperationWarning = "No container matches the requested filter"
 		trace.Status.State = "Completed"

--- a/pkg/gadget-collection/gadgets/top/block-io/gadget.go
+++ b/pkg/gadget-collection/gadgets/top/block-io/gadget.go
@@ -31,7 +31,7 @@ import (
 )
 
 type Trace struct {
-	resolver gadgets.Resolver
+	helpers gadgets.GadgetHelpers
 
 	started bool
 	tracer  *biotoptracer.Tracer
@@ -75,7 +75,7 @@ func deleteTrace(name string, t interface{}) {
 func (f *TraceFactory) Operations() map[string]gadgets.TraceOperation {
 	n := func() interface{} {
 		return &Trace{
-			resolver: f.Resolver,
+			helpers: f.Helpers,
 		}
 	}
 
@@ -136,7 +136,7 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 		}
 	}
 
-	mountNsMap, err := t.resolver.TracerMountNsMap(traceName)
+	mountNsMap, err := t.helpers.TracerMountNsMap(traceName)
 	if err != nil {
 		trace.Status.OperationError = fmt.Sprintf("failed to find tracer's mount ns map: %s", err)
 		return
@@ -160,7 +160,7 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 			log.Warnf("Gadget %s: Failed to marshall event: %s", trace.Spec.Gadget, err)
 			return
 		}
-		t.resolver.PublishEvent(traceName, string(r))
+		t.helpers.PublishEvent(traceName, string(r))
 	}
 
 	errorCallback := func(err error) {
@@ -173,10 +173,10 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 			log.Warnf("Gadget %s: Failed to marshall event: %s", trace.Spec.Gadget, err)
 			return
 		}
-		t.resolver.PublishEvent(traceName, string(r))
+		t.helpers.PublishEvent(traceName, string(r))
 	}
 
-	tracer, err := biotoptracer.NewTracer(config, t.resolver, statsCallback, errorCallback)
+	tracer, err := biotoptracer.NewTracer(config, t.helpers, statsCallback, errorCallback)
 	if err != nil {
 		trace.Status.OperationError = fmt.Sprintf("failed to create tracer: %s", err)
 		return

--- a/pkg/gadget-collection/gadgets/top/file/gadget.go
+++ b/pkg/gadget-collection/gadgets/top/file/gadget.go
@@ -31,7 +31,7 @@ import (
 )
 
 type Trace struct {
-	resolver gadgets.Resolver
+	helpers gadgets.GadgetHelpers
 
 	started bool
 	tracer  *filetoptracer.Tracer
@@ -77,7 +77,7 @@ func deleteTrace(name string, t interface{}) {
 func (f *TraceFactory) Operations() map[string]gadgets.TraceOperation {
 	n := func() interface{} {
 		return &Trace{
-			resolver: f.Resolver,
+			helpers: f.Helpers,
 		}
 	}
 
@@ -147,7 +147,7 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 		}
 	}
 
-	mountNsMap, err := t.resolver.TracerMountNsMap(traceName)
+	mountNsMap, err := t.helpers.TracerMountNsMap(traceName)
 	if err != nil {
 		trace.Status.OperationError = fmt.Sprintf("failed to find tracer's mount ns map: %s", err)
 		return
@@ -173,7 +173,7 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 			log.Warnf("Gadget %s: Failed to marshall event: %s", trace.Spec.Gadget, err)
 			return
 		}
-		t.resolver.PublishEvent(traceName, string(r))
+		t.helpers.PublishEvent(traceName, string(r))
 	}
 
 	errorCallback := func(err error) {
@@ -186,10 +186,10 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 			log.Warnf("Gadget %s: Failed to marshall event: %s", trace.Spec.Gadget, err)
 			return
 		}
-		t.resolver.PublishEvent(traceName, string(r))
+		t.helpers.PublishEvent(traceName, string(r))
 	}
 
-	tracer, err := filetoptracer.NewTracer(config, t.resolver, statsCallback, errorCallback)
+	tracer, err := filetoptracer.NewTracer(config, t.helpers, statsCallback, errorCallback)
 	if err != nil {
 		trace.Status.OperationError = fmt.Sprintf("failed to create tracer: %s", err)
 		return

--- a/pkg/gadget-collection/gadgets/top/tcp/gadget.go
+++ b/pkg/gadget-collection/gadgets/top/tcp/gadget.go
@@ -31,7 +31,7 @@ import (
 )
 
 type Trace struct {
-	resolver gadgets.Resolver
+	helpers gadgets.GadgetHelpers
 
 	started bool
 	tracer  *tcptoptracer.Tracer
@@ -78,7 +78,7 @@ func deleteTrace(name string, t interface{}) {
 func (f *TraceFactory) Operations() map[string]gadgets.TraceOperation {
 	n := func() interface{} {
 		return &Trace{
-			resolver: f.Resolver,
+			helpers: f.Helpers,
 		}
 	}
 
@@ -159,7 +159,7 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 		}
 	}
 
-	mountNsMap, err := t.resolver.TracerMountNsMap(traceName)
+	mountNsMap, err := t.helpers.TracerMountNsMap(traceName)
 	if err != nil {
 		trace.Status.OperationError = fmt.Sprintf("failed to find tracer's mount ns map: %s", err)
 		return
@@ -185,7 +185,7 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 			log.Warnf("Gadget %s: Failed to marshall event: %s", trace.Spec.Gadget, err)
 			return
 		}
-		t.resolver.PublishEvent(traceName, string(r))
+		t.helpers.PublishEvent(traceName, string(r))
 	}
 
 	errorCallback := func(err error) {
@@ -198,10 +198,10 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 			log.Warnf("Gadget %s: Failed to marshall event: %s", trace.Spec.Gadget, err)
 			return
 		}
-		t.resolver.PublishEvent(traceName, string(r))
+		t.helpers.PublishEvent(traceName, string(r))
 	}
 
-	tracer, err := tcptoptracer.NewTracer(config, t.resolver, statsCallback, errorCallback)
+	tracer, err := tcptoptracer.NewTracer(config, t.helpers, statsCallback, errorCallback)
 	if err != nil {
 		trace.Status.OperationError = fmt.Sprintf("failed to create tracer: %s", err)
 		return

--- a/pkg/gadget-collection/gadgets/trace/bind/gadget.go
+++ b/pkg/gadget-collection/gadgets/trace/bind/gadget.go
@@ -166,7 +166,7 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 		log.Infof("Gadget %s: falling back to standard tracer. CO-RE tracer failed: %s",
 			trace.Spec.Gadget, err)
 
-		t.tracer, err = standardtracer.NewTracer(config, t.resolver, eventCallback, trace.Spec.Node)
+		t.tracer, err = standardtracer.NewTracer(config, eventCallback, trace.Spec.Node)
 		if err != nil {
 			trace.Status.OperationError = fmt.Sprintf("failed to create tracer: %s", err)
 			return

--- a/pkg/gadget-collection/gadgets/trace/bind/gadget.go
+++ b/pkg/gadget-collection/gadgets/trace/bind/gadget.go
@@ -33,7 +33,7 @@ import (
 )
 
 type Trace struct {
-	resolver gadgets.Resolver
+	helpers gadgets.GadgetHelpers
 
 	started bool
 	tracer  trace.Tracer
@@ -69,7 +69,7 @@ func deleteTrace(name string, t interface{}) {
 func (f *TraceFactory) Operations() map[string]gadgets.TraceOperation {
 	n := func() interface{} {
 		return &Trace{
-			resolver: f.Resolver,
+			helpers: f.Helpers,
 		}
 	}
 
@@ -103,7 +103,7 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 			log.Warnf("Gadget %s: error marshalling event: %s", trace.Spec.Gadget, err)
 			return
 		}
-		t.resolver.PublishEvent(traceName, string(r))
+		t.helpers.PublishEvent(traceName, string(r))
 	}
 
 	params := trace.Spec.Parameters
@@ -147,7 +147,7 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 
 	var err error
 
-	mountNsMap, err := t.resolver.TracerMountNsMap(traceName)
+	mountNsMap, err := t.helpers.TracerMountNsMap(traceName)
 	if err != nil {
 		trace.Status.OperationError = fmt.Sprintf("failed to find tracer's mount ns map: %s", err)
 		return
@@ -158,7 +158,7 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 		TargetPorts:  targetPorts,
 		IgnoreErrors: ignoreErrors,
 	}
-	t.tracer, err = tracer.NewTracer(config, t.resolver, eventCallback, trace.Spec.Node)
+	t.tracer, err = tracer.NewTracer(config, t.helpers, eventCallback, trace.Spec.Node)
 	if err != nil {
 		trace.Status.OperationWarning = fmt.Sprint("failed to create core tracer. Falling back to standard one")
 

--- a/pkg/gadget-collection/gadgets/trace/capabilities/gadget.go
+++ b/pkg/gadget-collection/gadgets/trace/capabilities/gadget.go
@@ -31,7 +31,7 @@ import (
 )
 
 type Trace struct {
-	resolver gadgets.Resolver
+	helpers gadgets.GadgetHelpers
 
 	started bool
 	tracer  trace.Tracer
@@ -67,7 +67,7 @@ func deleteTrace(name string, t interface{}) {
 func (f *TraceFactory) Operations() map[string]gadgets.TraceOperation {
 	n := func() interface{} {
 		return &Trace{
-			resolver: f.Resolver,
+			helpers: f.Helpers,
 		}
 	}
 
@@ -101,12 +101,12 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 			log.Warnf("Gadget %s: error marshalling event: %s", trace.Spec.Gadget, err)
 			return
 		}
-		t.resolver.PublishEvent(traceName, string(r))
+		t.helpers.PublishEvent(traceName, string(r))
 	}
 
 	var err error
 
-	mountNsMap, err := t.resolver.TracerMountNsMap(traceName)
+	mountNsMap, err := t.helpers.TracerMountNsMap(traceName)
 	if err != nil {
 		trace.Status.OperationError = fmt.Sprintf("failed to find tracer's mount ns map: %s", err)
 		return
@@ -115,7 +115,7 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 		MountnsMap: mountNsMap,
 	}
 
-	t.tracer, err = tracer.NewTracer(config, t.resolver, eventCallback, trace.Spec.Node)
+	t.tracer, err = tracer.NewTracer(config, t.helpers, eventCallback, trace.Spec.Node)
 	if err != nil {
 		trace.Status.OperationWarning = fmt.Sprint("failed to create core tracer. Falling back to standard one")
 

--- a/pkg/gadget-collection/gadgets/trace/capabilities/gadget.go
+++ b/pkg/gadget-collection/gadgets/trace/capabilities/gadget.go
@@ -123,7 +123,7 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 		log.Infof("Gadget %s: falling back to standard tracer. CO-RE tracer failed: %s",
 			trace.Spec.Gadget, err)
 
-		t.tracer, err = standardtracer.NewTracer(config, t.resolver, eventCallback, trace.Spec.Node)
+		t.tracer, err = standardtracer.NewTracer(config, eventCallback, trace.Spec.Node)
 		if err != nil {
 			trace.Status.OperationError = fmt.Sprintf("failed to create tracer: %s", err)
 			return

--- a/pkg/gadget-collection/gadgets/trace/dns/gadget.go
+++ b/pkg/gadget-collection/gadgets/trace/dns/gadget.go
@@ -114,8 +114,10 @@ func (t *Trace) publishMessage(
 ) {
 	event := &types.Event{
 		Event: eventtypes.Event{
-			Type:    eventType,
-			Node:    trace.Spec.Node,
+			Type: eventType,
+			CommonData: eventtypes.CommonData{
+				Node: trace.Spec.Node,
+			},
 			Message: msg,
 		},
 	}

--- a/pkg/gadget-collection/gadgets/trace/exec/gadget.go
+++ b/pkg/gadget-collection/gadgets/trace/exec/gadget.go
@@ -31,7 +31,7 @@ import (
 )
 
 type Trace struct {
-	resolver gadgets.Resolver
+	helpers gadgets.GadgetHelpers
 
 	started bool
 	tracer  trace.Tracer
@@ -67,7 +67,7 @@ func deleteTrace(name string, t interface{}) {
 func (f *TraceFactory) Operations() map[string]gadgets.TraceOperation {
 	n := func() interface{} {
 		return &Trace{
-			resolver: f.Resolver,
+			helpers: f.Helpers,
 		}
 	}
 
@@ -101,12 +101,12 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 			log.Warnf("Gadget %s: error marshalling event: %s", trace.Spec.Gadget, err)
 			return
 		}
-		t.resolver.PublishEvent(traceName, string(r))
+		t.helpers.PublishEvent(traceName, string(r))
 	}
 
 	var err error
 
-	mountNsMap, err := t.resolver.TracerMountNsMap(traceName)
+	mountNsMap, err := t.helpers.TracerMountNsMap(traceName)
 	if err != nil {
 		trace.Status.OperationError = fmt.Sprintf("failed to find tracer's mount ns map: %s", err)
 		return
@@ -114,7 +114,7 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 	config := &tracer.Config{
 		MountnsMap: mountNsMap,
 	}
-	t.tracer, err = tracer.NewTracer(config, t.resolver, eventCallback, trace.Spec.Node)
+	t.tracer, err = tracer.NewTracer(config, t.helpers, eventCallback, trace.Spec.Node)
 	if err != nil {
 		trace.Status.OperationWarning = fmt.Sprint("failed to create core tracer. Falling back to standard one")
 

--- a/pkg/gadget-collection/gadgets/trace/exec/gadget.go
+++ b/pkg/gadget-collection/gadgets/trace/exec/gadget.go
@@ -122,7 +122,7 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 		log.Infof("Gadget %s: falling back to standard tracer. CO-RE tracer failed: %s",
 			trace.Spec.Gadget, err)
 
-		t.tracer, err = standardtracer.NewTracer(config, t.resolver, eventCallback, trace.Spec.Node)
+		t.tracer, err = standardtracer.NewTracer(config, eventCallback, trace.Spec.Node)
 		if err != nil {
 			trace.Status.OperationError = fmt.Sprintf("failed to create tracer: %s", err)
 			return

--- a/pkg/gadget-collection/gadgets/trace/fsslower/gadget.go
+++ b/pkg/gadget-collection/gadgets/trace/fsslower/gadget.go
@@ -32,7 +32,7 @@ import (
 var validFilesystems = []string{"btrfs", "ext4", "nfs", "xfs"}
 
 type Trace struct {
-	resolver gadgets.Resolver
+	helpers gadgets.GadgetHelpers
 
 	started bool
 	tracer  trace.Tracer
@@ -74,7 +74,7 @@ func deleteTrace(name string, t interface{}) {
 func (f *TraceFactory) Operations() map[string]gadgets.TraceOperation {
 	n := func() interface{} {
 		return &Trace{
-			resolver: f.Resolver,
+			helpers: f.Helpers,
 		}
 	}
 
@@ -108,7 +108,7 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 			fmt.Printf("error marshalling event: %s\n", err)
 			return
 		}
-		t.resolver.PublishEvent(traceName, string(r))
+		t.helpers.PublishEvent(traceName, string(r))
 	}
 
 	var err error
@@ -138,7 +138,7 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 		minLatency = uint(minLatencyParsed)
 	}
 
-	mountNsMap, err := t.resolver.TracerMountNsMap(traceName)
+	mountNsMap, err := t.helpers.TracerMountNsMap(traceName)
 	if err != nil {
 		trace.Status.OperationError = fmt.Sprintf("failed to find tracer's mount ns map: %s", err)
 		return
@@ -149,7 +149,7 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 		Filesystem: filesystem,
 		MinLatency: minLatency,
 	}
-	t.tracer, err = tracer.NewTracer(config, t.resolver, eventCallback, trace.Spec.Node)
+	t.tracer, err = tracer.NewTracer(config, t.helpers, eventCallback, trace.Spec.Node)
 	if err != nil {
 		trace.Status.OperationError = fmt.Sprintf("failed to create tracer: %s", err)
 		return

--- a/pkg/gadget-collection/gadgets/trace/mount/gadget.go
+++ b/pkg/gadget-collection/gadgets/trace/mount/gadget.go
@@ -32,7 +32,7 @@ import (
 )
 
 type Trace struct {
-	resolver gadgets.Resolver
+	helpers gadgets.GadgetHelpers
 
 	started bool
 	tracer  trace.Tracer
@@ -68,7 +68,7 @@ func deleteTrace(name string, t interface{}) {
 func (f *TraceFactory) Operations() map[string]gadgets.TraceOperation {
 	n := func() interface{} {
 		return &Trace{
-			resolver: f.Resolver,
+			helpers: f.Helpers,
 		}
 	}
 
@@ -102,12 +102,12 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 			log.Warnf("Gadget %s: error marshalling event: %s", trace.Spec.Gadget, err)
 			return
 		}
-		t.resolver.PublishEvent(traceName, string(r))
+		t.helpers.PublishEvent(traceName, string(r))
 	}
 
 	var err error
 
-	mountNsMap, err := t.resolver.TracerMountNsMap(traceName)
+	mountNsMap, err := t.helpers.TracerMountNsMap(traceName)
 	if err != nil {
 		trace.Status.OperationError = fmt.Sprintf("failed to find tracer's mount ns map: %s", err)
 		return
@@ -115,7 +115,7 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 	config := &tracer.Config{
 		MountnsMap: mountNsMap,
 	}
-	t.tracer, err = tracer.NewTracer(config, t.resolver, eventCallback, trace.Spec.Node)
+	t.tracer, err = tracer.NewTracer(config, t.helpers, eventCallback, trace.Spec.Node)
 	if err != nil {
 		trace.Status.OperationWarning = fmt.Sprint("failed to create core tracer. Falling back to standard one")
 

--- a/pkg/gadget-collection/gadgets/trace/mount/gadget.go
+++ b/pkg/gadget-collection/gadgets/trace/mount/gadget.go
@@ -123,7 +123,7 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 		log.Infof("Gadget %s: falling back to standard tracer. CO-RE tracer failed: %s",
 			trace.Spec.Gadget, err)
 
-		t.tracer, err = standardtracer.NewTracer(config, t.resolver, eventCallback, trace.Spec.Node)
+		t.tracer, err = standardtracer.NewTracer(config, eventCallback, trace.Spec.Node)
 		if err != nil {
 			trace.Status.OperationError = fmt.Sprintf("failed to create tracer: %s", err)
 			return

--- a/pkg/gadget-collection/gadgets/trace/network/enricher.go
+++ b/pkg/gadget-collection/gadgets/trace/network/enricher.go
@@ -68,11 +68,13 @@ func (e *Enricher) convertEvent(
 
 	out := types.Event{
 		Event: eventtypes.Event{
-			Type:      eventtypes.NORMAL,
-			Node:      e.node,
-			Message:   "",
-			Namespace: namespace,
-			Pod:       name,
+			Type: eventtypes.NORMAL,
+			CommonData: eventtypes.CommonData{
+				Node:      e.node,
+				Namespace: namespace,
+				Pod:       name,
+			},
+			Message: "",
 		},
 
 		PktType: edge.PktType,

--- a/pkg/gadget-collection/gadgets/trace/network/gadget.go
+++ b/pkg/gadget-collection/gadgets/trace/network/gadget.go
@@ -120,8 +120,10 @@ func (t *Trace) publishMessage(
 ) {
 	event := &types.Event{
 		Event: eventtypes.Event{
-			Type:    eventType,
-			Node:    trace.Spec.Node,
+			Type: eventType,
+			CommonData: eventtypes.CommonData{
+				Node: trace.Spec.Node,
+			},
 			Message: msg,
 		},
 	}

--- a/pkg/gadget-collection/gadgets/trace/oomkill/gadget.go
+++ b/pkg/gadget-collection/gadgets/trace/oomkill/gadget.go
@@ -27,7 +27,7 @@ import (
 )
 
 type Trace struct {
-	resolver gadgets.Resolver
+	helpers gadgets.GadgetHelpers
 
 	started bool
 	tracer  *tracer.Tracer
@@ -63,7 +63,7 @@ func deleteTrace(name string, t interface{}) {
 func (f *TraceFactory) Operations() map[string]gadgets.TraceOperation {
 	n := func() interface{} {
 		return &Trace{
-			resolver: f.Resolver,
+			helpers: f.Helpers,
 		}
 	}
 
@@ -98,12 +98,12 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 			fmt.Printf("error marshalling event: %s\n", err)
 			return
 		}
-		t.resolver.PublishEvent(traceName, string(r))
+		t.helpers.PublishEvent(traceName, string(r))
 	}
 
 	var err error
 
-	mountNsMap, err := t.resolver.TracerMountNsMap(traceName)
+	mountNsMap, err := t.helpers.TracerMountNsMap(traceName)
 	if err != nil {
 		trace.Status.OperationError = fmt.Sprintf("failed to find tracer's mount ns map: %s", err)
 		return
@@ -111,7 +111,7 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 	config := &tracer.Config{
 		MountnsMap: mountNsMap,
 	}
-	t.tracer, err = tracer.NewTracer(config, t.resolver, eventCallback, trace.Spec.Node)
+	t.tracer, err = tracer.NewTracer(config, t.helpers, eventCallback, trace.Spec.Node)
 	if err != nil {
 		trace.Status.OperationError = fmt.Sprintf("failed to create tracer: %s", err)
 		return

--- a/pkg/gadget-collection/gadgets/trace/open/gadget.go
+++ b/pkg/gadget-collection/gadgets/trace/open/gadget.go
@@ -31,7 +31,7 @@ import (
 )
 
 type Trace struct {
-	resolver gadgets.Resolver
+	helpers gadgets.GadgetHelpers
 
 	started bool
 	tracer  trace.Tracer
@@ -67,7 +67,7 @@ func deleteTrace(name string, t interface{}) {
 func (f *TraceFactory) Operations() map[string]gadgets.TraceOperation {
 	n := func() interface{} {
 		return &Trace{
-			resolver: f.Resolver,
+			helpers: f.Helpers,
 		}
 	}
 
@@ -101,12 +101,12 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 			log.Warnf("Gadget %s: error marshalling event: %s", trace.Spec.Gadget, err)
 			return
 		}
-		t.resolver.PublishEvent(traceName, string(r))
+		t.helpers.PublishEvent(traceName, string(r))
 	}
 
 	var err error
 
-	mountNsMap, err := t.resolver.TracerMountNsMap(traceName)
+	mountNsMap, err := t.helpers.TracerMountNsMap(traceName)
 	if err != nil {
 		trace.Status.OperationError = fmt.Sprintf("failed to find tracer's mount ns map: %s", err)
 		return
@@ -114,7 +114,7 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 	config := &tracer.Config{
 		MountnsMap: mountNsMap,
 	}
-	t.tracer, err = tracer.NewTracer(config, t.resolver, eventCallback, trace.Spec.Node)
+	t.tracer, err = tracer.NewTracer(config, t.helpers, eventCallback, trace.Spec.Node)
 	if err != nil {
 		trace.Status.OperationWarning = fmt.Sprint("failed to create core tracer. Falling back to standard one")
 

--- a/pkg/gadget-collection/gadgets/trace/open/gadget.go
+++ b/pkg/gadget-collection/gadgets/trace/open/gadget.go
@@ -122,7 +122,7 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 		log.Infof("Gadget %s: falling back to standard tracer. CO-RE tracer failed: %s",
 			trace.Spec.Gadget, err)
 
-		t.tracer, err = standardtracer.NewTracer(config, t.resolver, eventCallback, trace.Spec.Node)
+		t.tracer, err = standardtracer.NewTracer(config, eventCallback, trace.Spec.Node)
 		if err != nil {
 			trace.Status.OperationError = fmt.Sprintf("failed to create tracer: %s", err)
 			return

--- a/pkg/gadget-collection/gadgets/trace/signal/gadget.go
+++ b/pkg/gadget-collection/gadgets/trace/signal/gadget.go
@@ -31,7 +31,7 @@ import (
 )
 
 type Trace struct {
-	resolver gadgets.Resolver
+	helpers gadgets.GadgetHelpers
 
 	started bool
 	tracer  trace.Tracer
@@ -73,7 +73,7 @@ func deleteTrace(name string, t interface{}) {
 func (f *TraceFactory) Operations() map[string]gadgets.TraceOperation {
 	n := func() interface{} {
 		return &Trace{
-			resolver: f.Resolver,
+			helpers: f.Helpers,
 		}
 	}
 
@@ -107,7 +107,7 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 			log.Warnf("Gadget %s: error marshalling event: %s", trace.Spec.Gadget, err)
 			return
 		}
-		t.resolver.PublishEvent(traceName, string(r))
+		t.helpers.PublishEvent(traceName, string(r))
 	}
 
 	params := trace.Spec.Parameters
@@ -141,7 +141,7 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 
 	var err error
 
-	mountNsMap, err := t.resolver.TracerMountNsMap(traceName)
+	mountNsMap, err := t.helpers.TracerMountNsMap(traceName)
 	if err != nil {
 		trace.Status.OperationError = fmt.Sprintf("failed to find tracer's mount ns map: %s", err)
 		return
@@ -152,7 +152,7 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 		TargetSignal: targetSignal,
 		FailedOnly:   failedOnly,
 	}
-	t.tracer, err = tracer.NewTracer(config, t.resolver, eventCallback, trace.Spec.Node)
+	t.tracer, err = tracer.NewTracer(config, t.helpers, eventCallback, trace.Spec.Node)
 	if err != nil {
 		trace.Status.OperationError = fmt.Sprintf("failed to create tracer: %s", err)
 		return

--- a/pkg/gadget-collection/gadgets/trace/sni/gadget.go
+++ b/pkg/gadget-collection/gadgets/trace/sni/gadget.go
@@ -133,8 +133,10 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 	printMessage := func(key string, t eventtypes.EventType, message string) string {
 		event := &types.Event{
 			Event: eventtypes.Event{
-				Type:    t,
-				Node:    trace.Spec.Node,
+				Type: t,
+				CommonData: eventtypes.CommonData{
+					Node: trace.Spec.Node,
+				},
 				Message: message,
 			},
 		}
@@ -151,7 +153,9 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 		event := &types.Event{
 			Event: eventtypes.Event{
 				Type: eventtypes.NORMAL,
-				Node: trace.Spec.Node,
+				CommonData: eventtypes.CommonData{
+					Node: trace.Spec.Node,
+				},
 			},
 			Name: name,
 		}

--- a/pkg/gadget-collection/gadgets/trace/sni/gadget.go
+++ b/pkg/gadget-collection/gadgets/trace/sni/gadget.go
@@ -33,8 +33,8 @@ import (
 )
 
 type Trace struct {
-	resolver gadgets.Resolver
-	client   client.Client
+	helpers gadgets.GadgetHelpers
+	client  client.Client
 
 	started bool
 
@@ -70,7 +70,7 @@ func (f *TraceFactory) OutputModesSupported() map[string]struct{} {
 func deleteTrace(name string, t interface{}) {
 	trace := t.(*Trace)
 	if trace.started {
-		trace.resolver.Unsubscribe(genPubSubKey(name))
+		trace.helpers.Unsubscribe(genPubSubKey(name))
 		trace.tracer.Close()
 		trace.tracer = nil
 	}
@@ -80,7 +80,7 @@ func (f *TraceFactory) Operations() map[string]gadgets.TraceOperation {
 	n := func() interface{} {
 		return &Trace{
 			client:    f.Client,
-			resolver:  f.Resolver,
+			helpers:   f.Helpers,
 			netnsHost: f.netnsHost,
 		}
 	}
@@ -172,7 +172,7 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 
 	newSNIRequestCallback := func(key string) func(event types.Event) {
 		return func(event types.Event) {
-			t.resolver.PublishEvent(
+			t.helpers.PublishEvent(
 				traceName,
 				printEvent(key, event.Name),
 			)
@@ -191,13 +191,13 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 
 		err = t.tracer.Attach(key, container.Pid, newSNIRequestCallback(key), trace.Spec.Node)
 		if err != nil {
-			t.resolver.PublishEvent(
+			t.helpers.PublishEvent(
 				traceName,
 				printMessage(key, eventtypes.ERR, fmt.Sprintf("failed to attach tracer: %s", err)),
 			)
 			return err
 		}
-		t.resolver.PublishEvent(
+		t.helpers.PublishEvent(
 			traceName,
 			printMessage(key, eventtypes.DEBUG, "tracer attached"),
 		)
@@ -209,13 +209,13 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 
 		err := t.tracer.Detach(key)
 		if err != nil {
-			t.resolver.PublishEvent(
+			t.helpers.PublishEvent(
 				traceName,
 				printMessage(key, eventtypes.ERR, fmt.Sprintf("failed to detach tracer: %s", err)),
 			)
 			return
 		}
-		t.resolver.PublishEvent(
+		t.helpers.PublishEvent(
 			traceName,
 			printMessage(key, eventtypes.DEBUG, "tracer detached"),
 		)
@@ -230,7 +230,7 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 		}
 	}
 
-	existingContainers := t.resolver.Subscribe(
+	existingContainers := t.helpers.Subscribe(
 		genPubSubKey(trace.ObjectMeta.Namespace+"/"+trace.ObjectMeta.Name),
 		*gadgets.ContainerSelectorFromContainerFilter(trace.Spec.Filter),
 		containerEventCallback,
@@ -254,7 +254,7 @@ func (t *Trace) Stop(trace *gadgetv1alpha1.Trace) {
 		return
 	}
 
-	t.resolver.Unsubscribe(genPubSubKey(trace.ObjectMeta.Namespace + "/" + trace.ObjectMeta.Name))
+	t.helpers.Unsubscribe(genPubSubKey(trace.ObjectMeta.Namespace + "/" + trace.ObjectMeta.Name))
 	t.tracer.Close()
 	t.tracer = nil
 	t.started = false

--- a/pkg/gadget-collection/gadgets/trace/tcp/gadget.go
+++ b/pkg/gadget-collection/gadgets/trace/tcp/gadget.go
@@ -31,7 +31,7 @@ import (
 )
 
 type Trace struct {
-	resolver gadgets.Resolver
+	helpers gadgets.GadgetHelpers
 
 	started bool
 	tracer  trace.Tracer
@@ -67,7 +67,7 @@ func deleteTrace(name string, t interface{}) {
 func (f *TraceFactory) Operations() map[string]gadgets.TraceOperation {
 	n := func() interface{} {
 		return &Trace{
-			resolver: f.Resolver,
+			helpers: f.Helpers,
 		}
 	}
 
@@ -101,12 +101,12 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 			log.Warnf("Gadget %s: error marshalling event: %s", trace.Spec.Gadget, err)
 			return
 		}
-		t.resolver.PublishEvent(traceName, string(r))
+		t.helpers.PublishEvent(traceName, string(r))
 	}
 
 	var err error
 
-	mountNsMap, err := t.resolver.TracerMountNsMap(traceName)
+	mountNsMap, err := t.helpers.TracerMountNsMap(traceName)
 	if err != nil {
 		trace.Status.OperationError = fmt.Sprintf("failed to find tracer's mount ns map: %s", err)
 		return
@@ -115,7 +115,7 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 		MountnsMap: mountNsMap,
 	}
 
-	t.tracer, err = tracer.NewTracer(config, t.resolver, eventCallback, trace.Spec.Node)
+	t.tracer, err = tracer.NewTracer(config, t.helpers, eventCallback, trace.Spec.Node)
 	if err != nil {
 		trace.Status.OperationWarning = fmt.Sprint("failed to create core tracer. Falling back to standard one")
 

--- a/pkg/gadget-collection/gadgets/trace/tcp/gadget.go
+++ b/pkg/gadget-collection/gadgets/trace/tcp/gadget.go
@@ -123,7 +123,7 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 		log.Infof("Gadget %s: falling back to standard tracer. CO-RE tracer failed: %s",
 			trace.Spec.Gadget, err)
 
-		t.tracer, err = standardtracer.NewTracer(config, t.resolver, eventCallback, trace.Spec.Node)
+		t.tracer, err = standardtracer.NewTracer(config, eventCallback, trace.Spec.Node)
 		if err != nil {
 			trace.Status.OperationError = fmt.Sprintf("failed to create tracer: %s", err)
 			return

--- a/pkg/gadget-collection/gadgets/trace/tcpconnect/gadget.go
+++ b/pkg/gadget-collection/gadgets/trace/tcpconnect/gadget.go
@@ -31,7 +31,7 @@ import (
 )
 
 type Trace struct {
-	resolver gadgets.Resolver
+	helpers gadgets.GadgetHelpers
 
 	started bool
 	tracer  trace.Tracer
@@ -67,7 +67,7 @@ func deleteTrace(name string, t interface{}) {
 func (f *TraceFactory) Operations() map[string]gadgets.TraceOperation {
 	n := func() interface{} {
 		return &Trace{
-			resolver: f.Resolver,
+			helpers: f.Helpers,
 		}
 	}
 
@@ -101,12 +101,12 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 			log.Warnf("Gadget %s: error marshalling event: %s", trace.Spec.Gadget, err)
 			return
 		}
-		t.resolver.PublishEvent(traceName, string(r))
+		t.helpers.PublishEvent(traceName, string(r))
 	}
 
 	var err error
 
-	mountNsMap, err := t.resolver.TracerMountNsMap(traceName)
+	mountNsMap, err := t.helpers.TracerMountNsMap(traceName)
 	if err != nil {
 		trace.Status.OperationError = fmt.Sprintf("failed to find tracer's mount ns map: %s", err)
 		return
@@ -114,7 +114,7 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 	config := &tracer.Config{
 		MountnsMap: mountNsMap,
 	}
-	t.tracer, err = tracer.NewTracer(config, t.resolver, eventCallback, trace.Spec.Node)
+	t.tracer, err = tracer.NewTracer(config, t.helpers, eventCallback, trace.Spec.Node)
 	if err != nil {
 		trace.Status.OperationWarning = fmt.Sprint("failed to create core tracer. Falling back to standard one")
 

--- a/pkg/gadget-collection/gadgets/trace/tcpconnect/gadget.go
+++ b/pkg/gadget-collection/gadgets/trace/tcpconnect/gadget.go
@@ -122,7 +122,7 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 		log.Infof("Gadget %s: falling back to standard tracer. CO-RE tracer failed: %s",
 			trace.Spec.Gadget, err)
 
-		t.tracer, err = standardtracer.NewTracer(config, t.resolver, eventCallback, trace.Spec.Node)
+		t.tracer, err = standardtracer.NewTracer(config, eventCallback, trace.Spec.Node)
 		if err != nil {
 			trace.Status.OperationError = fmt.Sprintf("failed to create tracer: %s", err)
 			return

--- a/pkg/gadgets/audit/seccomp/tracer/tracer.go
+++ b/pkg/gadgets/audit/seccomp/tracer/tracer.go
@@ -143,20 +143,21 @@ func (t *Tracer) run() {
 		event := types.Event{
 			Event: eventtypes.Event{
 				Type: eventtypes.NORMAL,
-				Node: t.node,
-
-				// Get 'Namespace', 'Pod' and 'Container' from
-				// BPF and not from the resolver because the
-				// container might be terminated immediately
-				// after the BPF kprobe on audit_seccomp() is
-				// executed (e.g. with SCMP_ACT_KILL), so by
-				// the time the event is read from the perf
-				// ring buffer, we might not be able to get the
-				// Kubernetes metadata from the mount namespace
-				// id.
-				Namespace: C.GoString(&eventC.container.namespace[0]),
-				Pod:       C.GoString(&eventC.container.pod[0]),
-				Container: C.GoString(&eventC.container.container[0]),
+				CommonData: eventtypes.CommonData{
+					Node: t.node,
+					// Get 'Namespace', 'Pod' and 'Container' from
+					// BPF and not from the gadget helpers  because the
+					// container might be terminated immediately
+					// after the BPF kprobe on audit_seccomp() is
+					// executed (e.g. with SCMP_ACT_KILL), so by
+					// the time the event is read from the perf
+					// ring buffer, we might not be able to get the
+					// Kubernetes metadata from the mount namespace
+					// id.
+					Namespace: C.GoString(&eventC.container.namespace[0]),
+					Pod:       C.GoString(&eventC.container.pod[0]),
+					Container: C.GoString(&eventC.container.container[0]),
+				},
 			},
 			Pid:       uint32(eventC.pid),
 			MountNsID: uint64(eventC.mntns_id),

--- a/pkg/gadgets/helpers.go
+++ b/pkg/gadgets/helpers.go
@@ -16,6 +16,7 @@ package gadgets
 
 import (
 	"github.com/cilium/ebpf/link"
+	"github.com/kinvolk/inspektor-gadget/pkg/types"
 )
 
 const (
@@ -33,4 +34,10 @@ func CloseLink(l link.Link) link.Link {
 		l.Close()
 	}
 	return nil
+}
+
+// DataEnricher is used to enrich events with Kubernetes information,
+// like node, namespace, pod name and container name.
+type DataEnricher interface {
+	Enrich(event *types.CommonData, mountnsid uint64)
 }

--- a/pkg/gadgets/profile/cpu/types/types.go
+++ b/pkg/gadgets/profile/cpu/types/types.go
@@ -14,16 +14,17 @@
 
 package types
 
+import (
+	eventtypes "github.com/kinvolk/inspektor-gadget/pkg/types"
+)
+
 const (
 	ProfileUserParam   = "user"
 	ProfileKernelParam = "kernel"
 )
 
 type Report struct {
-	Node      string `json:"node,omitempty"`
-	Namespace string `json:"namespace,omitempty"`
-	Pod       string `json:"pod,omitempty"`
-	Container string `json:"container,omitempty"`
+	eventtypes.CommonData
 
 	Comm        string   `json:"comm,omitempty"`
 	Pid         uint32   `json:"pid,omitempty"`

--- a/pkg/gadgets/snapshot/socket/tracer/tracer.go
+++ b/pkg/gadgets/snapshot/socket/tracer/tracer.go
@@ -157,10 +157,12 @@ func RunCollector(pid uint32, podname, namespace, node string, proto socketcolle
 
 				sockets = append(sockets, socketcollectortypes.Event{
 					Event: eventtypes.Event{
-						Type:      eventtypes.NORMAL,
-						Node:      node,
-						Namespace: namespace,
-						Pod:       podname,
+						Type: eventtypes.NORMAL,
+						CommonData: eventtypes.CommonData{
+							Node:      node,
+							Namespace: namespace,
+							Pod:       podname,
+						},
 					},
 					Protocol:      proto,
 					LocalAddress:  parseIPv4(src),

--- a/pkg/gadgets/top/block-io/tracer/tracer.go
+++ b/pkg/gadgets/top/block-io/tracer/tracer.go
@@ -26,7 +26,6 @@ import (
 	"time"
 	"unsafe"
 
-	containercollection "github.com/kinvolk/inspektor-gadget/pkg/container-collection"
 	"github.com/kinvolk/inspektor-gadget/pkg/gadgets"
 	"github.com/kinvolk/inspektor-gadget/pkg/gadgets/top/block-io/types"
 
@@ -55,18 +54,18 @@ type Tracer struct {
 	ioStartLink      link.Link
 	startRequestLink link.Link
 	doneLink         link.Link
-	resolver         containercollection.ContainerResolver
+	enricher         gadgets.DataEnricher
 	statsCallback    func([]types.Stats)
 	errorCallback    func(error)
 	done             chan bool
 }
 
-func NewTracer(config *Config, resolver containercollection.ContainerResolver,
+func NewTracer(config *Config, enricher gadgets.DataEnricher,
 	statsCallback func([]types.Stats), errorCallback func(error),
 ) (*Tracer, error) {
 	t := &Tracer{
 		config:        config,
-		resolver:      resolver,
+		enricher:      enricher,
 		statsCallback: statsCallback,
 		errorCallback: errorCallback,
 		done:          make(chan bool),
@@ -252,12 +251,8 @@ func (t *Tracer) nextStats() ([]types.Stats, error) {
 			Operations: uint32(val.io),
 		}
 
-		container := t.resolver.LookupContainerByMntns(stat.MountNsID)
-		if container != nil {
-			stat.Container = container.Name
-			stat.Pod = container.Podname
-			stat.Namespace = container.Namespace
-			stat.Node = t.config.Node
+		if t.enricher != nil {
+			t.enricher.Enrich(&stat.CommonData, stat.MountNsID)
 		}
 
 		stats = append(stats, stat)

--- a/pkg/gadgets/top/block-io/types/types.go
+++ b/pkg/gadgets/top/block-io/types/types.go
@@ -18,6 +18,8 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+
+	eventtypes "github.com/kinvolk/inspektor-gadget/pkg/types"
 )
 
 type SortBy int
@@ -78,10 +80,7 @@ type Event struct {
 
 // Stats represents the operations performed on a single file
 type Stats struct {
-	Node      string `json:"node,omitempty"`
-	Namespace string `json:"namespace,omitempty"`
-	Pod       string `json:"pod,omitempty"`
-	Container string `json:"container,omitempty"`
+	eventtypes.CommonData
 
 	Write      bool   `json:"write,omitempty"`
 	Major      int    `json:"major,omitempty"`

--- a/pkg/gadgets/top/file/types/types.go
+++ b/pkg/gadgets/top/file/types/types.go
@@ -17,6 +17,8 @@ package types
 import (
 	"fmt"
 	"sort"
+
+	eventtypes "github.com/kinvolk/inspektor-gadget/pkg/types"
 )
 
 type SortBy int
@@ -81,10 +83,7 @@ type Event struct {
 
 // Stats represents the operations performed on a single file
 type Stats struct {
-	Node      string `json:"node,omitempty"`
-	Namespace string `json:"namespace,omitempty"`
-	Pod       string `json:"pod,omitempty"`
-	Container string `json:"container,omitempty"`
+	eventtypes.CommonData
 
 	Reads      uint64 `json:"reads,omitempty"`
 	Writes     uint64 `json:"writes,omitempty"`

--- a/pkg/gadgets/top/tcp/tracer/tracer.go
+++ b/pkg/gadgets/top/tcp/tracer/tracer.go
@@ -23,7 +23,6 @@ import (
 	"time"
 	"unsafe"
 
-	containercollection "github.com/kinvolk/inspektor-gadget/pkg/container-collection"
 	"github.com/kinvolk/inspektor-gadget/pkg/gadgets"
 	"github.com/kinvolk/inspektor-gadget/pkg/gadgets/top/tcp/types"
 
@@ -80,18 +79,18 @@ type Tracer struct {
 	objs               tcptopObjects
 	tcpSendmsgLink     link.Link
 	tcpCleanupRbufLink link.Link
-	resolver           containercollection.ContainerResolver
+	enricher           gadgets.DataEnricher
 	statsCallback      func([]types.Stats)
 	errorCallback      func(error)
 	done               chan bool
 }
 
-func NewTracer(config *Config, resolver containercollection.ContainerResolver,
+func NewTracer(config *Config, enricher gadgets.DataEnricher,
 	statsCallback func([]types.Stats), errorCallback func(error),
 ) (*Tracer, error) {
 	t := &Tracer{
 		config:        config,
-		resolver:      resolver,
+		enricher:      enricher,
 		statsCallback: statsCallback,
 		errorCallback: errorCallback,
 		done:          make(chan bool),
@@ -221,12 +220,8 @@ func (t *Tracer) nextStats() ([]types.Stats, error) {
 		C.free(unsafe.Pointer(srcAddr))
 		C.free(unsafe.Pointer(dstAddr))
 
-		container := t.resolver.LookupContainerByMntns(stat.MountNsID)
-		if container != nil {
-			stat.Container = container.Name
-			stat.Pod = container.Podname
-			stat.Namespace = container.Namespace
-			stat.Node = t.config.Node
+		if t.enricher != nil {
+			t.enricher.Enrich(&stat.CommonData, stat.MountNsID)
 		}
 
 		stats = append(stats, stat)

--- a/pkg/gadgets/top/tcp/types/types.go
+++ b/pkg/gadgets/top/tcp/types/types.go
@@ -18,6 +18,8 @@ import (
 	"fmt"
 	"sort"
 	"syscall"
+
+	eventtypes "github.com/kinvolk/inspektor-gadget/pkg/types"
 )
 
 type SortBy int
@@ -91,10 +93,7 @@ type Event struct {
 
 // Stats represents the operations performed on a single file
 type Stats struct {
-	Node      string `json:"node,omitempty"`
-	Namespace string `json:"namespace,omitempty"`
-	Pod       string `json:"pod,omitempty"`
-	Container string `json:"container,omitempty"`
+	eventtypes.CommonData
 
 	Saddr     string `json:"saddr,omitempty"`
 	Daddr     string `json:"daddr,omitempty"`

--- a/pkg/gadgets/trace/dns/tracer/tracer.go
+++ b/pkg/gadgets/trace/dns/tracer/tracer.go
@@ -314,7 +314,9 @@ func (t *Tracer) listen(
 			event := types.Event{
 				Event: eventtypes.Event{
 					Type: eventtypes.NORMAL,
-					Node: node,
+					CommonData: eventtypes.CommonData{
+						Node: node,
+					},
 				},
 				DNSName: name,
 				PktType: pktType,

--- a/pkg/gadgets/trace/exec/tracer/tracer.go
+++ b/pkg/gadgets/trace/exec/tracer/tracer.go
@@ -30,7 +30,6 @@ import (
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/link"
 	"github.com/cilium/ebpf/perf"
-	containercollection "github.com/kinvolk/inspektor-gadget/pkg/container-collection"
 	"github.com/kinvolk/inspektor-gadget/pkg/gadgets"
 	"github.com/kinvolk/inspektor-gadget/pkg/gadgets/trace/exec/types"
 	eventtypes "github.com/kinvolk/inspektor-gadget/pkg/types"
@@ -44,7 +43,7 @@ type Config struct {
 
 type Tracer struct {
 	config        *Config
-	resolver      containercollection.ContainerResolver
+	enricher      gadgets.DataEnricher
 	eventCallback func(types.Event)
 	node          string
 
@@ -54,12 +53,12 @@ type Tracer struct {
 	reader    *perf.Reader
 }
 
-func NewTracer(config *Config, resolver containercollection.ContainerResolver,
+func NewTracer(config *Config, enricher gadgets.DataEnricher,
 	eventCallback func(types.Event), node string,
 ) (*Tracer, error) {
 	t := &Tracer{
 		config:        config,
-		resolver:      resolver,
+		enricher:      enricher,
 		eventCallback: eventCallback,
 		node:          node,
 	}
@@ -155,7 +154,6 @@ func (t *Tracer) run() {
 		event := types.Event{
 			Event: eventtypes.Event{
 				Type: eventtypes.NORMAL,
-				Node: t.node,
 			},
 			Pid:       uint32(eventC.pid),
 			Ppid:      uint32(eventC.ppid),
@@ -179,11 +177,8 @@ func (t *Tracer) run() {
 			}
 		}
 
-		container := t.resolver.LookupContainerByMntns(event.MountNsID)
-		if container != nil {
-			event.Container = container.Name
-			event.Pod = container.Podname
-			event.Namespace = container.Namespace
+		if t.enricher != nil {
+			t.enricher.Enrich(&event.CommonData, event.MountNsID)
 		}
 
 		t.eventCallback(event)

--- a/pkg/gadgets/trace/mount/tracer/tracer.go
+++ b/pkg/gadgets/trace/mount/tracer/tracer.go
@@ -30,7 +30,6 @@ import (
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/link"
 	"github.com/cilium/ebpf/perf"
-	containercollection "github.com/kinvolk/inspektor-gadget/pkg/container-collection"
 	"github.com/kinvolk/inspektor-gadget/pkg/gadgets"
 	"github.com/kinvolk/inspektor-gadget/pkg/gadgets/trace/mount/types"
 	eventtypes "github.com/kinvolk/inspektor-gadget/pkg/types"
@@ -44,7 +43,7 @@ type Config struct {
 
 type Tracer struct {
 	config        *Config
-	resolver      containercollection.ContainerResolver
+	enricher      gadgets.DataEnricher
 	eventCallback func(types.Event)
 	node          string
 
@@ -56,12 +55,12 @@ type Tracer struct {
 	reader          *perf.Reader
 }
 
-func NewTracer(config *Config, resolver containercollection.ContainerResolver,
+func NewTracer(config *Config, enricher gadgets.DataEnricher,
 	eventCallback func(types.Event), node string,
 ) (*Tracer, error) {
 	t := &Tracer{config: config}
 
-	t.resolver = resolver
+	t.enricher = enricher
 	t.eventCallback = eventCallback
 	t.node = node
 
@@ -173,7 +172,6 @@ func (t *Tracer) run() {
 		event := types.Event{
 			Event: eventtypes.Event{
 				Type: eventtypes.NORMAL,
-				Node: t.node,
 			},
 			MountNsID: uint64(eventC.mount_ns_id),
 			Pid:       uint32(eventC.pid),
@@ -198,11 +196,8 @@ func (t *Tracer) run() {
 
 		event.Flags = DecodeFlags(uint64(eventC.flags))
 
-		container := t.resolver.LookupContainerByMntns(event.MountNsID)
-		if container != nil {
-			event.Container = container.Name
-			event.Pod = container.Podname
-			event.Namespace = container.Namespace
+		if t.enricher != nil {
+			t.enricher.Enrich(&event.CommonData, event.MountNsID)
 		}
 
 		t.eventCallback(event)

--- a/pkg/gadgets/trace/sni/tracer/tracer.go
+++ b/pkg/gadgets/trace/sni/tracer/tracer.go
@@ -180,7 +180,9 @@ func (t *Tracer) listen(
 			event := types.Event{
 				Event: eventtypes.Event{
 					Type: eventtypes.NORMAL,
-					Node: node,
+					CommonData: eventtypes.CommonData{
+						Node: node,
+					},
 				},
 				Name: name,
 			}

--- a/pkg/gadgets/trace/tcp/tracer/tracer.go
+++ b/pkg/gadgets/trace/tcp/tracer/tracer.go
@@ -63,7 +63,6 @@ import (
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/link"
 	"github.com/cilium/ebpf/perf"
-	containercollection "github.com/kinvolk/inspektor-gadget/pkg/container-collection"
 	"github.com/kinvolk/inspektor-gadget/pkg/gadgets"
 	"github.com/kinvolk/inspektor-gadget/pkg/gadgets/trace/tcp/types"
 	eventtypes "github.com/kinvolk/inspektor-gadget/pkg/types"
@@ -77,7 +76,7 @@ type Config struct {
 
 type Tracer struct {
 	config        *Config
-	resolver      containercollection.ContainerResolver
+	enricher      gadgets.DataEnricher
 	eventCallback func(types.Event)
 	node          string
 
@@ -94,11 +93,11 @@ type Tracer struct {
 	reader *perf.Reader
 }
 
-func NewTracer(config *Config, resolver containercollection.ContainerResolver,
+func NewTracer(config *Config, enricher gadgets.DataEnricher,
 	eventCallback func(types.Event), node string) (*Tracer, error) {
 	t := &Tracer{
 		config:        config,
-		resolver:      resolver,
+		enricher:      enricher,
 		eventCallback: eventCallback,
 		node:          node,
 	}
@@ -230,7 +229,6 @@ func (t *Tracer) run() {
 		event := types.Event{
 			Event: eventtypes.Event{
 				Type: eventtypes.NORMAL,
-				Node: t.node,
 			},
 			MountNsID: uint64(eventC.mntns_id),
 			Pid:       uint32(eventC.pid),
@@ -261,11 +259,8 @@ func (t *Tracer) run() {
 		event.Daddr = C.GoString(dstAddr)
 		C.free(unsafe.Pointer(dstAddr))
 
-		container := t.resolver.LookupContainerByMntns(event.MountNsID)
-		if container != nil {
-			event.Container = container.Name
-			event.Pod = container.Podname
-			event.Namespace = container.Namespace
+		if t.enricher != nil {
+			t.enricher.Enrich(&event.CommonData, event.MountNsID)
 		}
 
 		t.eventCallback(event)

--- a/pkg/local-gadget-manager/local-gadget-manager.go
+++ b/pkg/local-gadget-manager/local-gadget-manager.go
@@ -27,6 +27,7 @@ import (
 	"github.com/kinvolk/inspektor-gadget/pkg/gadget-collection/gadgets"
 	containersmap "github.com/kinvolk/inspektor-gadget/pkg/gadgettracermanager/containers-map"
 	tracercollection "github.com/kinvolk/inspektor-gadget/pkg/tracer-collection"
+	eventtypes "github.com/kinvolk/inspektor-gadget/pkg/types"
 
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/rlimit"
@@ -375,4 +376,13 @@ func NewManager(runtimes []*containerutils.RuntimeConfig) (*LocalGadgetManager, 
 func (l *LocalGadgetManager) Close() {
 	l.ContainerCollectionClose()
 	l.containersMap.Close()
+}
+
+func (l *LocalGadgetManager) Enrich(event *eventtypes.CommonData, mountnsid uint64) {
+	container := l.LookupContainerByMntns(mountnsid)
+	if container != nil {
+		event.Container = container.Name
+		event.Pod = container.Podname
+		event.Namespace = container.Namespace
+	}
 }

--- a/pkg/local-gadget-manager/local-gadget-manager_test.go
+++ b/pkg/local-gadget-manager/local-gadget-manager_test.go
@@ -276,7 +276,7 @@ func TestAuditSeccomp(t *testing.T) {
 		t.Fatalf("Failed to get stream: %s", err)
 	}
 	results := <-ch
-	if !strings.Contains(results, `"container":"test-local-gadget-auditseccomp001","syscall":"unshare","code":"log"`) {
+	if !strings.Contains(results, `"container":"test-local-gadget-auditseccomp001","type":"normal","syscall":"unshare","code":"log"`) {
 		t.Fatalf("Failed to get correct Seccomp Audit: %s", results)
 	}
 
@@ -340,11 +340,13 @@ func TestDNS(t *testing.T) {
 
 	expectedEvent = dnstypes.Event{
 		Event: eventtypes.Event{
-			Type:      eventtypes.DEBUG,
-			Message:   "tracer attached",
-			Node:      "local",
-			Namespace: "default",
-			Pod:       "test-local-gadget-dns001",
+			Type: eventtypes.DEBUG,
+			CommonData: eventtypes.CommonData{
+				Node:      "local",
+				Namespace: "default",
+				Pod:       "test-local-gadget-dns001",
+			},
+			Message: "tracer attached",
 		},
 	}
 
@@ -361,10 +363,12 @@ func TestDNS(t *testing.T) {
 
 	expectedEvent = dnstypes.Event{
 		Event: eventtypes.Event{
-			Type:      eventtypes.NORMAL,
-			Node:      "local",
-			Namespace: "default",
-			Pod:       "test-local-gadget-dns001",
+			Type: eventtypes.NORMAL,
+			CommonData: eventtypes.CommonData{
+				Node:      "local",
+				Namespace: "default",
+				Pod:       "test-local-gadget-dns001",
+			},
 		},
 		DNSName: "microsoft.com.",
 		PktType: "OUTGOING",
@@ -384,11 +388,13 @@ func TestDNS(t *testing.T) {
 
 	expectedEvent = dnstypes.Event{
 		Event: eventtypes.Event{
-			Type:      eventtypes.DEBUG,
-			Message:   "tracer detached",
-			Node:      "local",
-			Namespace: "default",
-			Pod:       "test-local-gadget-dns001",
+			Type: eventtypes.DEBUG,
+			CommonData: eventtypes.CommonData{
+				Node:      "local",
+				Namespace: "default",
+				Pod:       "test-local-gadget-dns001",
+			},
+			Message: "tracer detached",
 		},
 	}
 
@@ -456,11 +462,13 @@ func TestNetworkGraph(t *testing.T) {
 
 	expectedEvent = networktypes.Event{
 		Event: eventtypes.Event{
-			Type:      eventtypes.DEBUG,
-			Message:   "tracer attached",
-			Node:      "local",
-			Namespace: "default",
-			Pod:       "test-local-gadget-network-graph001",
+			Type: eventtypes.DEBUG,
+			CommonData: eventtypes.CommonData{
+				Node:      "local",
+				Namespace: "default",
+				Pod:       "test-local-gadget-network-graph001",
+			},
+			Message: "tracer attached",
 		},
 	}
 
@@ -477,10 +485,12 @@ func TestNetworkGraph(t *testing.T) {
 
 	expectedEvent = networktypes.Event{
 		Event: eventtypes.Event{
-			Type:      eventtypes.NORMAL,
-			Node:      "local",
-			Namespace: "default",
-			Pod:       "test-local-gadget-network-graph001",
+			Type: eventtypes.NORMAL,
+			CommonData: eventtypes.CommonData{
+				Node:      "local",
+				Namespace: "default",
+				Pod:       "test-local-gadget-network-graph001",
+			},
 		},
 		PktType: "OUTGOING",
 		Proto:   "tcp",
@@ -501,11 +511,13 @@ func TestNetworkGraph(t *testing.T) {
 
 	expectedEvent = networktypes.Event{
 		Event: eventtypes.Event{
-			Type:      eventtypes.DEBUG,
-			Message:   "tracer detached",
-			Node:      "local",
-			Namespace: "default",
-			Pod:       "test-local-gadget-network-graph001",
+			Type: eventtypes.DEBUG,
+			CommonData: eventtypes.CommonData{
+				Node:      "local",
+				Namespace: "default",
+				Pod:       "test-local-gadget-network-graph001",
+			},
+			Message: "tracer detached",
 		},
 	}
 

--- a/pkg/standardgadgets/trace/bind/tracer.go
+++ b/pkg/standardgadgets/trace/bind/tracer.go
@@ -18,7 +18,6 @@ import (
 	"encoding/json"
 	"fmt"
 
-	containercollection "github.com/kinvolk/inspektor-gadget/pkg/container-collection"
 	"github.com/kinvolk/inspektor-gadget/pkg/gadgets/trace/bind/tracer"
 	"github.com/kinvolk/inspektor-gadget/pkg/gadgets/trace/bind/types"
 	"github.com/kinvolk/inspektor-gadget/pkg/standardgadgets/trace"
@@ -28,12 +27,11 @@ import (
 type Tracer struct {
 	trace.StandardTracerBase
 
-	resolver      containercollection.ContainerResolver
 	eventCallback func(types.Event)
 	node          string
 }
 
-func NewTracer(config *tracer.Config, resolver containercollection.ContainerResolver, eventCallback func(types.Event), node string) (*Tracer, error) {
+func NewTracer(config *tracer.Config, eventCallback func(types.Event), node string) (*Tracer, error) {
 	lineCallback := func(line string) {
 		event := types.Event{}
 		event.Type = eventtypes.NORMAL
@@ -57,7 +55,6 @@ func NewTracer(config *tracer.Config, resolver containercollection.ContainerReso
 	return &Tracer{
 		StandardTracerBase: *baseTracer,
 		eventCallback:      eventCallback,
-		resolver:           resolver, // not used right now but could be useful in the future
 		node:               node,
 	}, nil
 }

--- a/pkg/standardgadgets/trace/capabilities/tracer.go
+++ b/pkg/standardgadgets/trace/capabilities/tracer.go
@@ -18,7 +18,6 @@ import (
 	"encoding/json"
 	"fmt"
 
-	containercollection "github.com/kinvolk/inspektor-gadget/pkg/container-collection"
 	"github.com/kinvolk/inspektor-gadget/pkg/gadgets/trace/capabilities/tracer"
 	"github.com/kinvolk/inspektor-gadget/pkg/gadgets/trace/capabilities/types"
 	"github.com/kinvolk/inspektor-gadget/pkg/standardgadgets/trace"
@@ -28,12 +27,11 @@ import (
 type Tracer struct {
 	trace.StandardTracerBase
 
-	resolver      containercollection.ContainerResolver
 	eventCallback func(types.Event)
 	node          string
 }
 
-func NewTracer(config *tracer.Config, resolver containercollection.ContainerResolver,
+func NewTracer(config *tracer.Config,
 	eventCallback func(types.Event), node string) (*Tracer, error,
 ) {
 	lineCallback := func(line string) {
@@ -59,7 +57,6 @@ func NewTracer(config *tracer.Config, resolver containercollection.ContainerReso
 	return &Tracer{
 		StandardTracerBase: *baseTracer,
 		eventCallback:      eventCallback,
-		resolver:           resolver, // not used right now but could be useful in the future
 		node:               node,
 	}, nil
 }

--- a/pkg/standardgadgets/trace/exec/tracer.go
+++ b/pkg/standardgadgets/trace/exec/tracer.go
@@ -18,7 +18,6 @@ import (
 	"encoding/json"
 	"fmt"
 
-	containercollection "github.com/kinvolk/inspektor-gadget/pkg/container-collection"
 	"github.com/kinvolk/inspektor-gadget/pkg/gadgets/trace/exec/tracer"
 	"github.com/kinvolk/inspektor-gadget/pkg/gadgets/trace/exec/types"
 	eventtypes "github.com/kinvolk/inspektor-gadget/pkg/types"
@@ -29,12 +28,11 @@ import (
 type Tracer struct {
 	trace.StandardTracerBase
 
-	resolver      containercollection.ContainerResolver
 	eventCallback func(types.Event)
 	node          string
 }
 
-func NewTracer(config *tracer.Config, resolver containercollection.ContainerResolver,
+func NewTracer(config *tracer.Config,
 	eventCallback func(types.Event), node string) (*Tracer, error,
 ) {
 	lineCallback := func(line string) {
@@ -60,7 +58,6 @@ func NewTracer(config *tracer.Config, resolver containercollection.ContainerReso
 	return &Tracer{
 		StandardTracerBase: *baseTracer,
 		eventCallback:      eventCallback,
-		resolver:           resolver, // not used right now but could be useful in the future
 		node:               node,
 	}, nil
 }

--- a/pkg/standardgadgets/trace/mount/tracer.go
+++ b/pkg/standardgadgets/trace/mount/tracer.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"strings"
 
-	containercollection "github.com/kinvolk/inspektor-gadget/pkg/container-collection"
 	"github.com/kinvolk/inspektor-gadget/pkg/gadgets/trace/mount/tracer"
 	"github.com/kinvolk/inspektor-gadget/pkg/gadgets/trace/mount/types"
 	"github.com/kinvolk/inspektor-gadget/pkg/standardgadgets/trace"
@@ -29,12 +28,11 @@ import (
 type Tracer struct {
 	trace.StandardTracerBase
 
-	resolver      containercollection.ContainerResolver
 	eventCallback func(types.Event)
 	node          string
 }
 
-func NewTracer(config *tracer.Config, resolver containercollection.ContainerResolver,
+func NewTracer(config *tracer.Config,
 	eventCallback func(types.Event), node string) (*Tracer, error,
 ) {
 	lineCallback := func(line string) {
@@ -67,7 +65,6 @@ func NewTracer(config *tracer.Config, resolver containercollection.ContainerReso
 	return &Tracer{
 		StandardTracerBase: *baseTracer,
 		eventCallback:      eventCallback,
-		resolver:           resolver, // not used right now but could be useful in the future
 		node:               node,
 	}, nil
 }

--- a/pkg/standardgadgets/trace/open/tracer.go
+++ b/pkg/standardgadgets/trace/open/tracer.go
@@ -18,7 +18,6 @@ import (
 	"encoding/json"
 	"fmt"
 
-	containercollection "github.com/kinvolk/inspektor-gadget/pkg/container-collection"
 	"github.com/kinvolk/inspektor-gadget/pkg/gadgets/trace/open/tracer"
 	"github.com/kinvolk/inspektor-gadget/pkg/gadgets/trace/open/types"
 	"github.com/kinvolk/inspektor-gadget/pkg/standardgadgets/trace"
@@ -28,12 +27,11 @@ import (
 type Tracer struct {
 	trace.StandardTracerBase
 
-	resolver      containercollection.ContainerResolver
 	eventCallback func(types.Event)
 	node          string
 }
 
-func NewTracer(config *tracer.Config, resolver containercollection.ContainerResolver,
+func NewTracer(config *tracer.Config,
 	eventCallback func(types.Event), node string) (*Tracer, error,
 ) {
 	lineCallback := func(line string) {
@@ -59,7 +57,6 @@ func NewTracer(config *tracer.Config, resolver containercollection.ContainerReso
 	return &Tracer{
 		StandardTracerBase: *baseTracer,
 		eventCallback:      eventCallback,
-		resolver:           resolver, // not used right now but could be useful in the future
 		node:               node,
 	}, nil
 }

--- a/pkg/standardgadgets/trace/tcp/tracer.go
+++ b/pkg/standardgadgets/trace/tcp/tracer.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"strings"
 
-	containercollection "github.com/kinvolk/inspektor-gadget/pkg/container-collection"
 	"github.com/kinvolk/inspektor-gadget/pkg/gadgets/trace/tcp/tracer"
 	"github.com/kinvolk/inspektor-gadget/pkg/gadgets/trace/tcp/types"
 	"github.com/kinvolk/inspektor-gadget/pkg/standardgadgets/trace"
@@ -29,12 +28,11 @@ import (
 type Tracer struct {
 	trace.StandardTracerBase
 
-	resolver      containercollection.ContainerResolver
 	eventCallback func(types.Event)
 	node          string
 }
 
-func NewTracer(config *tracer.Config, resolver containercollection.ContainerResolver,
+func NewTracer(config *tracer.Config,
 	eventCallback func(types.Event), node string) (*Tracer, error,
 ) {
 	lineCallback := func(line string) {
@@ -64,7 +62,6 @@ func NewTracer(config *tracer.Config, resolver containercollection.ContainerReso
 	return &Tracer{
 		StandardTracerBase: *baseTracer,
 		eventCallback:      eventCallback,
-		resolver:           resolver, // not used right now but could be useful in the future
 		node:               node,
 	}, nil
 }

--- a/pkg/standardgadgets/trace/tcpconnect/tracer.go
+++ b/pkg/standardgadgets/trace/tcpconnect/tracer.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"strings"
 
-	containercollection "github.com/kinvolk/inspektor-gadget/pkg/container-collection"
 	"github.com/kinvolk/inspektor-gadget/pkg/gadgets/trace/tcpconnect/tracer"
 	"github.com/kinvolk/inspektor-gadget/pkg/gadgets/trace/tcpconnect/types"
 	"github.com/kinvolk/inspektor-gadget/pkg/standardgadgets/trace"
@@ -29,12 +28,11 @@ import (
 type Tracer struct {
 	trace.StandardTracerBase
 
-	resolver      containercollection.ContainerResolver
 	eventCallback func(types.Event)
 	node          string
 }
 
-func NewTracer(config *tracer.Config, resolver containercollection.ContainerResolver,
+func NewTracer(config *tracer.Config,
 	eventCallback func(types.Event), node string) (*Tracer, error,
 ) {
 	lineCallback := func(line string) {
@@ -63,7 +61,6 @@ func NewTracer(config *tracer.Config, resolver containercollection.ContainerReso
 	return &Tracer{
 		StandardTracerBase: *baseTracer,
 		eventCallback:      eventCallback,
-		resolver:           resolver, // not used right now but could be useful in the future
 		node:               node,
 	}, nil
 }

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -21,6 +21,22 @@ import (
 
 type EventType string
 
+type CommonData struct {
+	// Node where the event comes from
+	Node string `json:"node,omitempty"`
+
+	// Pod namespace where the event comes from, or empty for host-level
+	// event
+	Namespace string `json:"namespace,omitempty"`
+
+	// Pod where the event comes from, or empty for host-level event
+	Pod string `json:"pod,omitempty"`
+
+	// Container where the event comes from, or empty for host-level or
+	// pod-level event
+	Container string `json:"container,omitempty"`
+}
+
 const (
 	// Indicates a generic event produced by a gadget. Gadgets extend
 	// the base event to contain the specific data the gadget provides
@@ -43,55 +59,51 @@ const (
 )
 
 type Event struct {
+	CommonData
+
 	// Type indicates the kind of this event
 	Type EventType `json:"type"`
 
 	// Message when Type is ERR, WARN, DEBUG or INFO
 	Message string `json:"message,omitempty"`
-
-	// Node where the event comes from
-	Node string `json:"node,omitempty"`
-
-	// Pod namespace where the event comes from, or empty for host-level
-	// event
-	Namespace string `json:"namespace,omitempty"`
-
-	// Pod where the event comes from, or empty for host-level event
-	Pod string `json:"pod,omitempty"`
-
-	// Container where the event comes from, or empty for host-level or
-	// pod-level event
-	Container string `json:"container,omitempty"`
 }
 
 func Err(msg, node string) Event {
 	return Event{
+		CommonData: CommonData{
+			Node: node,
+		},
 		Type:    ERR,
-		Node:    node,
 		Message: msg,
 	}
 }
 
 func Warn(msg, node string) Event {
 	return Event{
+		CommonData: CommonData{
+			Node: node,
+		},
 		Type:    WARN,
-		Node:    node,
 		Message: msg,
 	}
 }
 
 func Debug(msg, node string) Event {
 	return Event{
+		CommonData: CommonData{
+			Node: node,
+		},
 		Type:    DEBUG,
-		Node:    node,
 		Message: msg,
 	}
 }
 
 func Info(msg, node string) Event {
 	return Event{
+		CommonData: CommonData{
+			Node: node,
+		},
 		Type:    INFO,
-		Node:    node,
 		Message: msg,
 	}
 }


### PR DESCRIPTION
This PR contains two commits to cleanup the resolver interface. The whole goal of this change is to make tracers usable by 3rd party apps (https://github.com/kinvolk/inspektor-gadget/issues/723). 

```
    pkg/gadget-collection: Rename Resolver interface to GadgetHelpers
    
    The old called "Resolver" interface is not a resolver anymore. It does
    a bunch of different things. This commit renames it to something more
    generic.
```

```
    pkg/gadgets: Create EventEnricher interface
    
    Create an EventEnricher interface that is used by the tracers to enrich
    events with container information. This commit also removes references
    to the resolver in standard tracers given that it's not used at all.

```


Fixes https://github.com/kinvolk/inspektor-gadget/issues/685