### PR TITLE
pkg/container-utils/runtime-client: replace grpc.WithDialer() with grpc.WithContextDialer()

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,10 +16,6 @@ issues:
     - text: "ST1000: at least one file in a package should have a package comment"
       linters:
         - stylecheck
-    # FIXME temporarily suppress. See issue #541
-    - text: "SA1019: grpc.WithDialer is deprecated: use WithContextDialer instead."
-      linters:
-        - staticcheck
 
 linters:
   disable-all: true

--- a/pkg/container-utils/runtime-client/interface.go
+++ b/pkg/container-utils/runtime-client/interface.go
@@ -80,8 +80,9 @@ func NewCRIClient(name, socketPath string, timeout time.Duration) (CRIClient, er
 	conn, err := grpc.Dial(
 		socketPath,
 		grpc.WithInsecure(),
-		grpc.WithDialer(func(addr string, timeout time.Duration) (net.Conn, error) {
-			return net.DialTimeout("unix", socketPath, timeout)
+		grpc.WithContextDialer(func(ctx context.Context, addr string) (net.Conn, error) {
+			d := net.Dialer{Timeout: timeout}
+			return d.DialContext(ctx, "unix", socketPath)
 		}),
 	)
 	if err != nil {


### PR DESCRIPTION
# Replace grpc.WithDialer() with grpc.WithContextDialer()

grpc.WithDialer() is marked as deprecated, so we need to move on to grpc.WithContextDialer().

Fixes #541