### PR TITLE
cmd/kubectl-gadget/audit: Use BaseParser on seccomp gadget

### DIFF
--- a/cmd/kubectl-gadget/audit/audit.go
+++ b/cmd/kubectl-gadget/audit/audit.go
@@ -15,16 +15,16 @@
 package audit
 
 import (
-	"github.com/kinvolk/inspektor-gadget/cmd/kubectl-gadget/utils"
-
 	"github.com/spf13/cobra"
 )
 
-// All the gadgets within this package use this global variable, so let's
-// declare it here.
-var params utils.CommonFlags
+func NewAuditCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "audit",
+		Short: "Audit a subsystem",
+	}
 
-var AuditCmd = &cobra.Command{
-	Use:   "audit",
-	Short: "Audit a subsystem",
+	cmd.AddCommand(newSeccompCmd())
+
+	return cmd
 }

--- a/cmd/kubectl-gadget/main.go
+++ b/cmd/kubectl-gadget/main.go
@@ -41,7 +41,7 @@ func init() {
 	utils.FlagInit(rootCmd)
 
 	rootCmd.AddCommand(advise.AdviseCmd)
-	rootCmd.AddCommand(audit.AuditCmd)
+	rootCmd.AddCommand(audit.NewAuditCmd())
 	rootCmd.AddCommand(profile.NewProfileCmd())
 	rootCmd.AddCommand(snapshot.NewSnapshotCmd())
 	rootCmd.AddCommand(top.TopCmd)

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -334,7 +334,7 @@ EOF
 		{
 			name:           "RunAuditSeccompGadget",
 			cmd:            fmt.Sprintf("$KUBECTL_GADGET audit seccomp -n %s --timeout 15", ns),
-			expectedRegexp: fmt.Sprintf(`%s\s+test-pod\s+container1\s+unshare\s+\d+\s+unshare\s+kill_thread`, ns),
+			expectedRegexp: fmt.Sprintf(`%s\s+test-pod\s+container1\s+\d+\s+unshare\s+unshare\s+kill_thread`, ns),
 		},
 		deleteTestNamespaceCommand(ns),
 	}


### PR DESCRIPTION
# Use BaseParser to avoid repeated code

With this PR, the audit-seccomp gadget starts using the `BaseParser` to reuse the logic that prints the header columns and transforms the events into columns.

In addition, using `BaseParser` for all the gadgets that support JSON and columns output modes will make easier the implementation of some common features like: combine the `OutputModeColumns` and `OutputModeCustomColumns` and printing the columns that can be used with `custom-columns`.

## How to use

The only impact of these changes is that the columns now follow the order we defined for other gadgets: node, podname, container, pid, comm and then the rest.

## Testing done

Integration tests were updated with the changes in the order of the columns, and it is passing.
