### PR TITLE
pkg/container-collection: Add `omitempty` tag to Container struct

### DIFF
--- a/docs/gadgets/seccomp.md
+++ b/docs/gadgets/seccomp.md
@@ -32,8 +32,8 @@ SeccompProfiles will have the following annotations:
   traced
 * seccomp.gadget.kinvolk.io/container: the container name in the pod that was
   traced
-* seccomp.gadget.kinvolk.io/ownerReference-ApiVersion: the ownerReference&#39;s
-  ApiVersion of the pod that was traced
+* seccomp.gadget.kinvolk.io/ownerReference-APIVersion: the ownerReference&#39;s
+  APIVersion of the pod that was traced
 * seccomp.gadget.kinvolk.io/ownerReference-Kind: the ownerReference&#39;s Kind of the
   pod that was traced
 * seccomp.gadget.kinvolk.io/ownerReference-Name: the ownerReference&#39;s Name of the

--- a/docs/local-gadget.md
+++ b/docs/local-gadget.md
@@ -76,23 +76,18 @@ The `list-containers` command also supports JSON format and filtering:
 $ sudo local-gadget list-containers -o json --containername calico-kube-controllers
 [
   {
-    "ID": "1fd08f8d9fc300a3c312edc1718d31d424744ebbcf70a3ed84a8dc5402a64dc7",
-    "Pid": 4670,
-    "OciConfig": null,
-    "Bundle": "",
-    "Mntns": 4026532515,
-    "Netns": 4026532368,
-    "CgroupPath": "/sys/fs/cgroup/unified/system.slice/containerd.service",
-    "CgroupID": 854,
-    "CgroupV1": "/system.slice/containerd.service/kubepods-besteffort-pod07c58ca4_5b3e_49dd_baa3_af39fd0b5363.slice:cri-containerd:1fd08f8d9fc300a3c312edc1718d31d424744ebbcf70a3ed84a8dc5402a64dc7",
-    "CgroupV2": "/system.slice/containerd.service",
-    "Namespace": "default",
-    "Podname": "calico-kube-controllers",
-    "Name": "calico-kube-controllers",
-    "Labels": null,
-    "OwnerReference": null,
-    "PodUID": "",
-    "Runtime": "containerd"
+    "id": "1fd08f8d9fc300a3c312edc1718d31d424744ebbcf70a3ed84a8dc5402a64dc7",
+    "pid": 2974,
+    "mntns": 4026532290,
+    "netns": 4026531992,
+    "cgroupPath": "/sys/fs/cgroup/unified/system.slice/containerd.service",
+    "cgroupID": 854,
+    "cgroupV1": "/system.slice/containerd.service/kubepods-besteffort-pod3b57919c_9239_4b73_a74c_2bdb9c7c2926.slice:cri-containerd:7e069227538c40f2965b9610018678e93e07fadd04add1aa5d5243337038f336",
+    "cgroupV2": "/system.slice/containerd.service",
+    "namespace": "default",
+    "podname": "kube-proxy",
+    "name": "kube-proxy",
+    "runtime": "containerd"
   }
 ]
 ```

--- a/pkg/container-collection/container-collection.go
+++ b/pkg/container-collection/container-collection.go
@@ -23,6 +23,8 @@ package containercollection
 
 import (
 	"sync"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // ContainerCollection holds a set of containers. It can be embedded as an
@@ -222,8 +224,8 @@ func (cc *ContainerCollection) LookupPIDByPod(namespace, pod string) map[string]
 
 // LookupOwnerReferenceByMntns returns a pointer to the owner reference of the
 // container identified by the mount namespace, or nil if not found
-func (cc *ContainerCollection) LookupOwnerReferenceByMntns(mntns uint64) *OwnerReference {
-	var ownerRef *OwnerReference
+func (cc *ContainerCollection) LookupOwnerReferenceByMntns(mntns uint64) *metav1.OwnerReference {
+	var ownerRef *metav1.OwnerReference
 	cc.containers.Range(func(key, value interface{}) bool {
 		c := value.(*Container)
 		if mntns == c.Mntns {

--- a/pkg/container-collection/containers.go
+++ b/pkg/container-collection/containers.go
@@ -22,42 +22,42 @@ import (
 // Container represents a container with its metadata.
 type Container struct {
 	// ID is the container id, typically a 64 hexadecimal string
-	ID string
+	ID string `json:"id,omitempty"`
 
 	// Pid is the process id of the container
-	Pid uint32
+	Pid uint32 `json:"pid,omitempty"`
 
 	// Container's configuration is the config.json from the OCI runtime
 	// spec
-	OciConfig *ocispec.Spec
+	OciConfig *ocispec.Spec `json:"ociConfig,omitempty"`
 
 	// Bundle is the directory containing the config.json from the OCI
 	// runtime spec
 	// See https://github.com/opencontainers/runtime-spec/blob/main/bundle.md
-	Bundle string
+	Bundle string `json:"bundle,omitempty"`
 
 	// Linux metadata can be derived from the pid via /proc/$pid/...
-	Mntns      uint64
-	Netns      uint64
-	CgroupPath string
-	CgroupID   uint64
+	Mntns      uint64 `json:"mntns,omitempty"`
+	Netns      uint64 `json:"netns,omitempty"`
+	CgroupPath string `json:"cgroupPath,omitempty"`
+	CgroupID   uint64 `json:"cgroupID,omitempty"`
 	// Data required to find the container to Pod association in the
 	// gadgettracermanager.
-	CgroupV1 string
-	CgroupV2 string
+	CgroupV1 string `json:"cgroupV1,omitempty"`
+	CgroupV2 string `json:"cgroupV2,omitempty"`
 
 	// Kubernetes metadata
-	Namespace string
-	Podname   string
-	Name      string
-	Labels    map[string]string
+	Namespace string            `json:"namespace,omitempty"`
+	Podname   string            `json:"podname,omitempty"`
+	Name      string            `json:"name,omitempty"`
+	Labels    map[string]string `json:"labels,omitempty"`
 	// The owner reference information is added to the seccomp profile as
 	// annotations to help users to identify the workflow of the profile.
-	OwnerReference *metav1.OwnerReference
-	PodUID         string
+	OwnerReference *metav1.OwnerReference `json:"ownerReference,omitempty"`
+	PodUID         string                 `json:"podUID,omitempty"`
 
 	// Container Runtime metadata
-	Runtime string
+	Runtime string `json:"runtime,omitempty"`
 }
 
 type ContainerSelector struct {

--- a/pkg/container-collection/containers.go
+++ b/pkg/container-collection/containers.go
@@ -16,6 +16,7 @@ package containercollection
 
 import (
 	ocispec "github.com/opencontainers/runtime-spec/specs-go"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // Container represents a container with its metadata.
@@ -52,18 +53,11 @@ type Container struct {
 	Labels    map[string]string
 	// The owner reference information is added to the seccomp profile as
 	// annotations to help users to identify the workflow of the profile.
-	OwnerReference *OwnerReference
+	OwnerReference *metav1.OwnerReference
 	PodUID         string
 
 	// Container Runtime metadata
 	Runtime string
-}
-
-type OwnerReference struct {
-	Apiversion string
-	Kind       string
-	Name       string
-	UID        string
 }
 
 type ContainerSelector struct {

--- a/pkg/container-collection/interface.go
+++ b/pkg/container-collection/interface.go
@@ -14,6 +14,8 @@
 
 package containercollection
 
+import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 // ContainerResolver offers primitives to look up running containers with
 // various criteria, and to subscribe to container creation and termination.
 type ContainerResolver interface {
@@ -41,7 +43,7 @@ type ContainerResolver interface {
 
 	// LookupOwnerReferenceByMntns returns a pointer to the owner reference of the
 	// container identified by the mount namespace, or nil if not found
-	LookupOwnerReferenceByMntns(mntns uint64) *OwnerReference
+	LookupOwnerReferenceByMntns(mntns uint64) *metav1.OwnerReference
 
 	// GetContainersBySelector returns a slice of containers that match
 	// the selector or an empty slice if there are not matches

--- a/pkg/container-collection/match_test.go
+++ b/pkg/container-collection/match_test.go
@@ -18,6 +18,9 @@ import (
 	"fmt"
 	"reflect"
 	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 func TestSelector(t *testing.T) {
@@ -152,8 +155,8 @@ func TestContainerResolver(t *testing.T) {
 			Pid:        uint32(100 + i),
 			CgroupPath: "/none",
 			CgroupID:   1,
-			OwnerReference: &OwnerReference{
-				UID: fmt.Sprintf("abcde%d", i),
+			OwnerReference: &metav1.OwnerReference{
+				UID: types.UID(fmt.Sprintf("abcde%d", i)),
 			},
 		})
 	}

--- a/pkg/container-collection/options.go
+++ b/pkg/container-collection/options.go
@@ -429,11 +429,11 @@ func ownerReferenceEnrichment(
 
 	// Update container's owner reference (If any)
 	if highestOwnerRef != nil {
-		container.OwnerReference = &OwnerReference{
-			Apiversion: highestOwnerRef.APIVersion,
+		container.OwnerReference = &metav1.OwnerReference{
+			APIVersion: highestOwnerRef.APIVersion,
 			Kind:       highestOwnerRef.Kind,
 			Name:       highestOwnerRef.Name,
-			UID:        string(highestOwnerRef.UID),
+			UID:        highestOwnerRef.UID,
 		}
 	}
 

--- a/pkg/gadget-collection/gadgets/advise/seccomp/gadget.go
+++ b/pkg/gadget-collection/gadgets/advise/seccomp/gadget.go
@@ -24,6 +24,7 @@ import (
 	"sync"
 
 	log "github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apimachineryruntime "k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -96,8 +97,8 @@ SeccompProfiles will have the following annotations:
   traced
 * seccomp.gadget.kinvolk.io/container: the container name in the pod that was
   traced
-* seccomp.gadget.kinvolk.io/ownerReference-ApiVersion: the ownerReference's
-  ApiVersion of the pod that was traced
+* seccomp.gadget.kinvolk.io/ownerReference-APIVersion: the ownerReference's
+  APIVersion of the pod that was traced
 * seccomp.gadget.kinvolk.io/ownerReference-Kind: the ownerReference's Kind of the
   pod that was traced
 * seccomp.gadget.kinvolk.io/ownerReference-Name: the ownerReference's Name of the
@@ -181,7 +182,7 @@ func seccompProfileAddLabelsAndAnnotations(
 	trace *gadgetv1alpha1.Trace,
 	podName string,
 	containerName string,
-	ownerReference *containercollection.OwnerReference,
+	ownerReference *metav1.OwnerReference,
 ) {
 	traceName := fmt.Sprintf("%s/%s", trace.ObjectMeta.Namespace, trace.ObjectMeta.Name)
 	r.ObjectMeta.Annotations["seccomp.gadget.kinvolk.io/trace"] = traceName
@@ -189,10 +190,10 @@ func seccompProfileAddLabelsAndAnnotations(
 	r.ObjectMeta.Annotations["seccomp.gadget.kinvolk.io/pod"] = podName
 	r.ObjectMeta.Annotations["seccomp.gadget.kinvolk.io/container"] = containerName
 	if ownerReference != nil {
-		r.ObjectMeta.Annotations["seccomp.gadget.kinvolk.io/ownerReference-ApiVersion"] = ownerReference.Apiversion
+		r.ObjectMeta.Annotations["seccomp.gadget.kinvolk.io/ownerReference-APIVersion"] = ownerReference.APIVersion
 		r.ObjectMeta.Annotations["seccomp.gadget.kinvolk.io/ownerReference-Kind"] = ownerReference.Kind
 		r.ObjectMeta.Annotations["seccomp.gadget.kinvolk.io/ownerReference-Name"] = ownerReference.Name
-		r.ObjectMeta.Annotations["seccomp.gadget.kinvolk.io/ownerReference-UID"] = ownerReference.UID
+		r.ObjectMeta.Annotations["seccomp.gadget.kinvolk.io/ownerReference-UID"] = string(ownerReference.UID)
 	}
 
 	// Copy labels from the trace into the SeccompProfile. This will allow
@@ -303,7 +304,7 @@ func getSeccompProfileNsName(
 
 // generateSeccompPolicy generates a seccomp policy which is ready to be
 // created.
-func generateSeccompPolicy(client client.Client, trace *gadgetv1alpha1.Trace, syscalls []byte, podname, containername, fullPodName string, ownerReference *containercollection.OwnerReference) (*seccompprofile.SeccompProfile, error) {
+func generateSeccompPolicy(client client.Client, trace *gadgetv1alpha1.Trace, syscalls []byte, podname, containername, fullPodName string, ownerReference *metav1.OwnerReference) (*seccompprofile.SeccompProfile, error) {
 	profileName, err := getSeccompProfileNsName(
 		client,
 		trace.ObjectMeta.Namespace,


### PR DESCRIPTION
# Use OwnerReference from Kubernetes and add JSON tag to Container struct

We copied the OwnerReference definition in IG because it needed to be included in the gRPC interface. Since commit https://github.com/kinvolk/inspektor-gadget/commit/a84b26fd6525feb2cfe782292392c2e5ed9dde95, it is no longer in the gRPC interface, so we can now use the OwnerReference type from Kubernetes upstream.

In addition, add JSON tags to the Container struct because it is useful for the `local-gadget list-containers` command. 
