### PR TITLE
integration: Fix logic to generate command

### DIFF
--- a/integration/command.go
+++ b/integration/command.go
@@ -73,7 +73,7 @@ func deployInspektorGadget(image string, livenessProbe bool) *command {
 	cmd := fmt.Sprintf("$KUBECTL_GADGET deploy --liveness-probe=%t", livenessProbe)
 
 	if image != "" {
-		cmd = cmd + "--image=" + image
+		cmd = cmd + " --image=" + image
 	}
 
 	return &command{


### PR DESCRIPTION
A space before "--image" is needed, otherwise it fails with
"Error: invalid argument "true--image=XXX" for "--liveness-probe""

Fixes: b9db9360d8b8 ("integration: Disable liveness probes when running on ARO")

