### PR TITLE
audit/seccomp: Move parser to common folder

### DIFF
--- a/cmd/common/audit/seccomp.go
+++ b/cmd/common/audit/seccomp.go
@@ -41,6 +41,7 @@ func newSeccompParser(outputConfig *commonutils.OutputConfig, prependK8sMetadata
 		"comm":      -16,
 		"syscall":   -16,
 		"code":      -16,
+		"mntns":     -12,
 	}
 
 	if len(outputConfig.CustomColumns) == 0 {
@@ -85,6 +86,8 @@ func (p *SeccompParser) TransformEvent(e *types.Event) string {
 				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], e.Syscall))
 			case "code":
 				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], e.Code))
+			case "mntns":
+				sb.WriteString(fmt.Sprintf("%*d", p.ColumnsWidth[col], e.MountNsID))
 			default:
 				continue
 			}

--- a/cmd/common/audit/seccomp.go
+++ b/cmd/common/audit/seccomp.go
@@ -1,0 +1,109 @@
+// Copyright 2022 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package audit
+
+import (
+	"fmt"
+	"strings"
+
+	commonutils "github.com/kinvolk/inspektor-gadget/cmd/common/utils"
+	"github.com/kinvolk/inspektor-gadget/pkg/gadgets/audit/seccomp/types"
+)
+
+type SeccompParser struct {
+	commonutils.BaseParser[types.Event]
+}
+
+// newSeccompParser returns a parser already configured to manage the output of
+// the audit/seccomp gadget. Consider that outputConfig describes how to print
+// the gadget's output and prependK8sMetadata indicates whether to prepend
+// the Kubernetes metadata columns or not.
+func newSeccompParser(outputConfig *commonutils.OutputConfig, prependK8sMetadata bool) *SeccompParser {
+	columnsWidth := map[string]int{
+		// TODO: Move Kubernetes metadata columns to common/utils.
+		"node":      -16,
+		"namespace": -16,
+		"pod":       -30,
+		"container": -16,
+		"pid":       -7,
+		"comm":      -16,
+		"syscall":   -16,
+		"code":      -16,
+	}
+
+	if len(outputConfig.CustomColumns) == 0 {
+		outputConfig.CustomColumns = GetSeccompDefaultColumns()
+		if prependK8sMetadata {
+			outputConfig.CustomColumns = append(commonutils.GetKubernetesColumns(), outputConfig.CustomColumns...)
+		}
+	}
+
+	return &SeccompParser{
+		BaseParser: commonutils.NewBaseWidthParser[types.Event](columnsWidth, outputConfig),
+	}
+}
+
+func NewSeccompK8sParser(outputConfig *commonutils.OutputConfig) *SeccompParser {
+	return newSeccompParser(outputConfig, true)
+}
+
+func NewSeccompParser(outputConfig *commonutils.OutputConfig) *SeccompParser {
+	return newSeccompParser(outputConfig, false)
+}
+
+func (p *SeccompParser) TransformEvent(e *types.Event) string {
+	return p.Transform(e, func(e *types.Event) string {
+		var sb strings.Builder
+
+		for _, col := range p.OutputConfig.CustomColumns {
+			switch col {
+			case "node":
+				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], e.Node))
+			case "namespace":
+				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], e.Namespace))
+			case "pod":
+				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], e.Pod))
+			case "container":
+				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], e.Container))
+			case "pid":
+				sb.WriteString(fmt.Sprintf("%*d", p.ColumnsWidth[col], e.Pid))
+			case "comm":
+				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], e.Comm))
+			case "syscall":
+				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], e.Syscall))
+			case "code":
+				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], e.Code))
+			default:
+				continue
+			}
+
+			// Needed when field is larger than the predefined columnsWidth.
+			sb.WriteRune(' ')
+		}
+
+		return sb.String()
+	})
+}
+
+func GetSeccompDefaultColumns() []string {
+	// The columns that will be used in case the user does not specify which
+	// specific columns they want to print through OutputConfig.
+	return []string{
+		"pid",
+		"comm",
+		"syscall",
+		"code",
+	}
+}

