### PR TITLE
cmd/kubect-gadget: Add readiness probe

### DIFF
--- a/integration/command.go
+++ b/integration/command.go
@@ -149,13 +149,6 @@ kubectl rollout status -n security-profiles-operator ds spod --timeout=180s || \
 	}
 }
 
-func waitUntilInspektorGadgetPodsInitialized(initialDelay int) *command {
-	return &command{
-		name: "WaitForInspektorGadgetInit",
-		cmd:  fmt.Sprintf("sleep %d", initialDelay),
-	}
-}
-
 var cleanupInspektorGadget *command = &command{
 	name:    "CleanupInspektorGadget",
 	cmd:     "$KUBECTL_GADGET undeploy",

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -154,16 +154,6 @@ func testMain(m *testing.M) int {
 		initCommands = append(initCommands, deployInspektorGadget)
 		initCommands = append(initCommands, waitUntilInspektorGadgetPodsDeployed)
 
-		initialDelay := 15
-		if *k8sDistro == K8sDistroARO {
-			// ARO and any other Kubernetes distribution that uses Red Hat
-			// Enterprise Linux CoreOS (RHCOS) requires more time to initialise
-			// because we automatically download the kernel headers for it. See
-			// gadget-container/entrypoint.sh.
-			initialDelay = 60
-		}
-		initCommands = append(initCommands, waitUntilInspektorGadgetPodsInitialized(initialDelay))
-
 		cleanupCommands = append(cleanupCommands, cleanupInspektorGadget)
 	}
 

--- a/pkg/resources/manifests/deploy.yaml
+++ b/pkg/resources/manifests/deploy.yaml
@@ -117,6 +117,12 @@ spec:
             exec:
               command:
                 - "/cleanup.sh"
+        readinessProbe:
+          periodSeconds: 5
+          exec:
+            command:
+              - /bin/gadgettracermanager
+              - -liveness
         livenessProbe:
           initialDelaySeconds: 60
           periodSeconds: 5


### PR DESCRIPTION
2a233cad91dc ("cmd/kubectl-gadget: Use k8s API for deploy operation.")
introduced some logic in the deploy command to wait until the gadget
pods are ready to process operations. The logic checks that the number
of ready pods in the daemon set is the desired one.

Even if the logic was right, (it waited until all pods where Ready),
there was a missing piece. It could happen that the gadget tracer
manager is started but it's not ready to take requests yet becuase its
initialization isn't done. This issue happens sometimes when we try to
run a gadget just after deploying Inspektor Gadget on a heavy loaded
machine:

```
$ ./kubectl-gadget deploy && ./kubectl-gadget snapshot process
Creating Namespace/gadget...
Creating ServiceAccount/gadget...
Creating Role/gadget-role...
Creating RoleBinding/gadget-role-binding...
Creating ClusterRole/gadget-cluster-role...
Creating ClusterRoleBinding/gadget-cluster-role-binding...
Creating DaemonSet/gadget...
Creating CustomResourceDefinition/traces.gadget.kinvolk.io...
Waiting for gadget pod(s) to be ready...
0/2 gadget pod(s) ready
1/2 gadget pod(s) ready
2/2 gadget pod(s) ready
Error: timed out waiting for the condition
```

This commit adds readiness probes to fix this issue, the pods are only
marked as "Ready" when the gadget tracer manager is ready to process
requests.

## How to test

We need to simulate that the gadget tracer manager takes long to start, and easy wait is to apply the following diff:

```diff
$ git diff
diff --git gadget-container/gadgettracermanager/main.go gadget-container/gadgettracermanager/main.go
index 7325c875..f50fad32 100644
--- gadget-container/gadgettracermanager/main.go
+++ gadget-container/gadgettracermanager/main.go
@@ -209,6 +209,9 @@ func main() {
        }
 
        if serve {
+
+               time.Sleep(30 * time.Second)
+
                node := os.Getenv("NODE_NAME")
                if node == "" {
                        log.Fatalf("Environment variable NODE_NAME not set")
```

Then

```bash
# without this commit 
$ ./kubectl-gadget deploy && ./kubectl-gadget snapshot process && ./kubectl-gadget undeploy
Creating Namespace/gadget...
Creating ServiceAccount/gadget...
Creating Role/gadget-role...
Creating RoleBinding/gadget-role-binding...
Creating ClusterRole/gadget-cluster-role...
Creating ClusterRoleBinding/gadget-cluster-role-binding...
Creating DaemonSet/gadget...
Creating CustomResourceDefinition/traces.gadget.kinvolk.io...
Waiting for gadget pod(s) to be ready...
0/2 gadget pod(s) ready
0/2 gadget pod(s) ready
1/2 gadget pod(s) ready
2/2 gadget pod(s) ready
Error: timed out waiting for the condition
[...]

# with this commit 
$ ./kubectl-gadget deploy && ./kubectl-gadget snapshot process && ./kubectl-gadget undeploy
Creating Namespace/gadget...
Creating ServiceAccount/gadget...
Creating Role/gadget-role...
Creating RoleBinding/gadget-role-binding...
Creating ClusterRole/gadget-cluster-role...
Creating ClusterRoleBinding/gadget-cluster-role-binding...
Creating DaemonSet/gadget...
Creating CustomResourceDefinition/traces.gadget.kinvolk.io...
Waiting for gadget pod(s) to be ready...
0/2 gadget pod(s) ready <-- it remains waiting here for some seconds
1/2 gadget pod(s) ready
2/2 gadget pod(s) ready
NODE              NAMESPACE    POD                                CONTAINER     COMM               PID       
ubuntu-hirsute    default      foo-apiserver-867644cf8c-4n9wc     apiserver     apiserver          277363    
ubuntu-hirsute    default      foo-controller-767fc79888-4v4kf    controller    controller-mana    6166 
```