### PR TITLE
trace/network: fix race on containerDetach

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,7 +149,7 @@ local-gadget-tests:
 	# available in the root environment
 	go test -c ./pkg/local-gadget-manager \
 		-tags withebpf
-	sudo ./local-gadget-manager.test -test.v -root-test
+	sudo ./local-gadget-manager.test -test.v -root-test $$LOCAL_GADGET_TESTS_PARAMS
 	rm -f ./local-gadget-manager.test
 
 .PHONY: integration-tests


### PR DESCRIPTION
# trace/network: fix race on containerDetach

The trace/network gadget checks the content of a global BPF map every
second in a go routine. When a pod is deleted, the BPF program for that
network namespace is removed in a different go routine.

This patch handles the pod deletion in the same go routine and make sure
that the BPF map is read before.

Symptoms:
```bash
$ make local-gadget-tests
=== RUN   TestNetworkGraph
    local-gadget-manager_test.go:120: Container docker.io/library/alpine output:
    local-gadget-manager_test.go:492: Received: {Event:{Type:debug Message:tracer detached Node:local Namespace:default Pod:test-local-gadget-network-graph001 Container:} PktType: Proto: IP: Port:0 RemoteKind: PodHostIP: PodIP: PodOwner: PodLabels:map[] RemoteSvcNamespace: RemoteSvcName: RemoteSvcLabelSelector:map[] RemotePodNamespace: RemotePodName: RemotePodLabels:map[] RemoteOther: Debug:}, Expected: {Event:{Type:normal Message: Node:local Namespace:default Pod:test-local-gadget-network-graph001 Container:} PktType:OUTGOING Proto:tcp IP:1.1.1.1 Port:443 RemoteKind: PodHostIP: PodIP: PodOwner: PodLabels:map[] RemoteSvcNamespace: RemoteSvcName: RemoteSvcLabelSelector:map[] RemotePodNamespace: RemotePodName: RemotePodLabels:map[] RemoteOther: Debug:}
--- FAIL: TestNetworkGraph (2.00s)
```

## How to use

No changes

## Testing done

If you have troubles reproducing the race condition, you can update the ticker to make it more likely:
```diff
--- a/pkg/gadget-collection/gadgets/trace/network/gadget.go
+++ b/pkg/gadget-collection/gadgets/trace/network/gadget.go
-       ticker := time.NewTicker(time.Second)
+       ticker := time.NewTicker(time.Second * 5)
```

Once this PR is applied, the following works without issues anymore:
```bash
$ make local-gadget-tests LOCAL_GADGET_TESTS_PARAMS="-test.run TestNetworkGraph -test.count 20"
```

