### PR TITLE
Revert "integration: Add a flag to skip tests without CO-RE version."

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -47,8 +47,6 @@ var (
 	doNotDeploySPO = flag.Bool("no-deploy-spo", false, "don't deploy the Security Profiles Operator (SPO)")
 
 	k8sDistro = flag.String("k8s-distro", "", "allows to skip tests that are not supported on a given Kubernetes distribution")
-
-	skipNoCORE = flag.Bool("skip-no-co-re", false, "skip tests which do not have a CO-RE version")
 )
 
 func runCommands(cmds []*command, t *testing.T) {
@@ -355,10 +353,6 @@ func TestBindsnoop(t *testing.T) {
 }
 
 func TestBiolatency(t *testing.T) {
-	if *skipNoCORE {
-		t.Skip("'profile block-io' does not have a CO-RE version")
-	}
-
 	t.Parallel()
 
 	commands := []*command{
@@ -400,10 +394,6 @@ func TestBiotop(t *testing.T) {
 }
 
 func TestCapabilities(t *testing.T) {
-	if *skipNoCORE {
-		t.Skip("'trace capabilities' does not have a CO-RE version")
-	}
-
 	ns := generateTestNamespaceName("test-capabilities")
 
 	t.Parallel()
@@ -751,10 +741,6 @@ func TestProcessCollector(t *testing.T) {
 }
 
 func TestProfile(t *testing.T) {
-	if *skipNoCORE {
-		t.Skip("'profile cpu' does not have a CO-RE version")
-	}
-
 	ns := generateTestNamespaceName("test-profile")
 
 	t.Parallel()
@@ -888,10 +874,6 @@ func TestTcpconnect(t *testing.T) {
 }
 
 func TestTcptracer(t *testing.T) {
-	if *skipNoCORE {
-		t.Skip("'trace tcp' does not have a CO-RE version")
-	}
-
 	ns := generateTestNamespaceName("test-tcptracer")
 
 	t.Parallel()


### PR DESCRIPTION
Now all our gadgets support CO-RE, hence we can revert 9327f2f6dda6c752c593471f58c3153ca5aa30bd.

