### PR TITLE
audit/seccomp: Remove node parameter from tracer

### DIFF
--- a/pkg/gadget-collection/gadgets/audit/seccomp/gadget.go
+++ b/pkg/gadget-collection/gadgets/audit/seccomp/gadget.go
@@ -98,6 +98,8 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 
 	traceName := gadgets.TraceName(trace.ObjectMeta.Namespace, trace.ObjectMeta.Name)
 	eventCallback := func(event types.Event) {
+		event.Node = trace.Spec.Node
+
 		t.helpers.PublishEvent(
 			traceName,
 			eventtypes.EventString(event),
@@ -116,7 +118,7 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 		MountnsMap:    mountNsMap,
 		ContainersMap: t.helpers.ContainersMap(),
 	}
-	t.tracer, err = auditseccomptracer.NewTracer(config, eventCallback, trace.Spec.Node)
+	t.tracer, err = auditseccomptracer.NewTracer(config, eventCallback)
 	if err != nil {
 		trace.Status.OperationError = fmt.Sprintf("Failed to start audit seccomp tracer: %s", err)
 		return

--- a/pkg/gadgets/audit/seccomp/tracer/tracer.go
+++ b/pkg/gadgets/audit/seccomp/tracer/tracer.go
@@ -43,7 +43,6 @@ const (
 type Tracer struct {
 	config        *Config
 	eventCallback func(types.Event)
-	node          string
 
 	collection *ebpf.Collection
 	eventMap   *ebpf.Map
@@ -61,7 +60,7 @@ type Config struct {
 	MountnsMap    *ebpf.Map
 }
 
-func NewTracer(config *Config, eventCallback func(types.Event), node string) (*Tracer, error) {
+func NewTracer(config *Config, eventCallback func(types.Event)) (*Tracer, error) {
 	var err error
 	var spec *ebpf.CollectionSpec
 
@@ -97,7 +96,6 @@ func NewTracer(config *Config, eventCallback func(types.Event), node string) (*T
 	t := &Tracer{
 		config:        config,
 		eventCallback: eventCallback,
-		node:          node,
 		collection:    coll,
 		eventMap:      coll.Maps[BPFMapName],
 		reader:        rd,
@@ -144,7 +142,6 @@ func (t *Tracer) run() {
 			Event: eventtypes.Event{
 				Type: eventtypes.NORMAL,
 				CommonData: eventtypes.CommonData{
-					Node: t.node,
 					// Get 'Namespace', 'Pod' and 'Container' from
 					// BPF and not from the gadget helpers  because the
 					// container might be terminated immediately


### PR DESCRIPTION
# Remove node parameter from audit/seccomp tracer

Enriching the event with node information on the gadget-collection side allows using the tracer from outside a Kubernetes context. For instance, from local-gadget or 3rd party apps using IG packages. 

## How to use

No changes for users.
