### PR TITLE
kubectl-gadget: add more detailed error logs when deploying fails

### DIFF
--- a/cmd/kubectl-gadget/consts.go
+++ b/cmd/kubectl-gadget/consts.go
@@ -1,0 +1,19 @@
+// Copyright 2022 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+const (
+	gadgetNamespace string = "gadget"
+)

--- a/cmd/kubectl-gadget/debug.go
+++ b/cmd/kubectl-gadget/debug.go
@@ -1,0 +1,116 @@
+// Copyright 2022 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/yaml"
+)
+
+func getGadgetPodsDebug(client *kubernetes.Clientset) string {
+	var sb strings.Builder
+
+	listOpts := metav1.ListOptions{
+		LabelSelector: "k8s-app=" + gadgetNamespace,
+	}
+
+	pods, err := client.CoreV1().Pods(gadgetNamespace).List(context.TODO(), listOpts)
+	if err != nil {
+		return ""
+	}
+
+	for _, pod := range pods.Items {
+		pod.ManagedFields = nil
+		bytes, err := yaml.Marshal(pod)
+		if err != nil {
+			continue
+		}
+		sb.WriteString(fmt.Sprintf("------ Pod %s -------\n", pod.Name))
+		sb.Write(bytes)
+		sb.WriteString("---------------------\n")
+
+		sb.WriteString(fmt.Sprintf("----------------- LOGS START (%s) -----------------\n", pod.Name))
+		sb.WriteString(getPodLog(client, pod.Name))
+		sb.WriteString("------------------ LOGS END ------------------\n")
+	}
+
+	return sb.String()
+}
+
+func getPodLog(client *kubernetes.Clientset, podname string) string {
+	podLogOpts := corev1.PodLogOptions{}
+	req := client.CoreV1().Pods(gadgetNamespace).GetLogs(podname, &podLogOpts)
+	if req == nil {
+		return ""
+	}
+
+	stream, err := req.Stream(context.TODO())
+	if err != nil {
+		return ""
+	}
+	defer stream.Close()
+
+	buf := new(strings.Builder)
+	_, err = io.Copy(buf, stream)
+	if err != nil {
+		return ""
+	}
+
+	return buf.String()
+}
+
+// taken from https://github.com/kubernetes/kubectl/blob/393c40f5c4acbe48edbc70f8c8696bb623744b76/pkg/cmd/events/events.go#L362-L372
+// Return the time that should be used for sorting, which can come from
+// various places in corev1.Event.
+func eventTime(event corev1.Event) time.Time {
+	if event.Series != nil {
+		return event.Series.LastObservedTime.Time
+	}
+	if !event.LastTimestamp.Time.IsZero() {
+		return event.LastTimestamp.Time
+	}
+	return event.EventTime.Time
+}
+
+func getEvents(client *kubernetes.Clientset) string {
+	var sb strings.Builder
+
+	events, err := client.CoreV1().Events(gadgetNamespace).List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		return ""
+	}
+
+	sb.WriteString(fmt.Sprintf("%-12s %-10s %-14s %-30s %s\n",
+		"LAST SEEN", "TYPE", "REASON", "OBJECT", "MESSAGE"))
+
+	now := time.Now()
+
+	for _, event := range events.Items {
+		dur := now.Sub(eventTime(event)).Truncate(time.Second)
+		sb.WriteString(fmt.Sprintf("%-12s %-10s %-14s %-30s %s\n",
+			dur, event.Type, event.Reason,
+			event.InvolvedObject.Kind+"\\"+event.InvolvedObject.Name, event.Message))
+	}
+
+	return sb.String()
+}

