### PR TITLE
cmd/kubectl-gadget/top: Use `BaseParser` to uniform and simplify gadgets

### DIFF
--- a/cmd/kubectl-gadget/main.go
+++ b/cmd/kubectl-gadget/main.go
@@ -44,7 +44,7 @@ func init() {
 	rootCmd.AddCommand(audit.NewAuditCmd())
 	rootCmd.AddCommand(profile.NewProfileCmd())
 	rootCmd.AddCommand(snapshot.NewSnapshotCmd())
-	rootCmd.AddCommand(top.TopCmd)
+	rootCmd.AddCommand(top.NewTopCmd())
 	rootCmd.AddCommand(trace.NewTraceCmd())
 }
 

--- a/cmd/kubectl-gadget/top/block-io.go
+++ b/cmd/kubectl-gadget/top/block-io.go
@@ -191,25 +191,17 @@ func (p *BlockIOParser) StartPrintLoop() {
 }
 
 func (p *BlockIOParser) PrintHeader() {
-	switch p.OutputConfig.OutputMode {
-	case commonutils.OutputModeColumns:
-		if term.IsTerminal(int(os.Stdout.Fd())) {
-			utils.ClearScreen()
-		} else {
-			fmt.Println("")
-		}
-
-		fmt.Printf("%-16s %-16s %-16s %-16s %-7s %-16s %-3s %-6s %-6s %-7s %-8s %s\n",
-			"NODE", "NAMESPACE", "POD", "CONTAINER",
-			"PID", "COMM", "R/W", "MAJOR", "MINOR", "BYTES", "TIME(µs)", "IOs")
-	case commonutils.OutputModeCustomColumns:
-		if term.IsTerminal(int(os.Stdout.Fd())) {
-			utils.ClearScreen()
-		} else {
-			fmt.Println("")
-		}
-		fmt.Println(p.GetCustomColsHeader(p.OutputConfig.CustomColumns))
+	if p.OutputConfig.OutputMode == commonutils.OutputModeJSON {
+		return
 	}
+
+	if term.IsTerminal(int(os.Stdout.Fd())) {
+		utils.ClearScreen()
+	} else {
+		fmt.Println("")
+	}
+
+	fmt.Println(p.BuildColumnsHeader())
 }
 
 func (p *BlockIOParser) PrintEvents() {
@@ -260,41 +252,6 @@ func (p *BlockIOParser) PrintEvents() {
 	}
 }
 
-func (p *BlockIOParser) GetCustomColsHeader(cols []string) string {
-	var sb strings.Builder
-
-	for _, col := range cols {
-		switch col {
-		case "node":
-			sb.WriteString(fmt.Sprintf("%-16s", "NODE"))
-		case "namespace":
-			sb.WriteString(fmt.Sprintf("%-16s", "NAMESPACE"))
-		case "pod":
-			sb.WriteString(fmt.Sprintf("%-16s", "POD"))
-		case "container":
-			sb.WriteString(fmt.Sprintf("%-16s", "CONTAINER"))
-		case "pid":
-			sb.WriteString(fmt.Sprintf("%-7s", "PID"))
-		case "comm":
-			sb.WriteString(fmt.Sprintf("%-16s", "COMM"))
-		case "r/w":
-			sb.WriteString(fmt.Sprintf("%-3s", "R/W"))
-		case "major":
-			sb.WriteString(fmt.Sprintf("%-6s", "MAJOR"))
-		case "minor":
-			sb.WriteString(fmt.Sprintf("%-6s", "MINOR"))
-		case "bytes":
-			sb.WriteString(fmt.Sprintf("%-7s", "BYTES"))
-		case "time":
-			sb.WriteString(fmt.Sprintf("%-8s", "TIME(µs)"))
-		case "ios":
-			sb.WriteString(fmt.Sprintf("%-8s", "IOs"))
-		}
-		sb.WriteRune(' ')
-	}
-
-	return sb.String()
-}
 
 func (p *BlockIOParser) FormatEventCustomCols(stats *types.Stats, cols []string) string {
 	var sb strings.Builder

--- a/cmd/kubectl-gadget/top/block-io.go
+++ b/cmd/kubectl-gadget/top/block-io.go
@@ -136,7 +136,7 @@ func newBlockIOCmd() *cobra.Command {
 			}
 
 			if singleShot {
-				parser.PrintEvents()
+				parser.PrintStats()
 			}
 
 			return nil
@@ -185,7 +185,7 @@ func (p *BlockIOParser) StartPrintLoop() {
 		for {
 			_ = <-ticker.C
 			p.PrintHeader()
-			p.PrintEvents()
+			p.PrintStats()
 		}
 	}()
 }
@@ -204,8 +204,8 @@ func (p *BlockIOParser) PrintHeader() {
 	fmt.Println(p.BuildColumnsHeader())
 }
 
-func (p *BlockIOParser) PrintEvents() {
-	// sort and print events
+func (p *BlockIOParser) PrintStats() {
+	// Sort and print stats
 	p.Lock()
 
 	stats := []types.Stats{}
@@ -222,11 +222,11 @@ func (p *BlockIOParser) PrintEvents() {
 		if idx == p.flags.MaxRows {
 			break
 		}
-		fmt.Println(p.FormatEventCustomCols(&stat))
+		fmt.Println(p.TransformStats(&stat))
 	}
 }
 
-func (p *BlockIOParser) FormatEventCustomCols(stats *types.Stats) string {
+func (p *BlockIOParser) TransformStats(stats *types.Stats) string {
 	return p.Transform(stats, func(stats *types.Stats) string {
 		var sb strings.Builder
 

--- a/cmd/kubectl-gadget/top/ebpf.go
+++ b/cmd/kubectl-gadget/top/ebpf.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	commonutils "github.com/kinvolk/inspektor-gadget/cmd/common/utils"
@@ -30,100 +31,148 @@ import (
 	"golang.org/x/term"
 )
 
-var ebpfNodeStats map[string][]types.Stats
+type EbpfFlags struct {
+	CommonTopFlags
 
-var ebpfSortBy types.SortBy
+	ParsedSortBy types.SortBy
+}
 
-var ebpfCmd = &cobra.Command{
-	Use:   fmt.Sprintf("ebpf [interval=%d]", types.IntervalDefault),
-	Short: "Periodically report ebpf runtime stats",
-	RunE: func(cmd *cobra.Command, args []string) error {
-		var err error
+type EbpfParser struct {
+	commonutils.BaseParser[types.Stats]
+	sync.Mutex
 
-		if params.NamespaceOverridden {
-			return commonutils.WrapInErrInvalidArg("--namespace / -n",
-				fmt.Errorf("this gadget cannot filter by namespace"))
-		}
-		if params.Podname != "" {
-			return commonutils.WrapInErrInvalidArg("--podname / -p",
-				fmt.Errorf("this gadget cannot filter by pod name"))
-		}
-		if params.Containername != "" {
-			return commonutils.WrapInErrInvalidArg("--containername / -c",
-				fmt.Errorf("this gadget cannot filter by container name"))
-		}
-		if len(params.Labels) > 0 {
-			return commonutils.WrapInErrInvalidArg("--selector / -l",
-				fmt.Errorf("this gadget cannot filter by selector"))
-		}
+	flags     *EbpfFlags
+	nodeStats map[string][]types.Stats
+}
 
-		ebpfNodeStats = make(map[string][]types.Stats)
+func newEbpfCmd() *cobra.Command {
+	var flags EbpfFlags
 
-		if len(args) == 1 {
-			outputInterval, err = strconv.Atoi(args[0])
-			if err != nil {
-				return commonutils.WrapInErrInvalidArg("<interval>",
-					fmt.Errorf("%q is not a valid value", args[0]))
-			}
-		} else {
-			outputInterval = types.IntervalDefault
-		}
-
-		config := &utils.TraceConfig{
-			GadgetName:       "ebpftop",
-			Operation:        "start",
-			TraceOutputMode:  "Stream",
-			TraceOutputState: "Started",
-			CommonFlags:      &params,
-			Parameters: map[string]string{
-				types.MaxRowsParam:  strconv.Itoa(maxRows),
-				types.IntervalParam: strconv.Itoa(outputInterval),
-				types.SortByParam:   sortBy,
+	commonFlags := &utils.CommonFlags{
+		OutputConfig: commonutils.OutputConfig{
+			// The columns that will be used in case the user does not specify
+			// which specific columns they want to print.
+			CustomColumns: []string{
+				"node",
+				"progid",
+				"type",
+				"name",
+				"pid",
+				"comm",
+				"runtime",
+				"runcount",
 			},
-		}
+		},
+	}
 
-		// when params.Timeout == interval it means the user
-		// only wants to run for a given amount of time and print
-		// that result.
-		singleShot := params.Timeout == outputInterval
+	columnsWidth := map[string]int{
+		"node":          -16,
+		"progid":        -8,
+		"type":          -16,
+		"name":          -16,
+		"pid":           -7,
+		"comm":          -20,
+		"runtime":       12,
+		"runcount":      10,
+		"totalruntime":  12,
+		"totalruncount": 13,
+	}
 
-		// start print loop if this is not a "single shoot" operation
-		if singleShot {
-			ebpfPrintHeader()
-		} else {
-			ebpfStartPrintLoop()
-		}
+	cmd := &cobra.Command{
+		Use:   fmt.Sprintf("ebpf [interval=%d]", types.IntervalDefault),
+		Short: "Periodically report ebpf runtime stats",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var err error
 
-		if err := utils.RunTraceStreamCallback(config, ebpfCallback); err != nil {
-			return commonutils.WrapInErrRunGadget(err)
-		}
+			parser := &EbpfParser{
+				BaseParser: commonutils.NewBaseWidthParser[types.Stats](columnsWidth, &commonFlags.OutputConfig),
+				flags:      &flags,
+				nodeStats:  make(map[string][]types.Stats),
+			}
 
-		if singleShot {
-			ebpfPrintEvents()
-		}
+			if len(args) == 1 {
+				flags.OutputInterval, err = strconv.Atoi(args[0])
+				if err != nil {
+					return commonutils.WrapInErrInvalidArg("<interval>",
+						fmt.Errorf("%q is not a valid value", args[0]))
+				}
+			} else {
+				flags.OutputInterval = types.IntervalDefault
+			}
 
-		return nil
-	},
-	SilenceUsage: true,
-	PreRunE: func(cmd *cobra.Command, args []string) error {
-		var err error
-		ebpfSortBy, err = types.ParseSortBy(sortBy)
-		if err != nil {
-			return commonutils.WrapInErrInvalidArg("--sort", err)
-		}
+			config := &utils.TraceConfig{
+				GadgetName:       "ebpftop",
+				Operation:        "start",
+				TraceOutputMode:  "Stream",
+				TraceOutputState: "Started",
+				CommonFlags:      commonFlags,
+				Parameters: map[string]string{
+					types.IntervalParam: strconv.Itoa(flags.OutputInterval),
+					types.MaxRowsParam:  strconv.Itoa(flags.MaxRows),
+					types.SortByParam:   flags.SortBy,
+				},
+			}
 
-		return nil
-	},
-	Args: cobra.MaximumNArgs(1),
+			// when params.Timeout == interval it means the user
+			// only wants to run for a given amount of time and print
+			// that result.
+			singleShot := commonFlags.Timeout == flags.OutputInterval
+
+			// start print loop if this is not a "single shot" operation
+			if singleShot {
+				parser.PrintHeader()
+			} else {
+				parser.StartPrintLoop()
+			}
+
+			if err := utils.RunTraceStreamCallback(config, parser.Callback); err != nil {
+				return commonutils.WrapInErrRunGadget(err)
+			}
+
+			if singleShot {
+				parser.PrintStats()
+			}
+
+			return nil
+		},
+		SilenceUsage: true,
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			var err error
+			flags.ParsedSortBy, err = types.ParseSortBy(flags.SortBy)
+			if err != nil {
+				return commonutils.WrapInErrInvalidArg("--sort", err)
+			}
+
+			if commonFlags.NamespaceOverridden {
+				return commonutils.WrapInErrInvalidArg("--namespace / -n",
+					fmt.Errorf("this gadget cannot filter by namespace"))
+			}
+			if commonFlags.Podname != "" {
+				return commonutils.WrapInErrInvalidArg("--podname / -p",
+					fmt.Errorf("this gadget cannot filter by pod name"))
+			}
+			if commonFlags.Containername != "" {
+				return commonutils.WrapInErrInvalidArg("--containername / -c",
+					fmt.Errorf("this gadget cannot filter by container name"))
+			}
+			if len(commonFlags.Labels) > 0 {
+				return commonutils.WrapInErrInvalidArg("--selector / -l",
+					fmt.Errorf("this gadget cannot filter by selector"))
+			}
+
+			return nil
+		},
+		Args: cobra.MaximumNArgs(1),
+	}
+
+	addCommonTopFlags(cmd, &flags.CommonTopFlags, commonFlags, types.MaxRowsDefault, types.SortBySlice)
+
+	return cmd
 }
 
-func init() {
-	addTopCommand(ebpfCmd, types.MaxRowsDefault, types.SortBySlice)
-}
-
-func ebpfCallback(line string, node string) {
-	mutex.Lock()
-	defer mutex.Unlock()
+func (p *EbpfParser) Callback(line string, node string) {
+	p.Lock()
+	defer p.Unlock()
 
 	var event types.Event
 
@@ -137,171 +186,98 @@ func ebpfCallback(line string, node string) {
 		return
 	}
 
-	ebpfNodeStats[node] = event.Stats
+	p.nodeStats[node] = event.Stats
 }
 
-func ebpfStartPrintLoop() {
+func (p *EbpfParser) StartPrintLoop() {
 	go func() {
-		ticker := time.NewTicker(time.Duration(outputInterval) * time.Second)
-		ebpfPrintHeader()
+		ticker := time.NewTicker(time.Duration(p.flags.OutputInterval) * time.Second)
+		p.PrintHeader()
 		for {
 			_ = <-ticker.C
-			ebpfPrintHeader()
-			ebpfPrintEvents()
+			p.PrintHeader()
+			p.PrintStats()
 		}
 	}()
 }
 
-func ebpfPrintHeader() {
-	switch params.OutputMode {
-	case commonutils.OutputModeColumns:
-		if term.IsTerminal(int(os.Stdout.Fd())) {
-			utils.ClearScreen()
-		} else {
-			fmt.Println("")
-		}
-		fmt.Printf("%-16s %-8s %-16s %-16s %-7s %-20s %12s %10s\n",
-			"NODE",
-			"PROGID",
-			"TYPE",
-			"NAME",
-			"PID", "COMM",
-			"RUNTIME",
-			"RUNCOUNT",
-		)
-	case commonutils.OutputModeCustomColumns:
-		if term.IsTerminal(int(os.Stdout.Fd())) {
-			utils.ClearScreen()
-		} else {
-			fmt.Println("")
-		}
-		fmt.Println(ebpfGetCustomColsHeader(params.CustomColumns))
+func (p *EbpfParser) PrintHeader() {
+	if p.OutputConfig.OutputMode == commonutils.OutputModeJSON {
+		return
 	}
+
+	if term.IsTerminal(int(os.Stdout.Fd())) {
+		utils.ClearScreen()
+	} else {
+		fmt.Println("")
+	}
+
+	fmt.Println(p.BuildColumnsHeader())
 }
 
-func ebpfPrintEvents() {
-	// sort and print events
-	mutex.Lock()
+func (p *EbpfParser) PrintStats() {
+	// Sort and print stats
+	p.Lock()
 
 	stats := []types.Stats{}
-	for node, stat := range ebpfNodeStats {
+	for node, stat := range p.nodeStats {
 		for i := range stat {
 			stat[i].Node = node
 		}
 		stats = append(stats, stat...)
 	}
-	ebpfNodeStats = make(map[string][]types.Stats)
+	p.nodeStats = make(map[string][]types.Stats)
 
-	mutex.Unlock()
+	p.Unlock()
 
-	types.SortStats(stats, ebpfSortBy)
+	types.SortStats(stats, p.flags.ParsedSortBy)
 
-	switch params.OutputMode {
-	case commonutils.OutputModeColumns:
-		for idx, event := range stats {
-			if idx == maxRows {
-				break
-			}
-			pid := ""
-			comm := ""
-			if len(event.Pids) > 0 {
-				pid = strconv.Itoa(int(event.Pids[0].Pid))
-				comm = event.Pids[0].Comm
-			}
-			fmt.Printf("%-16s %-8d %-16s %-16s %-7s %-20s %12v %10d\n",
-				event.Node,
-				event.ProgramID,
-				event.Type,
-				event.Name,
-				pid, comm,
-				time.Duration(event.CurrentRuntime),
-				event.CurrentRunCount,
-			)
-
+	for idx, stat := range stats {
+		if idx == p.flags.MaxRows {
+			break
 		}
-	case commonutils.OutputModeJSON:
-		b, err := json.Marshal(stats)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error: %s", commonutils.WrapInErrMarshalOutput(err))
-			return
-		}
-		fmt.Println(string(b))
-	case commonutils.OutputModeCustomColumns:
-		for idx, stat := range stats {
-			if idx == maxRows {
-				break
-			}
-			fmt.Println(ebpfFormatEventCustomCols(&stat, params.CustomColumns))
-		}
+		fmt.Println(p.TransformStats(&stat))
 	}
 }
 
-func ebpfGetCustomColsHeader(cols []string) string {
-	var sb strings.Builder
+func (p *EbpfParser) TransformStats(stats *types.Stats) string {
+	return p.Transform(stats, func(stats *types.Stats) string {
+		var sb strings.Builder
 
-	for _, col := range cols {
-		switch col {
-		case "node":
-			sb.WriteString(fmt.Sprintf("%-16s", "NODE"))
-		case "progid":
-			sb.WriteString(fmt.Sprintf("%-8s", "PROGID"))
-		case "type":
-			sb.WriteString(fmt.Sprintf("%-16s", "TYPE"))
-		case "name":
-			sb.WriteString(fmt.Sprintf("%-16s", "NAME"))
-		case "pid":
-			sb.WriteString(fmt.Sprintf("%-7s", "PID"))
-		case "comm":
-			sb.WriteString(fmt.Sprintf("%-20s", "COMM"))
-		case "runtime":
-			sb.WriteString(fmt.Sprintf("%12s", "RUNTIME"))
-		case "runcount":
-			sb.WriteString(fmt.Sprintf("%10s", "RUNCOUNT"))
-		case "totalruntime":
-			sb.WriteString(fmt.Sprintf("%12s", "T-RUNTIME"))
-		case "totalruncount":
-			sb.WriteString(fmt.Sprintf("%11s", "T-RUNCOUNT"))
-		}
-		sb.WriteRune(' ')
-	}
-
-	return sb.String()
-}
-
-func ebpfFormatEventCustomCols(stats *types.Stats, cols []string) string {
-	var sb strings.Builder
-	for _, col := range cols {
-		switch col {
-		case "node":
-			sb.WriteString(fmt.Sprintf("%-16s", stats.Node))
-		case "progid":
-			sb.WriteString(fmt.Sprintf("%-8d", stats.ProgramID))
-		case "type":
-			sb.WriteString(fmt.Sprintf("%-16s", stats.Type))
-		case "name":
-			sb.WriteString(fmt.Sprintf("%-16s", stats.Name))
-		case "pid":
-			pid := ""
-			if len(stats.Pids) > 0 {
-				pid = fmt.Sprintf("%d", stats.Pids[0].Pid)
+		for _, col := range p.OutputConfig.CustomColumns {
+			switch col {
+			case "node":
+				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], stats.Node))
+			case "progid":
+				sb.WriteString(fmt.Sprintf("%*d", p.ColumnsWidth[col], stats.ProgramID))
+			case "type":
+				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], stats.Type))
+			case "name":
+				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], stats.Name))
+			case "pid":
+				pid := ""
+				if len(stats.Pids) > 0 {
+					pid = fmt.Sprintf("%d", stats.Pids[0].Pid)
+				}
+				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], pid))
+			case "comm":
+				comm := ""
+				if len(stats.Pids) > 0 {
+					comm = stats.Pids[0].Comm
+				}
+				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], comm))
+			case "runtime":
+				sb.WriteString(fmt.Sprintf("%*v", p.ColumnsWidth[col], time.Duration(stats.CurrentRuntime)))
+			case "runcount":
+				sb.WriteString(fmt.Sprintf("%*d", p.ColumnsWidth[col], stats.CurrentRunCount))
+			case "totalruntime":
+				sb.WriteString(fmt.Sprintf("%*v", p.ColumnsWidth[col], time.Duration(stats.TotalRuntime)))
+			case "totalruncount":
+				sb.WriteString(fmt.Sprintf("%*d", p.ColumnsWidth[col], stats.TotalRunCount))
 			}
-			sb.WriteString(fmt.Sprintf("%-7s", pid))
-		case "comm":
-			comm := ""
-			if len(stats.Pids) > 0 {
-				comm = stats.Pids[0].Comm
-			}
-			sb.WriteString(fmt.Sprintf("%-20s", comm))
-		case "runtime":
-			sb.WriteString(fmt.Sprintf("%12v", time.Duration(stats.CurrentRuntime)))
-		case "runcount":
-			sb.WriteString(fmt.Sprintf("%10d", stats.CurrentRunCount))
-		case "totalruntime":
-			sb.WriteString(fmt.Sprintf("%12v", time.Duration(stats.TotalRuntime)))
-		case "totalruncount":
-			sb.WriteString(fmt.Sprintf("%11d", stats.TotalRunCount))
+			sb.WriteRune(' ')
 		}
-		sb.WriteRune(' ')
-	}
-	return sb.String()
+
+		return sb.String()
+	})
 }

--- a/cmd/kubectl-gadget/top/file.go
+++ b/cmd/kubectl-gadget/top/file.go
@@ -196,24 +196,17 @@ func (p *FileParser) StartPrintLoop() {
 }
 
 func (p *FileParser) PrintHeader() {
-	switch p.OutputConfig.OutputMode {
-	case commonutils.OutputModeColumns:
-		if term.IsTerminal(int(os.Stdout.Fd())) {
-			utils.ClearScreen()
-		} else {
-			fmt.Println("")
-		}
-		fmt.Printf("%-16s %-16s %-16s %-16s %-7s %-16s %-6s %-6s %-7s %-7s %1s %s\n",
-			"NODE", "NAMESPACE", "POD", "CONTAINER",
-			"PID", "COMM", "READS", "WRITES", "R_Kb", "W_Kb", "T", "FILE")
-	case commonutils.OutputModeCustomColumns:
-		if term.IsTerminal(int(os.Stdout.Fd())) {
-			utils.ClearScreen()
-		} else {
-			fmt.Println("")
-		}
-		fmt.Println(p.GetCustomColsHeader(p.OutputConfig.CustomColumns))
+	if p.OutputConfig.OutputMode == commonutils.OutputModeJSON {
+		return
 	}
+
+	if term.IsTerminal(int(os.Stdout.Fd())) {
+		utils.ClearScreen()
+	} else {
+		fmt.Println("")
+	}
+
+	fmt.Println(p.BuildColumnsHeader())
 }
 
 func (p *FileParser) PrintEvents() {
@@ -256,44 +249,6 @@ func (p *FileParser) PrintEvents() {
 			fmt.Println(p.FormatEventCustomCols(&stat, p.OutputConfig.CustomColumns))
 		}
 	}
-}
-
-func (p *FileParser) GetCustomColsHeader(cols []string) string {
-	var sb strings.Builder
-
-	for _, col := range cols {
-		switch col {
-		case "node":
-			sb.WriteString(fmt.Sprintf("%-16s", "NODE"))
-		case "namespace":
-			sb.WriteString(fmt.Sprintf("%-16s", "NAMESPACE"))
-		case "pod":
-			sb.WriteString(fmt.Sprintf("%-16s", "POD"))
-		case "container":
-			sb.WriteString(fmt.Sprintf("%-16s", "CONTAINER"))
-		case "pid":
-			sb.WriteString(fmt.Sprintf("%-7s", "PID"))
-		case "tid":
-			sb.WriteString(fmt.Sprintf("%-7s", "TID"))
-		case "comm":
-			sb.WriteString(fmt.Sprintf("%-16s", "COMM"))
-		case "reads":
-			sb.WriteString(fmt.Sprintf("%-6s", "READS"))
-		case "writes":
-			sb.WriteString(fmt.Sprintf("%-6s", "WRITES"))
-		case "r_kb":
-			sb.WriteString(fmt.Sprintf("%-7s", "R_kb"))
-		case "w_kb":
-			sb.WriteString(fmt.Sprintf("%-7s", "W_kb"))
-		case "t":
-			sb.WriteString(fmt.Sprintf("%s", "T"))
-		case "file":
-			sb.WriteString(fmt.Sprintf("%s", "FILE"))
-		}
-		sb.WriteRune(' ')
-	}
-
-	return sb.String()
 }
 
 func (p *FileParser) FormatEventCustomCols(stats *types.Stats, cols []string) string {

--- a/cmd/kubectl-gadget/top/file.go
+++ b/cmd/kubectl-gadget/top/file.go
@@ -139,7 +139,7 @@ func newFileCmd() *cobra.Command {
 			}
 
 			if singleShot {
-				parser.PrintEvents()
+				parser.PrintStats()
 			}
 
 			return nil
@@ -190,7 +190,7 @@ func (p *FileParser) StartPrintLoop() {
 		for {
 			_ = <-ticker.C
 			p.PrintHeader()
-			p.PrintEvents()
+			p.PrintStats()
 		}
 	}()
 }
@@ -209,8 +209,8 @@ func (p *FileParser) PrintHeader() {
 	fmt.Println(p.BuildColumnsHeader())
 }
 
-func (p *FileParser) PrintEvents() {
-	// sort and print events
+func (p *FileParser) PrintStats() {
+	// Sort and print stats
 	p.Lock()
 
 	stats := []types.Stats{}
@@ -227,11 +227,11 @@ func (p *FileParser) PrintEvents() {
 		if idx == p.flags.MaxRows {
 			break
 		}
-		fmt.Println(p.FormatEventCustomCols(&stat))
+		fmt.Println(p.TransformStats(&stat))
 	}
 }
 
-func (p *FileParser) FormatEventCustomCols(stats *types.Stats) string {
+func (p *FileParser) TransformStats(stats *types.Stats) string {
 	return p.Transform(stats, func(stats *types.Stats) string {
 		var sb strings.Builder
 

--- a/cmd/kubectl-gadget/top/tcp.go
+++ b/cmd/kubectl-gadget/top/tcp.go
@@ -146,7 +146,7 @@ func newTCPCmd() *cobra.Command {
 			}
 
 			if singleShot {
-				parser.PrintEvents()
+				parser.PrintStats()
 			}
 
 			return nil
@@ -210,7 +210,7 @@ func (p *TCPParser) StartPrintLoop() {
 		for {
 			_ = <-ticker.C
 			p.PrintHeader()
-			p.PrintEvents()
+			p.PrintStats()
 		}
 	}()
 }
@@ -229,8 +229,8 @@ func (p *TCPParser) PrintHeader() {
 	fmt.Println(p.BuildColumnsHeader())
 }
 
-func (p *TCPParser) PrintEvents() {
-	// sort and print events
+func (p *TCPParser) PrintStats() {
+	// Sort and print stats
 	p.Lock()
 
 	stats := []types.Stats{}
@@ -247,11 +247,11 @@ func (p *TCPParser) PrintEvents() {
 		if idx == p.flags.MaxRows {
 			break
 		}
-		fmt.Println(p.FormatEventCustomCols(&stat))
+		fmt.Println(p.TransformStats(&stat))
 	}
 }
 
-func (p *TCPParser) FormatEventCustomCols(stats *types.Stats) string {
+func (p *TCPParser) TransformStats(stats *types.Stats) string {
 	return p.Transform(stats, func(stats *types.Stats) string {
 		var sb strings.Builder
 

--- a/cmd/kubectl-gadget/top/tcp.go
+++ b/cmd/kubectl-gadget/top/tcp.go
@@ -216,24 +216,17 @@ func (p *TCPParser) StartPrintLoop() {
 }
 
 func (p *TCPParser) PrintHeader() {
-	switch p.OutputConfig.OutputMode {
-	case commonutils.OutputModeColumns:
-		if term.IsTerminal(int(os.Stdout.Fd())) {
-			utils.ClearScreen()
-		} else {
-			fmt.Println("")
-		}
-		fmt.Printf("%-16s %-16s %-16s %-16s %-7s %-16s %-3s %-51s %-51s %-7s %s\n",
-			"NODE", "NAMESPACE", "POD", "CONTAINER",
-			"PID", "COMM", "IPv", "LADDR", "RADDR", "RX_KB", "TX_KB")
-	case commonutils.OutputModeCustomColumns:
-		if term.IsTerminal(int(os.Stdout.Fd())) {
-			utils.ClearScreen()
-		} else {
-			fmt.Println("")
-		}
-		fmt.Println(p.GetCustomColsHeader(p.OutputConfig.CustomColumns))
+	if p.OutputConfig.OutputMode == commonutils.OutputModeJSON {
+		return
 	}
+
+	if term.IsTerminal(int(os.Stdout.Fd())) {
+		utils.ClearScreen()
+	} else {
+		fmt.Println("")
+	}
+
+	fmt.Println(p.BuildColumnsHeader())
 }
 
 func (p *TCPParser) PrintEvents() {
@@ -286,39 +279,6 @@ func (p *TCPParser) PrintEvents() {
 	}
 }
 
-func (p *TCPParser) GetCustomColsHeader(cols []string) string {
-	var sb strings.Builder
-
-	for _, col := range cols {
-		switch col {
-		case "node":
-			sb.WriteString(fmt.Sprintf("%-16s", "NODE"))
-		case "namespace":
-			sb.WriteString(fmt.Sprintf("%-16s", "NAMESPACE"))
-		case "pod":
-			sb.WriteString(fmt.Sprintf("%-16s", "POD"))
-		case "container":
-			sb.WriteString(fmt.Sprintf("%-16s", "CONTAINER"))
-		case "pid":
-			sb.WriteString(fmt.Sprintf("%-7s", "PID"))
-		case "comm":
-			sb.WriteString(fmt.Sprintf("%-16s", "COMM"))
-		case "family":
-			sb.WriteString(fmt.Sprintf("%-3s", "IPv"))
-		case "saddr":
-			sb.WriteString(fmt.Sprintf("%-51s", "LADDR"))
-		case "daddr":
-			sb.WriteString(fmt.Sprintf("%-51s", "DADDR"))
-		case "sent":
-			sb.WriteString(fmt.Sprintf("%-7s", "TX_KB"))
-		case "received":
-			sb.WriteString(fmt.Sprintf("%-7s", "RX_KB"))
-		}
-		sb.WriteRune(' ')
-	}
-
-	return sb.String()
-}
 
 func (p *TCPParser) FormatEventCustomCols(stats *types.Stats, cols []string) string {
 	var sb strings.Builder

--- a/cmd/kubectl-gadget/top/tcp.go
+++ b/cmd/kubectl-gadget/top/tcp.go
@@ -62,7 +62,7 @@ func newTCPCmd() *cobra.Command {
 				"container",
 				"pid",
 				"comm",
-				"family",
+				"ip",
 				"saddr",
 				"daddr",
 				"sent",
@@ -78,7 +78,7 @@ func newTCPCmd() *cobra.Command {
 		"container": -16,
 		"pid":       -7,
 		"comm":      -16,
-		"family":    -3,
+		"ip":        -3,
 		"saddr":     -51,
 		"daddr":     -51,
 		"sent":      -7,
@@ -269,7 +269,7 @@ func (p *TCPParser) FormatEventCustomCols(stats *types.Stats) string {
 				sb.WriteString(fmt.Sprintf("%*d", p.ColumnsWidth[col], stats.Pid))
 			case "comm":
 				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], stats.Comm))
-			case "family":
+			case "ip":
 				tcpFamily := 4
 				if stats.Family == syscall.AF_INET6 {
 					tcpFamily = 6

--- a/cmd/kubectl-gadget/top/top.go
+++ b/cmd/kubectl-gadget/top/top.go
@@ -17,31 +17,40 @@ package top
 import (
 	"fmt"
 	"strings"
-	"sync"
 
 	"github.com/kinvolk/inspektor-gadget/cmd/kubectl-gadget/utils"
 
 	"github.com/spf13/cobra"
 )
 
-var (
-	params utils.CommonFlags
-	mutex  sync.Mutex
-
-	outputInterval int
-	maxRows        int
-	sortBy         string
-)
-
-var TopCmd = &cobra.Command{
-	Use:   "top",
-	Short: "Gather, sort and periodically report events according to a given criteria",
+type CommonTopFlags struct {
+	OutputInterval int
+	MaxRows        int
+	SortBy         string
 }
 
-func addTopCommand(command *cobra.Command, defaultMaxRows int, sortBySlice []string) {
-	command.Flags().IntVarP(&maxRows, "max-rows", "r", defaultMaxRows, "Maximum rows to print")
-	command.Flags().StringVarP(&sortBy, "sort", "", sortBySlice[0], fmt.Sprintf("Sort column, possible values are: %s", strings.Join(sortBySlice, ", ")))
+func NewTopCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "top",
+		Short: "Gather, sort and periodically report events according to a given criteria",
+	}
 
-	utils.AddCommonFlags(command, &params)
-	TopCmd.AddCommand(command)
+	cmd.AddCommand(newBlockIOCmd())
+	cmd.AddCommand(newFileCmd())
+	cmd.AddCommand(newTCPCmd())
+
+	return cmd
+}
+
+func addCommonTopFlags(
+	command *cobra.Command,
+	commonTopFlags *CommonTopFlags,
+	commonFlags *utils.CommonFlags,
+	defaultMaxRows int,
+	sortBySlice []string,
+) {
+	command.Flags().IntVarP(&commonTopFlags.MaxRows, "max-rows", "r", defaultMaxRows, "Maximum rows to print")
+	command.Flags().StringVarP(&commonTopFlags.SortBy, "sort", "", sortBySlice[0], fmt.Sprintf("Sort column, possible values are: %s", strings.Join(sortBySlice, ", ")))
+
+	utils.AddCommonFlags(command, commonFlags)
 }

--- a/cmd/kubectl-gadget/top/top.go
+++ b/cmd/kubectl-gadget/top/top.go
@@ -51,7 +51,7 @@ func addCommonTopFlags(
 	sortBySlice []string,
 ) {
 	command.Flags().IntVarP(&commonTopFlags.MaxRows, "max-rows", "r", defaultMaxRows, "Maximum rows to print")
-	command.Flags().StringVarP(&commonTopFlags.SortBy, "sort", "", sortBySlice[0], fmt.Sprintf("Sort column, possible values are: %s", strings.Join(sortBySlice, ", ")))
+	command.Flags().StringVarP(&commonTopFlags.SortBy, "sort", "", sortBySlice[0], fmt.Sprintf("Sort column (%s)", strings.Join(sortBySlice, ", ")))
 
 	utils.AddCommonFlags(command, commonFlags)
 }

--- a/cmd/kubectl-gadget/top/top.go
+++ b/cmd/kubectl-gadget/top/top.go
@@ -36,6 +36,7 @@ func NewTopCmd() *cobra.Command {
 	}
 
 	cmd.AddCommand(newBlockIOCmd())
+	cmd.AddCommand(newEbpfCmd())
 	cmd.AddCommand(newFileCmd())
 	cmd.AddCommand(newTCPCmd())
 


### PR DESCRIPTION
# Use `BaseParser` to uniform and simplify top category gadgets

This PR modifies the top category gadgets to use `BaseParser` so that they don't have to implement the logic to print the header and transform stats to columns.

This PR doesn't modify the logic or current behaviour of the gadgets. This PR aims to uniform this category with the rest of the categories so we can manage the two mentioned logics from a single place for all the gadgets. For instance, combine the `OutputModeColumns` and `OutputModeCustomColumns`, and printing the columns that can be used with the `custom-columns` flag.

## How to use

These changes don't have any impact on the user.
