### PR TITLE
gadgets/collect/process: Add missing Close() calls

### DIFF
--- a/pkg/gadgets/snapshot/process/tracer/tracer.go
+++ b/pkg/gadgets/snapshot/process/tracer/tracer.go
@@ -60,6 +60,7 @@ func RunCollector(enricher gadgets.DataEnricher, mntnsmap *ebpf.Map) ([]processc
 	if err != nil {
 		return nil, fmt.Errorf("failed to create BPF collection: %w", err)
 	}
+	defer coll.Close()
 
 	dumpTask, ok := coll.Programs[BPFIterName]
 	if !ok {
@@ -71,6 +72,7 @@ func RunCollector(enricher gadgets.DataEnricher, mntnsmap *ebpf.Map) ([]processc
 	if err != nil {
 		return nil, fmt.Errorf("failed to attach BPF iterator: %w", err)
 	}
+	defer dumpTaskIter.Close()
 
 	file, err := dumpTaskIter.Open()
 	if err != nil {

--- a/pkg/gadgets/snapshot/socket/tracer/tracer.go
+++ b/pkg/gadgets/snapshot/socket/tracer/tracer.go
@@ -109,6 +109,12 @@ func RunCollector(pid uint32, podname, namespace, node string, proto socketcolle
 	var it *link.Iter
 	iters := []*link.Iter{}
 
+	defer func() {
+		for _, it := range iters {
+			it.Close()
+		}
+	}()
+
 	if proto == socketcollectortypes.TCP || proto == socketcollectortypes.ALL {
 		it, err = getTCPIter()
 		if err != nil {


### PR DESCRIPTION
The documentation on NewCollectionWithOptions() states that
"Omitting Collection.Close() during application shutdown is an error.",
this commit fixes that by adding this missing line.

Even if AttachIter() doesn't state we should call Close() on the 
returned link, it's a good practice.