--- a/cmd/kubectl-gadget/undeploy.go
+++ b/cmd/kubectl-gadget/undeploy.go
@@ -47,8 +47,7 @@ var undeployCmd = &cobra.Command{
 var undeployWait bool
 
 const (
-	gadgetNamespace string = "gadget"
-	timeout         int    = 30
+	timeout int = 30
 )
 
 func init() {

--- a/integration/command.go
+++ b/integration/command.go
@@ -70,7 +70,7 @@ type command struct {
 }
 
 func deployInspektorGadget(image string, livenessProbe bool) *command {
-	cmd := fmt.Sprintf("$KUBECTL_GADGET deploy --liveness-probe=%t", livenessProbe)
+	cmd := fmt.Sprintf("$KUBECTL_GADGET deploy --liveness-probe=%t --debug", livenessProbe)
 
 	if image != "" {
 		cmd = cmd + " --image=" + image


### PR DESCRIPTION
Add a "--debug" option to print extra information when the deploy
command fails. It's useful for scenarios where it's not possible to
access the logs, like the CI, and also to ask for more information in
case a user reports an issue.

## How to use

We need to make the deploy to fail. One option is to add a delay to the gadget tracer manager and use a smaller timeout:

```diff
diff --git gadget-container/gadgettracermanager/main.go gadget-container/gadgettracermanager/main.go
index 7325c875..019f8905 100644
--- gadget-container/gadgettracermanager/main.go
+++ gadget-container/gadgettracermanager/main.go
@@ -214,6 +214,9 @@ func main() {
                        log.Fatalf("Environment variable NODE_NAME not set")
                }
 
+               fmt.Printf("sleeping\n")
+               time.Sleep(20 * time.Second)
+
                lis, err := net.Listen("unix", socketfile)
                if err != nil {
                        log.Fatalf("failed to listen: %v", err)
```


```bash
$ ./kubectl-gadget deploy --timeout=10s --debug
Creating Namespace/gadget...
Creating ServiceAccount/gadget...
Creating Role/gadget-role...
Creating RoleBinding/gadget-role-binding...
Creating ClusterRole/gadget-cluster-role...
Creating ClusterRoleBinding/gadget-cluster-role-binding...
Creating DaemonSet/gadget...
Creating CustomResourceDefinition/traces.gadget.kinvolk.io...
Waiting for gadget pod(s) to be ready...
0/2 gadget pod(s) ready
0/2 gadget pod(s) ready
DUMP PODS:
------ Pod gadget-2kpqn -------
metadata:
  annotations:
    container.apparmor.security.beta.kubernetes.io/gadget: unconfined
    inspektor-gadget.kinvolk.io/option-hook-mode: auto
  creationTimestamp: "2022-08-04T12:35:15Z"
  generateName: gadget-
  labels:
    controller-revision-hash: 646867f594
    k8s-app: gadget
    pod-template-generation: "1"
  name: gadget-2kpqn
  namespace: gadget
  ownerReferences:
  - apiVersion: apps/v1
    blockOwnerDeletion: true
    controller: true
    kind: DaemonSet
    name: gadget
    uid: 81f83437-b524-4224-91cf-242baa919941
  resourceVersion: "6697475"
  uid: 2a691e8f-1caa-47a0-b183-1244503a9677
spec:
  affinity:
    nodeAffinity:
      requiredDuringSchedulingIgnoredDuringExecution:
        nodeSelectorTerms:
        - matchFields:
          - key: metadata.name
            operator: In
            values:
            - ubuntu-hirsute
  containers:
  - command:
    - /entrypoint.sh
    env:
    - name: NODE_NAME
      valueFrom:
        fieldRef:
          apiVersion: v1
          fieldPath: spec.nodeName
    - name: GADGET_POD_UID
      valueFrom:
        fieldRef:
          apiVersion: v1
          fieldPath: metadata.uid
    - name: TRACELOOP_NODE_NAME
      valueFrom:
        fieldRef:
          apiVersion: v1
          fieldPath: spec.nodeName
    - name: TRACELOOP_POD_NAME
      valueFrom:
        fieldRef:
          apiVersion: v1
          fieldPath: metadata.name
    - name: TRACELOOP_POD_NAMESPACE
      valueFrom:
        fieldRef:
          apiVersion: v1
          fieldPath: metadata.namespace
    - name: GADGET_IMAGE
      value: 192.168.1.150:5000/gadget:mauricio-add-error-logs
    - name: INSPEKTOR_GADGET_VERSION
      value: v0.7.1-1-g5ddfc087-dirty
    - name: INSPEKTOR_GADGET_OPTION_HOOK_MODE
      value: auto
    - name: INSPEKTOR_GADGET_OPTION_FALLBACK_POD_INFORMER
      value: "true"
    image: 192.168.1.150:5000/gadget:mauricio-add-error-logs
    imagePullPolicy: Always
    lifecycle:
      preStop:
        exec:
          command:
          - /cleanup.sh
    livenessProbe:
      exec:
        command:
        - /bin/gadgettracermanager
        - -liveness
      failureThreshold: 3
      initialDelaySeconds: 60
      periodSeconds: 5
      successThreshold: 1
      timeoutSeconds: 1
    name: gadget
    readinessProbe:
      exec:
        command:
        - /bin/gadgettracermanager
        - -liveness
      failureThreshold: 3
      periodSeconds: 5
      successThreshold: 1
      timeoutSeconds: 1
    resources: {}
    securityContext:
      capabilities:
        add:
        - NET_ADMIN
        - SYS_ADMIN
        - SYSLOG
        - SYS_PTRACE
        - SYS_RESOURCE
        - IPC_LOCK
        - SYS_MODULE
        - NET_RAW
    terminationMessagePath: /dev/termination-log
    terminationMessagePolicy: FallbackToLogsOnError
    volumeMounts:
    - mountPath: /host
      name: host
    - mountPath: /run
      name: run
    - mountPath: /lib/modules
      name: modules
    - mountPath: /sys/kernel/debug
      name: debugfs
    - mountPath: /sys/fs/cgroup
      name: cgroup
    - mountPath: /sys/fs/bpf
      name: bpffs
    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
      name: kube-api-access-q7pr8
      readOnly: true
  dnsPolicy: ClusterFirst
  enableServiceLinks: true
  hostNetwork: true
  hostPID: true
  nodeName: ubuntu-hirsute
  preemptionPolicy: PreemptLowerPriority
  priority: 0
  restartPolicy: Always
  schedulerName: default-scheduler
  securityContext: {}
  serviceAccount: gadget
  serviceAccountName: gadget
  terminationGracePeriodSeconds: 30
  tolerations:
  - effect: NoSchedule
    operator: Exists
  - effect: NoExecute
    operator: Exists
  - effect: NoExecute
    key: node.kubernetes.io/not-ready
    operator: Exists
  - effect: NoExecute
    key: node.kubernetes.io/unreachable
    operator: Exists
  - effect: NoSchedule
    key: node.kubernetes.io/disk-pressure
    operator: Exists
  - effect: NoSchedule
    key: node.kubernetes.io/memory-pressure
    operator: Exists
  - effect: NoSchedule
    key: node.kubernetes.io/pid-pressure
    operator: Exists
  - effect: NoSchedule
    key: node.kubernetes.io/unschedulable
    operator: Exists
  - effect: NoSchedule
    key: node.kubernetes.io/network-unavailable
    operator: Exists
  volumes:
  - hostPath:
      path: /
      type: ""
    name: host
  - hostPath:
      path: /run
      type: ""
    name: run
  - hostPath:
      path: /sys/fs/cgroup
      type: ""
    name: cgroup
  - hostPath:
      path: /lib/modules
      type: ""
    name: modules
  - hostPath:
      path: /sys/fs/bpf
      type: ""
    name: bpffs
  - hostPath:
      path: /sys/kernel/debug
      type: ""
    name: debugfs
  - name: kube-api-access-q7pr8
    projected:
      defaultMode: 420
      sources:
      - serviceAccountToken:
          expirationSeconds: 3607
          path: token
      - configMap:
          items:
          - key: ca.crt
            path: ca.crt
          name: kube-root-ca.crt
      - downwardAPI:
          items:
          - fieldRef:
              apiVersion: v1
              fieldPath: metadata.namespace
            path: namespace
status:
  conditions:
  - lastProbeTime: null
    lastTransitionTime: "2022-08-04T12:35:15Z"
    status: "True"
    type: Initialized
  - lastProbeTime: null
    lastTransitionTime: "2022-08-04T12:35:15Z"
    message: 'containers with unready status: [gadget]'
    reason: ContainersNotReady
    status: "False"
    type: Ready
  - lastProbeTime: null
    lastTransitionTime: "2022-08-04T12:35:15Z"
    message: 'containers with unready status: [gadget]'
    reason: ContainersNotReady
    status: "False"
    type: ContainersReady
  - lastProbeTime: null
    lastTransitionTime: "2022-08-04T12:35:15Z"
    status: "True"
    type: PodScheduled
  containerStatuses:
  - containerID: docker://f9fad771f227fc47b26877b999e8b2394dec00526d7dc53787ec856710813c9a
    image: 192.168.1.150:5000/gadget:mauricio-add-error-logs
    imageID: docker-pullable://192.168.1.150:5000/gadget@sha256:d4c4f7c497d9e0f9acc3277c87de6afb0cb4120b0b54f60c0ed733bd2eb089f7
    lastState: {}
    name: gadget
    ready: false
    restartCount: 0
    started: true
    state:
      running:
        startedAt: "2022-08-04T12:35:18Z"
  hostIP: 192.168.26.10
  phase: Running
  podIP: 192.168.26.10
  podIPs:
  - ip: 192.168.26.10
  qosClass: BestEffort
  startTime: "2022-08-04T12:35:15Z"
---------------------
----------------- LOGS START (gadget-2kpqn) -----------------
OS detected: Ubuntu 21.04
Kernel detected: 5.11.0-49-generic
bcc detected: 0.24.0-1
Gadget image: 192.168.1.150:5000/gadget:mauricio-add-error-logs
Deployment options:
INSPEKTOR_GADGET_OPTION_FALLBACK_POD_INFORMER=true
INSPEKTOR_GADGET_OPTION_HOOK_MODE=auto
Inspektor Gadget version: v0.7.1-1-g5ddfc087-dirty
Gadget Tracer Manager hook mode: auto
Kernel provided BTF is available at /sys/kernel/btf/vmlinux
Starting the Gadget Tracer Manager...
sleeping
------------------ LOGS END ------------------
------ Pod gadget-mn4tr -------
metadata:
  annotations:
    container.apparmor.security.beta.kubernetes.io/gadget: unconfined
    inspektor-gadget.kinvolk.io/option-hook-mode: auto
  creationTimestamp: "2022-08-04T12:35:15Z"
  generateName: gadget-
  labels:
    controller-revision-hash: 646867f594
    k8s-app: gadget
    pod-template-generation: "1"
  name: gadget-mn4tr
  namespace: gadget
  ownerReferences:
  - apiVersion: apps/v1
    blockOwnerDeletion: true
    controller: true
    kind: DaemonSet
    name: gadget
    uid: 81f83437-b524-4224-91cf-242baa919941
  resourceVersion: "6697477"
  uid: ab3959b3-88e0-49e9-a0ce-0dad1e06d407
spec:
  affinity:
    nodeAffinity:
      requiredDuringSchedulingIgnoredDuringExecution:
        nodeSelectorTerms:
        - matchFields:
          - key: metadata.name
            operator: In
            values:
            - worker
  containers:
  - command:
    - /entrypoint.sh
    env:
    - name: NODE_NAME
      valueFrom:
        fieldRef:
          apiVersion: v1
          fieldPath: spec.nodeName
    - name: GADGET_POD_UID
      valueFrom:
        fieldRef:
          apiVersion: v1
          fieldPath: metadata.uid
    - name: TRACELOOP_NODE_NAME
      valueFrom:
        fieldRef:
          apiVersion: v1
          fieldPath: spec.nodeName
    - name: TRACELOOP_POD_NAME
      valueFrom:
        fieldRef:
          apiVersion: v1
          fieldPath: metadata.name
    - name: TRACELOOP_POD_NAMESPACE
      valueFrom:
        fieldRef:
          apiVersion: v1
          fieldPath: metadata.namespace
    - name: GADGET_IMAGE
      value: 192.168.1.150:5000/gadget:mauricio-add-error-logs
    - name: INSPEKTOR_GADGET_VERSION
      value: v0.7.1-1-g5ddfc087-dirty
    - name: INSPEKTOR_GADGET_OPTION_HOOK_MODE
      value: auto
    - name: INSPEKTOR_GADGET_OPTION_FALLBACK_POD_INFORMER
      value: "true"
    image: 192.168.1.150:5000/gadget:mauricio-add-error-logs
    imagePullPolicy: Always
    lifecycle:
      preStop:
        exec:
          command:
          - /cleanup.sh
    livenessProbe:
      exec:
        command:
        - /bin/gadgettracermanager
        - -liveness
      failureThreshold: 3
      initialDelaySeconds: 60
      periodSeconds: 5
      successThreshold: 1
      timeoutSeconds: 1
    name: gadget
    readinessProbe:
      exec:
        command:
        - /bin/gadgettracermanager
        - -liveness
      failureThreshold: 3
      periodSeconds: 5
      successThreshold: 1
      timeoutSeconds: 1
    resources: {}
    securityContext:
      capabilities:
        add:
        - NET_ADMIN
        - SYS_ADMIN
        - SYSLOG
        - SYS_PTRACE
        - SYS_RESOURCE
        - IPC_LOCK
        - SYS_MODULE
        - NET_RAW
    terminationMessagePath: /dev/termination-log
    terminationMessagePolicy: FallbackToLogsOnError
    volumeMounts:
    - mountPath: /host
      name: host
    - mountPath: /run
      name: run
    - mountPath: /lib/modules
      name: modules
    - mountPath: /sys/kernel/debug
      name: debugfs
    - mountPath: /sys/fs/cgroup
      name: cgroup
    - mountPath: /sys/fs/bpf
      name: bpffs
    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
      name: kube-api-access-jdcr8
      readOnly: true
  dnsPolicy: ClusterFirst
  enableServiceLinks: true
  hostNetwork: true
  hostPID: true
  nodeName: worker
  preemptionPolicy: PreemptLowerPriority
  priority: 0
  restartPolicy: Always
  schedulerName: default-scheduler
  securityContext: {}
  serviceAccount: gadget
  serviceAccountName: gadget
  terminationGracePeriodSeconds: 30
  tolerations:
  - effect: NoSchedule
    operator: Exists
  - effect: NoExecute
    operator: Exists
  - effect: NoExecute
    key: node.kubernetes.io/not-ready
    operator: Exists
  - effect: NoExecute
    key: node.kubernetes.io/unreachable
    operator: Exists
  - effect: NoSchedule
    key: node.kubernetes.io/disk-pressure
    operator: Exists
  - effect: NoSchedule
    key: node.kubernetes.io/memory-pressure
    operator: Exists
  - effect: NoSchedule
    key: node.kubernetes.io/pid-pressure
    operator: Exists
  - effect: NoSchedule
    key: node.kubernetes.io/unschedulable
    operator: Exists
  - effect: NoSchedule
    key: node.kubernetes.io/network-unavailable
    operator: Exists
  volumes:
  - hostPath:
      path: /
      type: ""
    name: host
  - hostPath:
      path: /run
      type: ""
    name: run
  - hostPath:
      path: /sys/fs/cgroup
      type: ""
    name: cgroup
  - hostPath:
      path: /lib/modules
      type: ""
    name: modules
  - hostPath:
      path: /sys/fs/bpf
      type: ""
    name: bpffs
  - hostPath:
      path: /sys/kernel/debug
      type: ""
    name: debugfs
  - name: kube-api-access-jdcr8
    projected:
      defaultMode: 420
      sources:
      - serviceAccountToken:
          expirationSeconds: 3607
          path: token
      - configMap:
          items:
          - key: ca.crt
            path: ca.crt
          name: kube-root-ca.crt
      - downwardAPI:
          items:
          - fieldRef:
              apiVersion: v1
              fieldPath: metadata.namespace
            path: namespace
status:
  conditions:
  - lastProbeTime: null
    lastTransitionTime: "2022-08-04T12:35:15Z"
    status: "True"
    type: Initialized
  - lastProbeTime: null
    lastTransitionTime: "2022-08-04T12:35:15Z"
    message: 'containers with unready status: [gadget]'
    reason: ContainersNotReady
    status: "False"
    type: Ready
  - lastProbeTime: null
    lastTransitionTime: "2022-08-04T12:35:15Z"
    message: 'containers with unready status: [gadget]'
    reason: ContainersNotReady
    status: "False"
    type: ContainersReady
  - lastProbeTime: null
    lastTransitionTime: "2022-08-04T12:35:15Z"
    status: "True"
    type: PodScheduled
  containerStatuses:
  - containerID: docker://1c51932ee44b8ecfa1f1dd51282e715c28aa9571474b7c7c09c5df3ce90d5495
    image: 192.168.1.150:5000/gadget:mauricio-add-error-logs
    imageID: docker-pullable://192.168.1.150:5000/gadget@sha256:d4c4f7c497d9e0f9acc3277c87de6afb0cb4120b0b54f60c0ed733bd2eb089f7
    lastState: {}
    name: gadget
    ready: false
    restartCount: 0
    started: true
    state:
      running:
        startedAt: "2022-08-04T12:35:18Z"
  hostIP: 192.168.26.11
  phase: Running
  podIP: 192.168.26.11
  podIPs:
  - ip: 192.168.26.11
  qosClass: BestEffort
  startTime: "2022-08-04T12:35:15Z"
---------------------
----------------- LOGS START (gadget-mn4tr) -----------------
OS detected: Ubuntu 21.04
Kernel detected: 5.11.0-49-generic
bcc detected: 0.24.0-1
Gadget image: 192.168.1.150:5000/gadget:mauricio-add-error-logs
Deployment options:
INSPEKTOR_GADGET_OPTION_FALLBACK_POD_INFORMER=true
INSPEKTOR_GADGET_OPTION_HOOK_MODE=auto
Inspektor Gadget version: v0.7.1-1-g5ddfc087-dirty
Gadget Tracer Manager hook mode: auto
Kernel provided BTF is available at /sys/kernel/btf/vmlinux
Starting the Gadget Tracer Manager...
sleeping
------------------ LOGS END ------------------

DUMP EVENTS:
LAST SEEN    TYPE       REASON         OBJECT                         MESSAGE
10s          Normal     Scheduled      Pod\gadget-2kpqn               Successfully assigned gadget/gadget-2kpqn to ubuntu-hirsute
9s           Normal     Pulling        Pod\gadget-2kpqn               Pulling image "192.168.1.150:5000/gadget:mauricio-add-error-logs"
8s           Normal     Pulled         Pod\gadget-2kpqn               Successfully pulled image "192.168.1.150:5000/gadget:mauricio-add-error-logs" in 1.755493276s
7s           Normal     Created        Pod\gadget-2kpqn               Created container gadget
7s           Normal     Started        Pod\gadget-2kpqn               Started container gadget
5s           Warning    Unhealthy      Pod\gadget-2kpqn               Readiness probe failed: Gadget Tracer Manager health RPC failed: 'connection error: desc = "transport: Error while dialing dial unix /run/gadgettracermanager.socket: connect: no such file or directory"'
10s          Normal     Scheduled      Pod\gadget-mn4tr               Successfully assigned gadget/gadget-mn4tr to worker
9s           Normal     Pulling        Pod\gadget-mn4tr               Pulling image "192.168.1.150:5000/gadget:mauricio-add-error-logs"
8s           Normal     Pulled         Pod\gadget-mn4tr               Successfully pulled image "192.168.1.150:5000/gadget:mauricio-add-error-logs" in 1.66263674s
7s           Normal     Created        Pod\gadget-mn4tr               Created container gadget
7s           Normal     Started        Pod\gadget-mn4tr               Started container gadget
5s           Warning    Unhealthy      Pod\gadget-mn4tr               Readiness probe failed: Gadget Tracer Manager health RPC failed: 'connection error: desc = "transport: Error while dialing dial unix /run/gadgettracermanager.socket: connect: no such file or directory"'
10s          Normal     SuccessfulCreate DaemonSet\gadget               Created pod: gadget-2kpqn
10s          Normal     SuccessfulCreate DaemonSet\gadget               Created pod: gadget-mn4tr

Error: timed out waiting for the condition

```
