### PR TITLE
pkg/resources: Fix image tag in manifest

### DIFF
--- a/pkg/resources/manifests/deploy.yaml
+++ b/pkg/resources/manifests/deploy.yaml
@@ -109,7 +109,7 @@ spec:
       containers:
       - name: gadget
         terminationMessagePolicy: FallbackToLogsOnError
-        image: "ghcr.io/kinvolk/gadget"
+        image: "ghcr.io/kinvolk/inspektor-gadget:latest"
         imagePullPolicy: "Always"
         command: [ "/entrypoint.sh" ]
         lifecycle:


### PR DESCRIPTION
`kubectl apply -f pkg/resources/manifests/deploy.yaml` wasn't working because the image was wrong. 