### PR TITLE
cmd/kubectl-gadget: Align `undeploy` and `deploy` command result

### DIFF
--- a/cmd/kubectl-gadget/deploy.go
+++ b/cmd/kubectl-gadget/deploy.go
@@ -300,7 +300,11 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	if printOnly || !wait {
+	if printOnly {
+		return nil
+	}
+	if !wait {
+		info("Inspektor Gadget is being deployed\n")
 		return nil
 	}
 
@@ -350,5 +354,11 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 		}
 	})
 
-	return err
+	if err != nil {
+		return err
+	}
+
+	info("Inspektor Gadget successfully deployed\n")
+
+	return nil
 }


### PR DESCRIPTION
# Align `undeploy` and `deploy` command result

Print the final command result for the `deploy` command, as it is done for `undeploy`: 

`Inspektor Gadget is being {removed|deployed}` and `Inspektor Gadget successfully {removed|deployed}`

## How to use

No wait:
```bash
$ ./kubectl-gadget undeploy --wait=false
Removing traces...
Removing CRD...
Removing cluster role binding...
Removing cluster role...
Removing namespace...
Inspektor Gadget is being removed

$ ./kubectl-gadget deploy --wait=false
Creating Namespace/gadget...
Creating ServiceAccount/gadget...
Creating Role/gadget-role...
Creating RoleBinding/gadget-role-binding...
Creating ClusterRole/gadget-cluster-role...
Creating ClusterRoleBinding/gadget-cluster-role-binding...
Creating DaemonSet/gadget...
Creating CustomResourceDefinition/traces.gadget.kinvolk.io...
Inspektor Gadget is being deployed
```

Wait:
```bash
$ ./kubectl-gadget undeploy
Removing traces...
Removing CRD...
Removing cluster role binding...
Removing cluster role...
Removing namespace...
Waiting for namespace to be removed...
Inspektor Gadget successfully removed

$ ./kubectl-gadget deploy
Creating Namespace/gadget...
Creating ServiceAccount/gadget...
Creating Role/gadget-role...
Creating RoleBinding/gadget-role-binding...
Creating ClusterRole/gadget-cluster-role...
Creating ClusterRoleBinding/gadget-cluster-role-binding...
Creating DaemonSet/gadget...
Creating CustomResourceDefinition/traces.gadget.kinvolk.io...
Waiting for gadget pod(s) to be ready...
0/2 gadget pod(s) ready
0/2 gadget pod(s) ready
1/2 gadget pod(s) ready
2/2 gadget pod(s) ready
Inspektor Gadget successfully deployed
```

The `quiet` flags is still valid so `kubectl-gadget deploy --wait=false --quiet` or `kubectl-gadget deploy --quiet` don't print anything.
