### PR TITLE
gadgets: Remove node parameter when creating tracer

### DIFF
--- a/pkg/gadget-collection/gadgets/profile/block-io/gadget.go
+++ b/pkg/gadget-collection/gadgets/profile/block-io/gadget.go
@@ -97,7 +97,7 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 	}
 
 	var err error
-	t.tracer, err = tracer.NewTracer(trace.Spec.Node)
+	t.tracer, err = tracer.NewTracer()
 	if err != nil {
 		trace.Status.OperationWarning = fmt.Sprint("failed to create core tracer. Falling back to standard one")
 
@@ -105,7 +105,7 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 		log.Infof("Gadget %s: falling back to standard tracer. CO-RE tracer failed: %s",
 			trace.Spec.Gadget, err)
 
-		t.tracer, err = standardtracer.NewTracer(trace.Spec.Node)
+		t.tracer, err = standardtracer.NewTracer()
 		if err != nil {
 			trace.Status.OperationError = fmt.Sprintf("failed to create tracer: %s", err)
 			return

--- a/pkg/gadget-collection/gadgets/profile/cpu/gadget.go
+++ b/pkg/gadget-collection/gadgets/profile/cpu/gadget.go
@@ -108,7 +108,7 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 		KernelStackOnly: kernelStackOnly,
 	}
 
-	t.tracer, err = tracer.NewTracer(t.helpers, config, trace.Spec.Node)
+	t.tracer, err = tracer.NewTracer(t.helpers, config)
 	if err != nil {
 		trace.Status.OperationWarning = fmt.Sprint("failed to create core tracer. Falling back to standard one")
 
@@ -116,7 +116,7 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 		log.Infof("Gadget %s: falling back to standard tracer. CO-RE tracer failed: %s",
 			trace.Spec.Gadget, err)
 
-		t.tracer, err = standardtracer.NewTracer(config, trace.Spec.Node)
+		t.tracer, err = standardtracer.NewTracer(config)
 		if err != nil {
 			trace.Status.OperationError = fmt.Sprintf("failed to create tracer: %s", err)
 			return

--- a/pkg/gadget-collection/gadgets/snapshot/process/gadget.go
+++ b/pkg/gadget-collection/gadgets/snapshot/process/gadget.go
@@ -71,7 +71,7 @@ func (t *Trace) Collect(trace *gadgetv1alpha1.Trace) {
 		trace.Status.OperationError = fmt.Sprintf("failed to find tracer's mount ns map: %s", err)
 		return
 	}
-	events, err := tracer.RunCollector(t.helpers, trace.Spec.Node, mountNsMap)
+	events, err := tracer.RunCollector(t.helpers, mountNsMap)
 	if err != nil {
 		trace.Status.OperationError = err.Error()
 		return

--- a/pkg/gadget-collection/gadgets/top/block-io/gadget.go
+++ b/pkg/gadget-collection/gadgets/top/block-io/gadget.go
@@ -146,7 +146,6 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 		Interval:   time.Second * time.Duration(intervalSeconds),
 		SortBy:     sortBy,
 		MountnsMap: mountNsMap,
-		Node:       trace.Spec.Node,
 	}
 
 	statsCallback := func(stats []types.Stats) {

--- a/pkg/gadget-collection/gadgets/top/file/gadget.go
+++ b/pkg/gadget-collection/gadgets/top/file/gadget.go
@@ -159,7 +159,6 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 		Interval:   time.Second * time.Duration(intervalSeconds),
 		SortBy:     sortBy,
 		MountnsMap: mountNsMap,
-		Node:       trace.Spec.Node,
 	}
 
 	statsCallback := func(stats []types.Stats) {

--- a/pkg/gadget-collection/gadgets/top/tcp/gadget.go
+++ b/pkg/gadget-collection/gadgets/top/tcp/gadget.go
@@ -171,7 +171,6 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 		MountnsMap:   mountNsMap,
 		TargetPid:    targetPid,
 		TargetFamily: targetFamily,
-		Node:         trace.Spec.Node,
 	}
 
 	statsCallback := func(stats []types.Stats) {

--- a/pkg/gadget-collection/gadgets/trace/bind/gadget.go
+++ b/pkg/gadget-collection/gadgets/trace/bind/gadget.go
@@ -158,7 +158,7 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 		TargetPorts:  targetPorts,
 		IgnoreErrors: ignoreErrors,
 	}
-	t.tracer, err = tracer.NewTracer(config, t.helpers, eventCallback, trace.Spec.Node)
+	t.tracer, err = tracer.NewTracer(config, t.helpers, eventCallback)
 	if err != nil {
 		trace.Status.OperationWarning = fmt.Sprint("failed to create core tracer. Falling back to standard one")
 
@@ -166,7 +166,7 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 		log.Infof("Gadget %s: falling back to standard tracer. CO-RE tracer failed: %s",
 			trace.Spec.Gadget, err)
 
-		t.tracer, err = standardtracer.NewTracer(config, eventCallback, trace.Spec.Node)
+		t.tracer, err = standardtracer.NewTracer(config, eventCallback)
 		if err != nil {
 			trace.Status.OperationError = fmt.Sprintf("failed to create tracer: %s", err)
 			return

--- a/pkg/gadget-collection/gadgets/trace/capabilities/gadget.go
+++ b/pkg/gadget-collection/gadgets/trace/capabilities/gadget.go
@@ -115,7 +115,7 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 		MountnsMap: mountNsMap,
 	}
 
-	t.tracer, err = tracer.NewTracer(config, t.helpers, eventCallback, trace.Spec.Node)
+	t.tracer, err = tracer.NewTracer(config, t.helpers, eventCallback)
 	if err != nil {
 		trace.Status.OperationWarning = fmt.Sprint("failed to create core tracer. Falling back to standard one")
 
@@ -123,7 +123,7 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 		log.Infof("Gadget %s: falling back to standard tracer. CO-RE tracer failed: %s",
 			trace.Spec.Gadget, err)
 
-		t.tracer, err = standardtracer.NewTracer(config, eventCallback, trace.Spec.Node)
+		t.tracer, err = standardtracer.NewTracer(config, eventCallback)
 		if err != nil {
 			trace.Status.OperationError = fmt.Sprintf("failed to create tracer: %s", err)
 			return

--- a/pkg/gadget-collection/gadgets/trace/exec/gadget.go
+++ b/pkg/gadget-collection/gadgets/trace/exec/gadget.go
@@ -114,7 +114,7 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 	config := &tracer.Config{
 		MountnsMap: mountNsMap,
 	}
-	t.tracer, err = tracer.NewTracer(config, t.helpers, eventCallback, trace.Spec.Node)
+	t.tracer, err = tracer.NewTracer(config, t.helpers, eventCallback)
 	if err != nil {
 		trace.Status.OperationWarning = fmt.Sprint("failed to create core tracer. Falling back to standard one")
 
@@ -122,7 +122,7 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 		log.Infof("Gadget %s: falling back to standard tracer. CO-RE tracer failed: %s",
 			trace.Spec.Gadget, err)
 
-		t.tracer, err = standardtracer.NewTracer(config, eventCallback, trace.Spec.Node)
+		t.tracer, err = standardtracer.NewTracer(config, eventCallback)
 		if err != nil {
 			trace.Status.OperationError = fmt.Sprintf("failed to create tracer: %s", err)
 			return

--- a/pkg/gadget-collection/gadgets/trace/fsslower/gadget.go
+++ b/pkg/gadget-collection/gadgets/trace/fsslower/gadget.go
@@ -149,7 +149,7 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 		Filesystem: filesystem,
 		MinLatency: minLatency,
 	}
-	t.tracer, err = tracer.NewTracer(config, t.helpers, eventCallback, trace.Spec.Node)
+	t.tracer, err = tracer.NewTracer(config, t.helpers, eventCallback)
 	if err != nil {
 		trace.Status.OperationError = fmt.Sprintf("failed to create tracer: %s", err)
 		return

--- a/pkg/gadget-collection/gadgets/trace/mount/gadget.go
+++ b/pkg/gadget-collection/gadgets/trace/mount/gadget.go
@@ -115,7 +115,7 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 	config := &tracer.Config{
 		MountnsMap: mountNsMap,
 	}
-	t.tracer, err = tracer.NewTracer(config, t.helpers, eventCallback, trace.Spec.Node)
+	t.tracer, err = tracer.NewTracer(config, t.helpers, eventCallback)
 	if err != nil {
 		trace.Status.OperationWarning = fmt.Sprint("failed to create core tracer. Falling back to standard one")
 
@@ -123,7 +123,7 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 		log.Infof("Gadget %s: falling back to standard tracer. CO-RE tracer failed: %s",
 			trace.Spec.Gadget, err)
 
-		t.tracer, err = standardtracer.NewTracer(config, eventCallback, trace.Spec.Node)
+		t.tracer, err = standardtracer.NewTracer(config, eventCallback)
 		if err != nil {
 			trace.Status.OperationError = fmt.Sprintf("failed to create tracer: %s", err)
 			return

--- a/pkg/gadget-collection/gadgets/trace/oomkill/gadget.go
+++ b/pkg/gadget-collection/gadgets/trace/oomkill/gadget.go
@@ -111,7 +111,7 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 	config := &tracer.Config{
 		MountnsMap: mountNsMap,
 	}
-	t.tracer, err = tracer.NewTracer(config, t.helpers, eventCallback, trace.Spec.Node)
+	t.tracer, err = tracer.NewTracer(config, t.helpers, eventCallback)
 	if err != nil {
 		trace.Status.OperationError = fmt.Sprintf("failed to create tracer: %s", err)
 		return

--- a/pkg/gadget-collection/gadgets/trace/open/gadget.go
+++ b/pkg/gadget-collection/gadgets/trace/open/gadget.go
@@ -114,7 +114,7 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 	config := &tracer.Config{
 		MountnsMap: mountNsMap,
 	}
-	t.tracer, err = tracer.NewTracer(config, t.helpers, eventCallback, trace.Spec.Node)
+	t.tracer, err = tracer.NewTracer(config, t.helpers, eventCallback)
 	if err != nil {
 		trace.Status.OperationWarning = fmt.Sprint("failed to create core tracer. Falling back to standard one")
 
@@ -122,7 +122,7 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 		log.Infof("Gadget %s: falling back to standard tracer. CO-RE tracer failed: %s",
 			trace.Spec.Gadget, err)
 
-		t.tracer, err = standardtracer.NewTracer(config, eventCallback, trace.Spec.Node)
+		t.tracer, err = standardtracer.NewTracer(config, eventCallback)
 		if err != nil {
 			trace.Status.OperationError = fmt.Sprintf("failed to create tracer: %s", err)
 			return

--- a/pkg/gadget-collection/gadgets/trace/signal/gadget.go
+++ b/pkg/gadget-collection/gadgets/trace/signal/gadget.go
@@ -152,7 +152,7 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 		TargetSignal: targetSignal,
 		FailedOnly:   failedOnly,
 	}
-	t.tracer, err = tracer.NewTracer(config, t.helpers, eventCallback, trace.Spec.Node)
+	t.tracer, err = tracer.NewTracer(config, t.helpers, eventCallback)
 	if err != nil {
 		trace.Status.OperationError = fmt.Sprintf("failed to create tracer: %s", err)
 		return

--- a/pkg/gadget-collection/gadgets/trace/tcp/gadget.go
+++ b/pkg/gadget-collection/gadgets/trace/tcp/gadget.go
@@ -115,7 +115,7 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 		MountnsMap: mountNsMap,
 	}
 
-	t.tracer, err = tracer.NewTracer(config, t.helpers, eventCallback, trace.Spec.Node)
+	t.tracer, err = tracer.NewTracer(config, t.helpers, eventCallback)
 	if err != nil {
 		trace.Status.OperationWarning = fmt.Sprint("failed to create core tracer. Falling back to standard one")
 
@@ -123,7 +123,7 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 		log.Infof("Gadget %s: falling back to standard tracer. CO-RE tracer failed: %s",
 			trace.Spec.Gadget, err)
 
-		t.tracer, err = standardtracer.NewTracer(config, eventCallback, trace.Spec.Node)
+		t.tracer, err = standardtracer.NewTracer(config, eventCallback)
 		if err != nil {
 			trace.Status.OperationError = fmt.Sprintf("failed to create tracer: %s", err)
 			return

--- a/pkg/gadget-collection/gadgets/trace/tcpconnect/gadget.go
+++ b/pkg/gadget-collection/gadgets/trace/tcpconnect/gadget.go
@@ -114,7 +114,7 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 	config := &tracer.Config{
 		MountnsMap: mountNsMap,
 	}
-	t.tracer, err = tracer.NewTracer(config, t.helpers, eventCallback, trace.Spec.Node)
+	t.tracer, err = tracer.NewTracer(config, t.helpers, eventCallback)
 	if err != nil {
 		trace.Status.OperationWarning = fmt.Sprint("failed to create core tracer. Falling back to standard one")
 
@@ -122,7 +122,7 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 		log.Infof("Gadget %s: falling back to standard tracer. CO-RE tracer failed: %s",
 			trace.Spec.Gadget, err)
 
-		t.tracer, err = standardtracer.NewTracer(config, eventCallback, trace.Spec.Node)
+		t.tracer, err = standardtracer.NewTracer(config, eventCallback)
 		if err != nil {
 			trace.Status.OperationError = fmt.Sprintf("failed to create tracer: %s", err)
 			return

--- a/pkg/gadgets/audit/seccomp/tracer/tracer.go
+++ b/pkg/gadgets/audit/seccomp/tracer/tracer.go
@@ -128,13 +128,13 @@ func (t *Tracer) run() {
 			}
 
 			msg := fmt.Sprintf("Error reading perf ring buffer: %s", err)
-			t.eventCallback(types.Base(eventtypes.Err(msg, t.node)))
+			t.eventCallback(types.Base(eventtypes.Err(msg)))
 			return
 		}
 
 		if record.LostSamples > 0 {
 			msg := fmt.Sprintf("lost %d samples", record.LostSamples)
-			t.eventCallback(types.Base(eventtypes.Warn(msg, t.node)))
+			t.eventCallback(types.Base(eventtypes.Warn(msg)))
 			continue
 		}
 

--- a/pkg/gadgets/profile/block-io/tracer/tracer.go
+++ b/pkg/gadgets/profile/block-io/tracer/tracer.go
@@ -37,17 +37,14 @@ import (
 //go:generate go run github.com/cilium/ebpf/cmd/bpf2go -target $TARGET -cc clang biolatencyBefore ./bpf/biolatency.bpf.c -- -I./bpf/ -I../../../../${TARGET} -DKERNEL_BEFORE_5_11
 
 type Tracer struct {
-	node                string
 	objs                biolatencyObjects
 	blockRqCompleteLink link.Link
 	blockRqInsertLink   link.Link
 	blockRqIssueLink    link.Link
 }
 
-func NewTracer(node string) (*Tracer, error) {
-	t := &Tracer{
-		node: node,
-	}
+func NewTracer() (*Tracer, error) {
+	t := &Tracer{}
 
 	if err := t.start(); err != nil {
 		t.Stop()

--- a/pkg/gadgets/profile/cpu/tracer/tracer.go
+++ b/pkg/gadgets/profile/cpu/tracer/tracer.go
@@ -51,7 +51,6 @@ type Config struct {
 
 type Tracer struct {
 	enricher gadgets.DataEnricher
-	node     string
 	objs     profileObjects
 	perfFds  []int
 	config   *Config
@@ -68,10 +67,9 @@ const (
 	frequencyBit = 1 << 10
 )
 
-func NewTracer(enricher gadgets.DataEnricher, config *Config, node string) (*Tracer, error) {
+func NewTracer(enricher gadgets.DataEnricher, config *Config) (*Tracer, error) {
 	t := &Tracer{
 		enricher: enricher,
-		node:     node,
 		config:   config,
 	}
 

--- a/pkg/gadgets/snapshot/process/tracer/tracer.go
+++ b/pkg/gadgets/snapshot/process/tracer/tracer.go
@@ -34,7 +34,7 @@ const (
 	BPFIterName = "dump_task"
 )
 
-func RunCollector(enricher gadgets.DataEnricher, node string, mntnsmap *ebpf.Map) ([]processcollectortypes.Event, error) {
+func RunCollector(enricher gadgets.DataEnricher, mntnsmap *ebpf.Map) ([]processcollectortypes.Event, error) {
 	var err error
 	var spec *ebpf.CollectionSpec
 

--- a/pkg/gadgets/top/block-io/tracer/tracer.go
+++ b/pkg/gadgets/top/block-io/tracer/tracer.go
@@ -45,7 +45,6 @@ type Config struct {
 	Interval   time.Duration
 	SortBy     types.SortBy
 	MountnsMap *ebpf.Map
-	Node       string
 }
 
 type Tracer struct {

--- a/pkg/gadgets/top/file/tracer/tracer.go
+++ b/pkg/gadgets/top/file/tracer/tracer.go
@@ -43,7 +43,6 @@ type Config struct {
 	MaxRows    int
 	Interval   time.Duration
 	SortBy     types.SortBy
-	Node       string
 }
 
 type Tracer struct {

--- a/pkg/gadgets/top/tcp/tracer/tracer.go
+++ b/pkg/gadgets/top/tcp/tracer/tracer.go
@@ -71,7 +71,6 @@ type Config struct {
 	MaxRows      int
 	Interval     time.Duration
 	SortBy       types.SortBy
-	Node         string
 }
 
 type Tracer struct {

--- a/pkg/gadgets/trace/bind/tracer/tracer.go
+++ b/pkg/gadgets/trace/bind/tracer/tracer.go
@@ -72,7 +72,6 @@ type Tracer struct {
 	config        *Config
 	enricher      gadgets.DataEnricher
 	eventCallback func(types.Event)
-	node          string
 
 	objs      bindsnoopObjects
 	ipv4Entry link.Link
@@ -83,13 +82,12 @@ type Tracer struct {
 }
 
 func NewTracer(config *Config, enricher gadgets.DataEnricher,
-	eventCallback func(types.Event), node string,
+	eventCallback func(types.Event),
 ) (*Tracer, error) {
 	t := &Tracer{
 		config:        config,
 		enricher:      enricher,
 		eventCallback: eventCallback,
-		node:          node,
 	}
 
 	if err := t.start(); err != nil {
@@ -260,13 +258,13 @@ func (t *Tracer) run() {
 			}
 
 			msg := fmt.Sprintf("Error reading perf ring buffer: %s", err)
-			t.eventCallback(types.Base(eventtypes.Err(msg, t.node)))
+			t.eventCallback(types.Base(eventtypes.Err(msg)))
 			return
 		}
 
 		if record.LostSamples > 0 {
 			msg := fmt.Sprintf("lost %d samples", record.LostSamples)
-			t.eventCallback(types.Base(eventtypes.Warn(msg, t.node)))
+			t.eventCallback(types.Base(eventtypes.Warn(msg)))
 			continue
 		}
 
@@ -285,7 +283,7 @@ func (t *Tracer) run() {
 			interf, err := netlink.LinkByIndex(interfaceNum)
 			if err != nil {
 				msg := fmt.Sprintf("Cannot get net interface for %d : %s", interfaceNum, err)
-				t.eventCallback(types.Base(eventtypes.Err(msg, t.node)))
+				t.eventCallback(types.Base(eventtypes.Err(msg)))
 				return
 			}
 

--- a/pkg/gadgets/trace/capabilities/tracer/tracer.go
+++ b/pkg/gadgets/trace/capabilities/tracer/tracer.go
@@ -50,7 +50,6 @@ type Tracer struct {
 	reader           *perf.Reader
 	enricher         gadgets.DataEnricher
 	eventCallback    func(types.Event)
-	node             string
 }
 
 var capabilitiesNames = map[uint32]string{
@@ -98,13 +97,12 @@ var capabilitiesNames = map[uint32]string{
 }
 
 func NewTracer(c *Config, enricher gadgets.DataEnricher,
-	eventCallback func(types.Event), node string,
+	eventCallback func(types.Event),
 ) (*Tracer, error) {
 	t := &Tracer{
 		config:        c,
 		enricher:      enricher,
 		eventCallback: eventCallback,
-		node:          node,
 	}
 
 	if err := t.start(); err != nil {
@@ -193,7 +191,7 @@ func (t *Tracer) run() {
 			}
 
 			msg := fmt.Sprintf("Error reading perf ring buffer: %s", err)
-			t.eventCallback(types.Base(eventtypes.Err(msg, t.node)))
+			t.eventCallback(types.Base(eventtypes.Err(msg)))
 			return
 		}
 
@@ -210,7 +208,7 @@ func (t *Tracer) run() {
 		runningKernelVersion, err := features.LinuxVersionCode()
 		if err != nil {
 			msg := fmt.Sprintf("Error getting kernel version: %s", err)
-			t.eventCallback(types.Base(eventtypes.Err(msg, t.node)))
+			t.eventCallback(types.Base(eventtypes.Err(msg)))
 		}
 
 		capOpt := int(eventC.cap_opt)

--- a/pkg/gadgets/trace/dns/tracer/tracer.go
+++ b/pkg/gadgets/trace/dns/tracer/tracer.go
@@ -296,13 +296,13 @@ func (t *Tracer) listen(
 			}
 
 			msg := fmt.Sprintf("Error reading perf ring buffer (%s): %s", key, err)
-			eventCallback(types.Base(eventtypes.Err(msg, node)))
+			eventCallback(types.Base(eventtypes.Err(msg)))
 			return
 		}
 
 		if record.LostSamples != 0 {
 			msg := fmt.Sprintf("lost %d samples (%s)", record.LostSamples, key)
-			eventCallback(types.Base(eventtypes.Warn(msg, node)))
+			eventCallback(types.Base(eventtypes.Warn(msg)))
 			continue
 		}
 

--- a/pkg/gadgets/trace/exec/tracer/tracer.go
+++ b/pkg/gadgets/trace/exec/tracer/tracer.go
@@ -45,7 +45,6 @@ type Tracer struct {
 	config        *Config
 	enricher      gadgets.DataEnricher
 	eventCallback func(types.Event)
-	node          string
 
 	objs      execsnoopObjects
 	enterLink link.Link
@@ -54,13 +53,12 @@ type Tracer struct {
 }
 
 func NewTracer(config *Config, enricher gadgets.DataEnricher,
-	eventCallback func(types.Event), node string,
+	eventCallback func(types.Event),
 ) (*Tracer, error) {
 	t := &Tracer{
 		config:        config,
 		enricher:      enricher,
 		eventCallback: eventCallback,
-		node:          node,
 	}
 
 	if err := t.start(); err != nil {
@@ -139,13 +137,13 @@ func (t *Tracer) run() {
 			}
 
 			msg := fmt.Sprintf("Error reading perf ring buffer: %s", err)
-			t.eventCallback(types.Base(eventtypes.Err(msg, t.node)))
+			t.eventCallback(types.Base(eventtypes.Err(msg)))
 			return
 		}
 
 		if record.LostSamples > 0 {
 			msg := fmt.Sprintf("lost %d samples", record.LostSamples)
-			t.eventCallback(types.Base(eventtypes.Warn(msg, t.node)))
+			t.eventCallback(types.Base(eventtypes.Warn(msg)))
 			continue
 		}
 

--- a/pkg/gadgets/trace/fsslower/tracer/tracer.go
+++ b/pkg/gadgets/trace/fsslower/tracer/tracer.go
@@ -48,7 +48,6 @@ type Tracer struct {
 	config        *Config
 	enricher      gadgets.DataEnricher
 	eventCallback func(types.Event)
-	node          string
 
 	objs           fsslowerObjects
 	readEnterLink  link.Link
@@ -97,13 +96,12 @@ var fsConfMap = map[string]fsConf{
 }
 
 func NewTracer(config *Config, enricher gadgets.DataEnricher,
-	eventCallback func(types.Event), node string,
+	eventCallback func(types.Event),
 ) (*Tracer, error) {
 	t := &Tracer{
 		config:        config,
 		enricher:      enricher,
 		eventCallback: eventCallback,
-		node:          node,
 	}
 
 	if err := t.start(); err != nil {
@@ -239,13 +237,13 @@ func (t *Tracer) run() {
 				return
 			}
 			msg := fmt.Sprintf("Error reading perf ring buffer: %s", err)
-			t.eventCallback(types.Base(eventtypes.Err(msg, t.node)))
+			t.eventCallback(types.Base(eventtypes.Err(msg)))
 			return
 		}
 
 		if record.LostSamples > 0 {
 			msg := fmt.Sprintf("lost %d samples", record.LostSamples)
-			t.eventCallback(types.Base(eventtypes.Warn(msg, t.node)))
+			t.eventCallback(types.Base(eventtypes.Warn(msg)))
 			continue
 		}
 

--- a/pkg/gadgets/trace/mount/tracer/tracer.go
+++ b/pkg/gadgets/trace/mount/tracer/tracer.go
@@ -45,7 +45,6 @@ type Tracer struct {
 	config        *Config
 	enricher      gadgets.DataEnricher
 	eventCallback func(types.Event)
-	node          string
 
 	objs            mountsnoopObjects
 	mountEnterLink  link.Link
@@ -56,13 +55,13 @@ type Tracer struct {
 }
 
 func NewTracer(config *Config, enricher gadgets.DataEnricher,
-	eventCallback func(types.Event), node string,
+	eventCallback func(types.Event),
 ) (*Tracer, error) {
-	t := &Tracer{config: config}
-
-	t.enricher = enricher
-	t.eventCallback = eventCallback
-	t.node = node
+	t := &Tracer{
+		config:        config,
+		enricher:      enricher,
+		eventCallback: eventCallback,
+	}
 
 	if err := t.start(); err != nil {
 		t.Stop()
@@ -157,13 +156,13 @@ func (t *Tracer) run() {
 			}
 
 			msg := fmt.Sprintf("Error reading perf ring buffer: %s", err)
-			t.eventCallback(types.Base(eventtypes.Err(msg, t.node)))
+			t.eventCallback(types.Base(eventtypes.Err(msg)))
 			return
 		}
 
 		if record.LostSamples > 0 {
 			msg := fmt.Sprintf("lost %d samples", record.LostSamples)
-			t.eventCallback(types.Base(eventtypes.Warn(msg, t.node)))
+			t.eventCallback(types.Base(eventtypes.Warn(msg)))
 			continue
 		}
 

--- a/pkg/gadgets/trace/oomkill/tracer/tracer.go
+++ b/pkg/gadgets/trace/oomkill/tracer/tracer.go
@@ -48,15 +48,13 @@ type Tracer struct {
 	reader        *perf.Reader
 	enricher      gadgets.DataEnricher
 	eventCallback func(types.Event)
-	node          string
 }
 
-func NewTracer(c *Config, enricher gadgets.DataEnricher, eventCallback func(types.Event), node string) (*Tracer, error) {
+func NewTracer(c *Config, enricher gadgets.DataEnricher, eventCallback func(types.Event)) (*Tracer, error) {
 	t := &Tracer{
 		config:        c,
 		enricher:      enricher,
 		eventCallback: eventCallback,
-		node:          node,
 	}
 
 	if err := t.start(); err != nil {
@@ -138,7 +136,7 @@ func (t *Tracer) run() {
 			}
 
 			msg := fmt.Sprintf("Error reading perf ring buffer: %s", err)
-			t.eventCallback(types.Base(eventtypes.Err(msg, t.node)))
+			t.eventCallback(types.Base(eventtypes.Err(msg)))
 			return
 		}
 

--- a/pkg/gadgets/trace/open/tracer/tracer.go
+++ b/pkg/gadgets/trace/open/tracer/tracer.go
@@ -46,7 +46,6 @@ type Tracer struct {
 	config        *Config
 	enricher      gadgets.DataEnricher
 	eventCallback func(types.Event)
-	node          string
 
 	objs            opensnoopObjects
 	openEnterLink   link.Link
@@ -57,13 +56,13 @@ type Tracer struct {
 }
 
 func NewTracer(config *Config, enricher gadgets.DataEnricher,
-	eventCallback func(types.Event), node string,
+	eventCallback func(types.Event),
 ) (*Tracer, error) {
-	t := &Tracer{config: config}
-
-	t.enricher = enricher
-	t.eventCallback = eventCallback
-	t.node = node
+	t := &Tracer{
+		config:        config,
+		enricher:      enricher,
+		eventCallback: eventCallback,
+	}
 
 	if err := t.start(); err != nil {
 		t.Stop()
@@ -167,13 +166,13 @@ func (t *Tracer) run() {
 			}
 
 			msg := fmt.Sprintf("Error reading perf ring buffer: %s", err)
-			t.eventCallback(types.Base(eventtypes.Err(msg, t.node)))
+			t.eventCallback(types.Base(eventtypes.Err(msg)))
 			return
 		}
 
 		if record.LostSamples > 0 {
 			msg := fmt.Sprintf("lost %d samples", record.LostSamples)
-			t.eventCallback(types.Base(eventtypes.Warn(msg, t.node)))
+			t.eventCallback(types.Base(eventtypes.Warn(msg)))
 			continue
 		}
 

--- a/pkg/gadgets/trace/signal/tracer/tracer.go
+++ b/pkg/gadgets/trace/signal/tracer/tracer.go
@@ -53,7 +53,6 @@ type Tracer struct {
 
 	enricher      gadgets.DataEnricher
 	eventCallback func(types.Event)
-	node          string
 }
 
 func signalStringToInt(signal string) (int32, error) {
@@ -84,13 +83,12 @@ func signalIntToString(signal int) string {
 }
 
 func NewTracer(config *Config, enricher gadgets.DataEnricher,
-	eventCallback func(types.Event), node string,
+	eventCallback func(types.Event),
 ) (*Tracer, error) {
 	t := &Tracer{
 		config:        config,
 		enricher:      enricher,
 		eventCallback: eventCallback,
-		node:          node,
 	}
 
 	if err := t.start(); err != nil {
@@ -214,13 +212,13 @@ func (t *Tracer) run() {
 			}
 
 			msg := fmt.Sprintf("Error reading perf ring buffer: %s", err)
-			t.eventCallback(types.Base(eventtypes.Err(msg, t.node)))
+			t.eventCallback(types.Base(eventtypes.Err(msg)))
 			return
 		}
 
 		if record.LostSamples > 0 {
 			msg := fmt.Sprintf("lost %d samples", record.LostSamples)
-			t.eventCallback(types.Base(eventtypes.Warn(msg, t.node)))
+			t.eventCallback(types.Base(eventtypes.Warn(msg)))
 			continue
 		}
 

--- a/pkg/gadgets/trace/sni/tracer/tracer.go
+++ b/pkg/gadgets/trace/sni/tracer/tracer.go
@@ -164,13 +164,13 @@ func (t *Tracer) listen(
 				return
 			}
 			msg := fmt.Sprintf("Error reading perf ring buffer (%s): %s", key, err)
-			eventCallback(types.Base(eventtypes.Err(msg, node)))
+			eventCallback(types.Base(eventtypes.Err(msg)))
 			return
 		}
 
 		if record.LostSamples != 0 {
 			msg := fmt.Sprintf("lost %d samples (%s)", record.LostSamples, key)
-			eventCallback(types.Base(eventtypes.Warn(msg, node)))
+			eventCallback(types.Base(eventtypes.Warn(msg)))
 			continue
 		}
 

--- a/pkg/gadgets/trace/tcp/tracer/tracer.go
+++ b/pkg/gadgets/trace/tcp/tracer/tracer.go
@@ -78,7 +78,6 @@ type Tracer struct {
 	config        *Config
 	enricher      gadgets.DataEnricher
 	eventCallback func(types.Event)
-	node          string
 
 	objs tcptracerObjects
 
@@ -94,12 +93,11 @@ type Tracer struct {
 }
 
 func NewTracer(config *Config, enricher gadgets.DataEnricher,
-	eventCallback func(types.Event), node string) (*Tracer, error) {
+	eventCallback func(types.Event)) (*Tracer, error) {
 	t := &Tracer{
 		config:        config,
 		enricher:      enricher,
 		eventCallback: eventCallback,
-		node:          node,
 	}
 
 	if err := t.start(); err != nil {
@@ -214,13 +212,13 @@ func (t *Tracer) run() {
 			}
 
 			msg := fmt.Sprintf("Error reading perf ring buffer: %s", err)
-			t.eventCallback(types.Base(eventtypes.Err(msg, t.node)))
+			t.eventCallback(types.Base(eventtypes.Err(msg)))
 			return
 		}
 
 		if record.LostSamples > 0 {
 			msg := fmt.Sprintf("lost %d samples", record.LostSamples)
-			t.eventCallback(types.Base(eventtypes.Warn(msg, t.node)))
+			t.eventCallback(types.Base(eventtypes.Warn(msg)))
 			continue
 		}
 

--- a/pkg/gadgets/trace/tcpconnect/tracer/tracer.go
+++ b/pkg/gadgets/trace/tcpconnect/tracer/tracer.go
@@ -78,7 +78,6 @@ type Tracer struct {
 	config        *Config
 	enricher      gadgets.DataEnricher
 	eventCallback func(types.Event)
-	node          string
 
 	objs        tcpconnectObjects
 	v4EnterLink link.Link
@@ -89,13 +88,13 @@ type Tracer struct {
 }
 
 func NewTracer(config *Config, enricher gadgets.DataEnricher,
-	eventCallback func(types.Event), node string,
+	eventCallback func(types.Event),
 ) (*Tracer, error) {
-	t := &Tracer{config: config}
-
-	t.enricher = enricher
-	t.eventCallback = eventCallback
-	t.node = node
+	t := &Tracer{
+		config:        config,
+		enricher:      enricher,
+		eventCallback: eventCallback,
+	}
 
 	if err := t.start(); err != nil {
 		t.Stop()
@@ -186,13 +185,13 @@ func (t *Tracer) run() {
 			}
 
 			msg := fmt.Sprintf("Error reading perf ring buffer: %s", err)
-			t.eventCallback(types.Base(eventtypes.Err(msg, t.node)))
+			t.eventCallback(types.Base(eventtypes.Err(msg)))
 			return
 		}
 
 		if record.LostSamples > 0 {
 			msg := fmt.Sprintf("lost %d samples", record.LostSamples)
-			t.eventCallback(types.Base(eventtypes.Warn(msg, t.node)))
+			t.eventCallback(types.Base(eventtypes.Warn(msg)))
 			continue
 		}
 

--- a/pkg/gadgettracermanager/gadgettracermanager.go
+++ b/pkg/gadgettracermanager/gadgettracermanager.go
@@ -227,6 +227,8 @@ func newServer(conf *Conf) (*GadgetTracerManager, error) {
 		withBPF:  !conf.TestOnly,
 	}
 
+	eventtypes.Init(conf.NodeName)
+
 	tracerCollection, err := tracercollection.NewTracerCollection(!conf.TestOnly, &g.ContainerCollection)
 	if err != nil {
 		return nil, err

--- a/pkg/standardgadgets/profile/block-io/tracer.go
+++ b/pkg/standardgadgets/profile/block-io/tracer.go
@@ -26,10 +26,9 @@ type Tracer struct {
 	cmd    *exec.Cmd
 	stdout *bytes.Buffer
 	stderr *bytes.Buffer
-	node   string
 }
 
-func NewTracer(node string) (*Tracer, error) {
+func NewTracer() (*Tracer, error) {
 	cmd := exec.Command("/usr/share/bcc/tools/biolatency", "--json")
 
 	stdout := bytes.NewBuffer([]byte{})
@@ -47,7 +46,6 @@ func NewTracer(node string) (*Tracer, error) {
 		cmd:    cmd,
 		stdout: stdout,
 		stderr: stderr,
-		node:   node,
 	}, nil
 }
 

--- a/pkg/standardgadgets/profile/cpu/tracer.go
+++ b/pkg/standardgadgets/profile/cpu/tracer.go
@@ -32,11 +32,10 @@ type Tracer struct {
 	cmd               *exec.Cmd
 	stdout            *bytes.Buffer
 	stderr            *bytes.Buffer
-	node              string
 	mountnsMapPinPath string
 }
 
-func NewTracer(config *tracer.Config, node string) (*Tracer, error) {
+func NewTracer(config *tracer.Config) (*Tracer, error) {
 	mountNsMapPinPath := filepath.Join(gadgets.PinPath, uuid.New().String())
 	if err := config.MountnsMap.Pin(mountNsMapPinPath); err != nil {
 		return nil, fmt.Errorf("failed to pin tracer's mount ns map: %w", err)
@@ -69,7 +68,6 @@ func NewTracer(config *tracer.Config, node string) (*Tracer, error) {
 		cmd:               cmd,
 		stdout:            stdout,
 		stderr:            stderr,
-		node:              node,
 		mountnsMapPinPath: mountNsMapPinPath,
 	}, nil
 }

--- a/pkg/standardgadgets/trace/bind/tracer.go
+++ b/pkg/standardgadgets/trace/bind/tracer.go
@@ -28,17 +28,16 @@ type Tracer struct {
 	trace.StandardTracerBase
 
 	eventCallback func(types.Event)
-	node          string
 }
 
-func NewTracer(config *tracer.Config, eventCallback func(types.Event), node string) (*Tracer, error) {
+func NewTracer(config *tracer.Config, eventCallback func(types.Event)) (*Tracer, error) {
 	lineCallback := func(line string) {
 		event := types.Event{}
 		event.Type = eventtypes.NORMAL
 
 		if err := json.Unmarshal([]byte(line), &event); err != nil {
 			msg := fmt.Sprintf("failed to unmarshal event '%s': %s", line, err)
-			eventCallback(types.Base(eventtypes.Warn(msg, node)))
+			eventCallback(types.Base(eventtypes.Warn(msg)))
 			return
 		}
 
@@ -55,12 +54,11 @@ func NewTracer(config *tracer.Config, eventCallback func(types.Event), node stri
 	return &Tracer{
 		StandardTracerBase: *baseTracer,
 		eventCallback:      eventCallback,
-		node:               node,
 	}, nil
 }
 
 func (t *Tracer) Stop() {
 	if err := t.StandardTracerBase.Stop(); err != nil {
-		t.eventCallback(types.Base(eventtypes.Warn(err.Error(), t.node)))
+		t.eventCallback(types.Base(eventtypes.Warn(err.Error())))
 	}
 }

--- a/pkg/standardgadgets/trace/capabilities/tracer.go
+++ b/pkg/standardgadgets/trace/capabilities/tracer.go
@@ -28,11 +28,10 @@ type Tracer struct {
 	trace.StandardTracerBase
 
 	eventCallback func(types.Event)
-	node          string
 }
 
 func NewTracer(config *tracer.Config,
-	eventCallback func(types.Event), node string) (*Tracer, error,
+	eventCallback func(types.Event)) (*Tracer, error,
 ) {
 	lineCallback := func(line string) {
 		event := types.Event{}
@@ -40,7 +39,7 @@ func NewTracer(config *tracer.Config,
 
 		if err := json.Unmarshal([]byte(line), &event); err != nil {
 			msg := fmt.Sprintf("failed to unmarshal event '%s': %s", line, err)
-			eventCallback(types.Base(eventtypes.Warn(msg, node)))
+			eventCallback(types.Base(eventtypes.Warn(msg)))
 			return
 		}
 
@@ -57,12 +56,11 @@ func NewTracer(config *tracer.Config,
 	return &Tracer{
 		StandardTracerBase: *baseTracer,
 		eventCallback:      eventCallback,
-		node:               node,
 	}, nil
 }
 
 func (t *Tracer) Stop() {
 	if err := t.StandardTracerBase.Stop(); err != nil {
-		t.eventCallback(types.Base(eventtypes.Warn(err.Error(), t.node)))
+		t.eventCallback(types.Base(eventtypes.Warn(err.Error())))
 	}
 }

--- a/pkg/standardgadgets/trace/exec/tracer.go
+++ b/pkg/standardgadgets/trace/exec/tracer.go
@@ -29,11 +29,10 @@ type Tracer struct {
 	trace.StandardTracerBase
 
 	eventCallback func(types.Event)
-	node          string
 }
 
 func NewTracer(config *tracer.Config,
-	eventCallback func(types.Event), node string) (*Tracer, error,
+	eventCallback func(types.Event)) (*Tracer, error,
 ) {
 	lineCallback := func(line string) {
 		event := types.Event{}
@@ -41,7 +40,7 @@ func NewTracer(config *tracer.Config,
 
 		if err := json.Unmarshal([]byte(line), &event); err != nil {
 			msg := fmt.Sprintf("failed to unmarshal event '%s': %s", line, err)
-			eventCallback(types.Base(eventtypes.Warn(msg, node)))
+			eventCallback(types.Base(eventtypes.Warn(msg)))
 			return
 		}
 
@@ -58,12 +57,11 @@ func NewTracer(config *tracer.Config,
 	return &Tracer{
 		StandardTracerBase: *baseTracer,
 		eventCallback:      eventCallback,
-		node:               node,
 	}, nil
 }
 
 func (t *Tracer) Stop() {
 	if err := t.StandardTracerBase.Stop(); err != nil {
-		t.eventCallback(types.Base(eventtypes.Warn(err.Error(), t.node)))
+		t.eventCallback(types.Base(eventtypes.Warn(err.Error())))
 	}
 }

--- a/pkg/standardgadgets/trace/mount/tracer.go
+++ b/pkg/standardgadgets/trace/mount/tracer.go
@@ -29,11 +29,10 @@ type Tracer struct {
 	trace.StandardTracerBase
 
 	eventCallback func(types.Event)
-	node          string
 }
 
 func NewTracer(config *tracer.Config,
-	eventCallback func(types.Event), node string) (*Tracer, error,
+	eventCallback func(types.Event)) (*Tracer, error,
 ) {
 	lineCallback := func(line string) {
 		event := types.Event{}
@@ -46,7 +45,7 @@ func NewTracer(config *tracer.Config,
 
 		if err := json.Unmarshal([]byte(line), &event); err != nil {
 			msg := fmt.Sprintf("failed to unmarshal event '%s': %s", line, err)
-			eventCallback(types.Base(eventtypes.Warn(msg, node)))
+			eventCallback(types.Base(eventtypes.Warn(msg)))
 			return
 		}
 
@@ -65,12 +64,11 @@ func NewTracer(config *tracer.Config,
 	return &Tracer{
 		StandardTracerBase: *baseTracer,
 		eventCallback:      eventCallback,
-		node:               node,
 	}, nil
 }
 
 func (t *Tracer) Stop() {
 	if err := t.StandardTracerBase.Stop(); err != nil {
-		t.eventCallback(types.Base(eventtypes.Warn(err.Error(), t.node)))
+		t.eventCallback(types.Base(eventtypes.Warn(err.Error())))
 	}
 }

--- a/pkg/standardgadgets/trace/open/tracer.go
+++ b/pkg/standardgadgets/trace/open/tracer.go
@@ -28,11 +28,10 @@ type Tracer struct {
 	trace.StandardTracerBase
 
 	eventCallback func(types.Event)
-	node          string
 }
 
 func NewTracer(config *tracer.Config,
-	eventCallback func(types.Event), node string) (*Tracer, error,
+	eventCallback func(types.Event)) (*Tracer, error,
 ) {
 	lineCallback := func(line string) {
 		event := types.Event{}
@@ -40,7 +39,7 @@ func NewTracer(config *tracer.Config,
 
 		if err := json.Unmarshal([]byte(line), &event); err != nil {
 			msg := fmt.Sprintf("failed to unmarshal event '%s': %s", line, err)
-			eventCallback(types.Base(eventtypes.Warn(msg, node)))
+			eventCallback(types.Base(eventtypes.Warn(msg)))
 			return
 		}
 
@@ -57,12 +56,11 @@ func NewTracer(config *tracer.Config,
 	return &Tracer{
 		StandardTracerBase: *baseTracer,
 		eventCallback:      eventCallback,
-		node:               node,
 	}, nil
 }
 
 func (t *Tracer) Stop() {
 	if err := t.StandardTracerBase.Stop(); err != nil {
-		t.eventCallback(types.Base(eventtypes.Warn(err.Error(), t.node)))
+		t.eventCallback(types.Base(eventtypes.Warn(err.Error())))
 	}
 }

--- a/pkg/standardgadgets/trace/tcp/tracer.go
+++ b/pkg/standardgadgets/trace/tcp/tracer.go
@@ -29,11 +29,10 @@ type Tracer struct {
 	trace.StandardTracerBase
 
 	eventCallback func(types.Event)
-	node          string
 }
 
 func NewTracer(config *tracer.Config,
-	eventCallback func(types.Event), node string) (*Tracer, error,
+	eventCallback func(types.Event)) (*Tracer, error,
 ) {
 	lineCallback := func(line string) {
 		event := types.Event{}
@@ -45,7 +44,7 @@ func NewTracer(config *tracer.Config,
 
 		if err := json.Unmarshal([]byte(line), &event); err != nil {
 			msg := fmt.Sprintf("failed to unmarshal event '%s': %s", line, err)
-			eventCallback(types.Base(eventtypes.Warn(msg, node)))
+			eventCallback(types.Base(eventtypes.Warn(msg)))
 			return
 		}
 
@@ -62,12 +61,11 @@ func NewTracer(config *tracer.Config,
 	return &Tracer{
 		StandardTracerBase: *baseTracer,
 		eventCallback:      eventCallback,
-		node:               node,
 	}, nil
 }
 
 func (t *Tracer) Stop() {
 	if err := t.StandardTracerBase.Stop(); err != nil {
-		t.eventCallback(types.Base(eventtypes.Warn(err.Error(), t.node)))
+		t.eventCallback(types.Base(eventtypes.Warn(err.Error())))
 	}
 }

--- a/pkg/standardgadgets/trace/tcpconnect/tracer.go
+++ b/pkg/standardgadgets/trace/tcpconnect/tracer.go
@@ -29,11 +29,10 @@ type Tracer struct {
 	trace.StandardTracerBase
 
 	eventCallback func(types.Event)
-	node          string
 }
 
 func NewTracer(config *tracer.Config,
-	eventCallback func(types.Event), node string) (*Tracer, error,
+	eventCallback func(types.Event)) (*Tracer, error,
 ) {
 	lineCallback := func(line string) {
 		event := types.Event{}
@@ -44,7 +43,7 @@ func NewTracer(config *tracer.Config,
 
 		if err := json.Unmarshal([]byte(line), &event); err != nil {
 			msg := fmt.Sprintf("failed to unmarshal event '%s': %s", line, err)
-			eventCallback(types.Base(eventtypes.Warn(msg, node)))
+			eventCallback(types.Base(eventtypes.Warn(msg)))
 			return
 		}
 
@@ -61,12 +60,11 @@ func NewTracer(config *tracer.Config,
 	return &Tracer{
 		StandardTracerBase: *baseTracer,
 		eventCallback:      eventCallback,
-		node:               node,
 	}, nil
 }
 
 func (t *Tracer) Stop() {
 	if err := t.StandardTracerBase.Stop(); err != nil {
-		t.eventCallback(types.Base(eventtypes.Warn(err.Error(), t.node)))
+		t.eventCallback(types.Base(eventtypes.Warn(err.Error())))
 	}
 }

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -21,6 +21,12 @@ import (
 
 type EventType string
 
+var node string
+
+func Init(nodeName string) {
+	node = nodeName
+}
+
 type CommonData struct {
 	// Node where the event comes from
 	Node string `json:"node,omitempty"`
@@ -68,7 +74,7 @@ type Event struct {
 	Message string `json:"message,omitempty"`
 }
 
-func Err(msg, node string) Event {
+func Err(msg string) Event {
 	return Event{
 		CommonData: CommonData{
 			Node: node,
@@ -78,7 +84,7 @@ func Err(msg, node string) Event {
 	}
 }
 
-func Warn(msg, node string) Event {
+func Warn(msg string) Event {
 	return Event{
 		CommonData: CommonData{
 			Node: node,
@@ -88,7 +94,7 @@ func Warn(msg, node string) Event {
 	}
 }
 
-func Debug(msg, node string) Event {
+func Debug(msg string) Event {
 	return Event{
 		CommonData: CommonData{
 			Node: node,
@@ -98,7 +104,7 @@ func Debug(msg, node string) Event {
 	}
 }
 
-func Info(msg, node string) Event {
+func Info(msg string) Event {
 	return Event{
 		CommonData: CommonData{
 			Node: node,


### PR DESCRIPTION
The node parameter is not needed anymore. This changes makes it easier
to import and use the tracers directly as there is one less parameter
to be passed.

