### PR TITLE
integration: Remove waitUntilInspektorGadgetPodsDeployed

### DIFF
--- a/integration/command.go
+++ b/integration/command.go
@@ -75,19 +75,6 @@ var deployInspektorGadget *command = &command{
 	expectedRegexp: `\d\/\d gadget pod\(s\) ready`,
 }
 
-var waitUntilInspektorGadgetPodsDeployed *command = &command{
-	name: "WaitForGadgetPods",
-	cmd: `
-	for POD in $(sleep 5; kubectl get pod -n gadget -l k8s-app=gadget -o name) ; do
-		kubectl wait --timeout=30s -n gadget --for=condition=ready $POD
-		if [ $? -ne 0 ]; then
-			kubectl get pod -n gadget
-			kubectl describe $POD -n gadget
-			exit 1
-		fi
-	done`,
-}
-
 func deploySPO(limitReplicas, bestEffortResourceMgmt bool) *command {
 	cmdStr := fmt.Sprintf(`
 kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.8.0/cert-manager.yaml

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -152,7 +152,6 @@ func testMain(m *testing.M) int {
 
 	if !*doNotDeployIG {
 		initCommands = append(initCommands, deployInspektorGadget)
-		initCommands = append(initCommands, waitUntilInspektorGadgetPodsDeployed)
 
 		cleanupCommands = append(cleanupCommands, cleanupInspektorGadget)
 	}


### PR DESCRIPTION
It's not needed to wait anymore for the gadget pods to be ready since
this logic was implemented in "kubectl gadget deploy" in
2a233cad91dc ("cmd/kubectl-gadget: Use k8s API for deploy operation.").