--- a/cmd/common/utils/parser.go
+++ b/cmd/common/utils/parser.go
@@ -120,3 +120,12 @@ func (p *BaseParser[E]) Transform(element *E, toColumns func(*E) string) string 
 func (p *BaseParser[E]) GetOutputConfig() *OutputConfig {
 	return p.OutputConfig
 }
+
+func GetKubernetesColumns() []string {
+	return []string{
+		"node",
+		"namespace",
+		"pod",
+		"container",
+	}
+}

--- a/docs/guides/audit/seccomp.md
+++ b/docs/guides/audit/seccomp.md
@@ -125,5 +125,5 @@ Bad system call (core dumped)
 * Observe the syscalls logged by seccomp in the first terminal.
 
 ```json
-{"type":"normal","node":"local","namespace":"default","pod":"laughing_tharp","container":"laughing_tharp","syscall":"unshare","code":"log","pid":949262,"mountnsid":4026532756,"pcomm":"unshare"}
+{"type":"normal","node":"local","namespace":"default","pod":"laughing_tharp","container":"laughing_tharp","syscall":"unshare","code":"log","pid":949262,"mntns":4026532756,"comm":"unshare"}
 ```

--- a/pkg/gadgets/audit/seccomp/types/types.go
+++ b/pkg/gadgets/audit/seccomp/types/types.go
@@ -24,8 +24,8 @@ type Event struct {
 	Syscall   string `json:"syscall,omitempty"`
 	Code      string `json:"code,omitempty"`
 	Pid       uint32 `json:"pid,omitempty"`
-	MountNsID uint64 `json:"mountnsid,omitempty"`
-	Comm      string `json:"pcomm,omitempty"`
+	MountNsID uint64 `json:"mntns,omitempty"`
+	Comm      string `json:"comm,omitempty"`
 }
 
 func Base(ev eventtypes.Event) Event {


### PR DESCRIPTION
# Move audit/seccomp parser to common folder

By moving the parser code to the `common` folder, we are allowing 3rd party apps to use it without importing the code of kubectl-gadget. In addition, there is no need to specify the columns to be printed by default, only if one wants to specify exactly which ones to print. Check the example below.

This is the first step to running the audit/seccomp gadget from `local-gadget` using the tracer directly instead of passing through the CRD.

Once we agree it is the correct approach, I will do the same work for the rest of the gadgets.

## How to use

For `kubectl-gadget` nothing changes. Instead, after this PR, unlike [this example](https://github.com/kinvolk/inspektor-gadget/pull/764#pullrequestreview-1054463622) for the trace/exec gadget, the audit/seccomp gadget parse can be used by importing only packages on the common folder that containers precisely what they need to parse the output. See this example:

```go
package main

import (
	"flag"
	"fmt"
	"os"
	"os/signal"

	"github.com/cilium/ebpf/rlimit"

	"github.com/kinvolk/inspektor-gadget/cmd/common/audit"
	"github.com/kinvolk/inspektor-gadget/cmd/common/utils"

	containercollection "github.com/kinvolk/inspektor-gadget/pkg/container-collection"
	containerutils "github.com/kinvolk/inspektor-gadget/pkg/container-utils"
	"github.com/kinvolk/inspektor-gadget/pkg/container-utils/docker"
	"github.com/kinvolk/inspektor-gadget/pkg/gadgets/audit/seccomp/tracer"
	"github.com/kinvolk/inspektor-gadget/pkg/gadgets/audit/seccomp/types"
	containersmap "github.com/kinvolk/inspektor-gadget/pkg/gadgettracermanager/containers-map"
	tracercollection "github.com/kinvolk/inspektor-gadget/pkg/tracer-collection"
	eventtypes "github.com/kinvolk/inspektor-gadget/pkg/types"
)

func main() {
	// In some kernel versions it's needed to bump the rlimits to
	// use run BPF programs.
	if err := rlimit.RemoveMemlock(); err != nil {
		return
	}

	var containerName string
	flag.StringVar(&containerName, "containername", "", "Show only data from containers with that name")
	flag.Parse()

	// Create the container-map that will be used to enrich the events.
	containersMap, err := containersmap.NewContainersMap("")
	if err != nil {
		fmt.Printf("error creating containers map: %s", err)
		return
	}
	defer containersMap.Close()

	// The trace-collection will allows us to filter by container
	containerCollection := containercollection.ContainerCollection{}
	tracerCollection, err := tracercollection.NewTracerCollection(true, &containerCollection)
	if err != nil {
		fmt.Printf("failed to create trace-collection: %s\n", err)
		return
	}
	defer tracerCollection.Close()

	// The container-collection will keep our container-map updated.
	containerEventFuncs := []containercollection.FuncNotify{
		containersMap.ContainersMapUpdater(),
		tracerCollection.TracerMapsUpdater(),
	}
	opts := []containercollection.ContainerCollectionOption{
		containercollection.WithPubSub(containerEventFuncs...),
		containercollection.WithLinuxNamespaceEnrichment(),
		containercollection.WithRuncFanotify(),
		containercollection.WithMultipleContainerRuntimesEnrichment([]*containerutils.RuntimeConfig{
			{Name: docker.Name},
		}),
	}
	err = containerCollection.ContainerCollectionInitialize(opts...)
	if err != nil {
		fmt.Printf("failed to initialize container collection: %s\n", err)
		return
	}
	defer containerCollection.ContainerCollectionClose()

	traceName := "myTrace"
	err = tracerCollection.AddTracer(traceName, containercollection.ContainerSelector{
		Name: containerName,
	})
	if err != nil {
		fmt.Printf("failed to create tracer's mount ns map: %s", err)
		return
	}
	defer tracerCollection.RemoveTracer(traceName)

	mountNsMap, err := tracerCollection.TracerMountNsMap(traceName)
	if err != nil {
		fmt.Printf("failed to find tracer's mount ns map: %s", err)
		return
	}

	outputConfig := utils.OutputConfig{
		// Use JSON format
		// OutputMode: utils.OutputModeJSON,

		// Print default columns
		// OutputMode: utils.OutputModeColumns,

		// Print the requested columns
		OutputMode: utils.OutputModeCustomColumns,
		// CustomColumns: []string{
		// 	"comm",
		// 	"code",
		// },
		CustomColumns: append([]string{"container"}, audit.GetSeccompDefaultColumns()...),
	}

	parser := audit.NewSeccompParser(&outputConfig)

	if outputConfig.OutputMode != utils.OutputModeJSON {
		fmt.Println(parser.BuildColumnsHeader())
	}

	// Define a callback to be called each time there is an event.
	eventCallback := func(event types.Event) {
		// This special case will not be needed soon, see
		// https://github.com/kinvolk/inspektor-gadget/pull/796.
		if event.Type != eventtypes.NORMAL {
			utils.ManageSpecialEvent(event.Event, outputConfig.Verbose)
			return
		}

		fmt.Println(parser.TransformEvent(&event))
	}

	config := &tracer.Config{
		ContainersMap: containersMap.ContainersMap(),
		MountnsMap:    mountNsMap,
	}
	tracer, err := tracer.NewTracer(config, eventCallback)
	if err != nil {
		fmt.Printf("error creating tracer: %s\n", err)
		return
	}

	// Wait for SIGINT
	c := make(chan os.Signal, 1)
	signal.Notify(c, os.Interrupt)

	<-c

	// Clean up everything before exiting.
	tracer.Close()
}
```

## Testing done

I verified that this PR doesn't introduce any regression on the `kubectl-gadget` and I run the previous example:

Run the binary:
```bash
$ sudo ./seccomp --containername myContainer
CONTAINER        PID     COMM             SYSCALL          CODE
```

In another terminal, run the container to trigger the events:
```bash
$ cat <<EOF >> profile.json
{
  "defaultAction": "SCMP_ACT_ALLOW",
  "architectures": [
    "SCMP_ARCH_X86_64"
  ],
  "syscalls": [
    {
      "action": "SCMP_ACT_KILL",
      "names": [
        "unshare"
      ]
    }
  ]
}
EOF

$ docker run -ti --name myContainer --rm --security-opt seccomp=profile.json ubuntu
root@6d7134293dfa:/# unshare
Bad system call (core dumped)
```

After running `unshare` in the container, the output in the binary will be:
```bash
CONTAINER        PID     COMM             SYSCALL          CODE
myContainer      15512   unshare          unshare          kill_thread
```
