### PR TITLE
Fix issues with CO-RE container image

### DIFF
--- a/gadget-container/entrypoint.sh
+++ b/gadget-container/entrypoint.sh
@@ -31,7 +31,7 @@ echo -n "Kernel detected: "
 echo $KERNEL
 
 echo -n "bcc detected: "
-dpkg-query --show libbcc|awk '{print $2}'
+dpkg-query --show libbcc | awk '{print $2}' || true
 
 echo -n "Gadget image: "
 echo $GADGET_IMAGE

--- a/gadget-core.Dockerfile
+++ b/gadget-core.Dockerfile
@@ -65,16 +65,16 @@ FROM ${BASE_IMAGE}
 # available on the base image
 RUN set -ex; \
 	if command -v tdnf; then \
-		tdnf install -y libseccomp wget curl; \
+		tdnf install -y libseccomp wget curl util-linux; \
 	elif command -v yum; then \
-		yum install -y libseccomp wget curl; \
+		yum install -y libseccomp wget curl util-linux; \
 	elif command -v apt-get; then \
 		apt-get update && \
-		apt-get install -y seccompwget curl ; \
+		apt-get install -y seccomp wget curl util-linux; \
 	elif command -v apk; then \
-		apk add gcompat libseccomp bash wget curl ; \
+		apk add gcompat libseccomp bash wget curl util-linux; \
 	fi && \
-	rmdir /usr/src || true && ln -sf /host/usr/src /usr/src && \
+	(rmdir /usr/src || true) && ln -sf /host/usr/src /usr/src && \
 	rm -f /etc/localtime && ln -sf /host/etc/localtime /etc/localtime
 
 COPY gadget-container/entrypoint.sh gadget-container/cleanup.sh /


### PR DESCRIPTION
- Do not fail when checking BCC version
- Fix dependency install command with apt-get
- Install util-linux to provide mount command

This PR installs some of the dependencies mentioned in https://github.com/kinvolk/inspektor-gadget/issues/801, some are still missing but I'd like to handle it directly in https://github.com/kinvolk/inspektor-gadget/issues/801.