### PR TITLE
examples: Add basic ContainerCollection example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -9,6 +9,10 @@ or `local-gadget` directly.
 - [runc-hook](runc-hook/): Use of the runcfanotify package to
   - receive notifications when a container starts or terminates
   - execute PreStart and PostStop hooks
+- [container-collection](container-collection/): Use the
+  container-collection package
+  ("github.com/kinvolk/inspektor-gadget/pkg/container-collection") to
+  print a message when a container is created or removed.
 - [kube-container-collection](kube-container-collection/): Use the
   container-collection package
   ("github.com/kinvolk/inspektor-gadget/pkg/container-collection") in

--- a/examples/container-collection/.gitignore
+++ b/examples/container-collection/.gitignore
@@ -1,0 +1,1 @@
+container-collection

--- a/examples/container-collection/README.md
+++ b/examples/container-collection/README.md
@@ -1,0 +1,42 @@
+# Container Collection Example
+
+This is a basic example that uses the container-collection package
+("github.com/kinvolk/inspektor-gadget/pkg/container-collection") to
+print a message when a container is created or removed.
+
+## How to build
+
+```bash
+$ go build .
+```
+
+## How to run
+
+Start the example in one terminal. It'll print the already existing containers:
+
+```bash
+$ sudo ./container-collection
+Container added: "local-registry" pid 6135
+```
+
+In another terminal, run a container:
+
+```
+$ docker run --name hi -rm ubuntu /bin/bash -c "echo hi && sleep 2"
+hi
+```
+
+The previous terminal will contain messages indicating the creation and
+removal of this container:
+
+```bash
+$ sudo ./container-collection
+Container added: "local-registry" pid 6135
+Container added: "hi" pid 130258
+Container removed: "hi" pid 130258
+```
+
+## More information
+
+The [`kube-container-collection`](../kube-container-collection) example
+contains a more complex setup using this package.

--- a/examples/container-collection/container-collection.go
+++ b/examples/container-collection/container-collection.go
@@ -1,0 +1,76 @@
+// Copyright 2022 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	containercollection "github.com/kinvolk/inspektor-gadget/pkg/container-collection"
+	containerutils "github.com/kinvolk/inspektor-gadget/pkg/container-utils"
+	"github.com/kinvolk/inspektor-gadget/pkg/container-utils/containerd"
+	"github.com/kinvolk/inspektor-gadget/pkg/container-utils/docker"
+)
+
+func main() {
+	// Function that will be called for events. event contains
+	// information about the kind of event (added, removed) and an
+	// instance of the container.
+	callback := func(event containercollection.PubSubEvent) {
+		switch event.Type {
+		case containercollection.EventTypeAddContainer:
+			fmt.Printf("Container added: %q pid %d\n",
+				event.Container.Name, event.Container.Pid)
+		case containercollection.EventTypeRemoveContainer:
+			fmt.Printf("Container removed: %q pid %d\n",
+				event.Container.Name, event.Container.Pid)
+		}
+	}
+
+	// Define the different options for the container collection instance
+	opts := []containercollection.ContainerCollectionOption{
+		// Indicate the callback that will be invoked each time
+		// there is an event
+		containercollection.WithPubSub(callback),
+
+		// Get containers created with runc
+		containercollection.WithRuncFanotify(),
+
+		// Enrich those containers with data from the container
+		// runtime. docker and containerd in this case.
+		// (It's needed to have the name of the container in this example).
+		containercollection.WithMultipleContainerRuntimesEnrichment(
+			[]*containerutils.RuntimeConfig{
+				{Name: docker.Name},
+				{Name: containerd.Name},
+			}),
+	}
+
+	// Create and initialize the container collection
+	containerCollection := &containercollection.ContainerCollection{}
+	err := containerCollection.Initialize(opts...)
+	if err != nil {
+		fmt.Printf("failed to initialize container collection: %s\n", err)
+		return
+	}
+	defer containerCollection.Close()
+
+	// Graceful shutdown
+	exit := make(chan os.Signal, 1)
+	signal.Notify(exit, os.Interrupt, syscall.SIGTERM)
+	<-exit
+}


### PR DESCRIPTION
Add an example that uses this package. It's simpler than the
"kube-container-collection" as Kubernetes is not used.

