### PR TITLE
pkg/gadgets/trace/{exec,open}: Implement unit tests

### DIFF
--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -277,6 +277,9 @@ jobs:
     - name: Basic unit tests
       run: |
         make test
+    - name: Gadgets unit tests
+      run: |
+        make gadgets-unit-tests
     - name: Controller unit tests
       run: |
         make controller-tests

--- a/Makefile
+++ b/Makefile
@@ -147,6 +147,10 @@ controller-tests: kube-apiserver etcd kubectl
 	TEST_ASSET_KUBECTL=$(KUBECTL_BIN) \
 	go test -test.v ./pkg/controllers/... -controller-test
 
+.PHONY: gadgets-unit-tests
+gadgets-unit-tests:
+	go test -test.v -exec sudo ./pkg/gadgets/...
+
 .PHONY: local-gadget-tests
 local-gadget-tests:
 	# Compile and execute in separate commands because Go might not be

--- a/pkg/gadgets/internal/test/helpers.go
+++ b/pkg/gadgets/internal/test/helpers.go
@@ -1,0 +1,131 @@
+//go:build linux
+// +build linux
+
+// Copyright 2022 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/cilium/ebpf"
+	"github.com/google/go-cmp/cmp"
+	"golang.org/x/sys/unix"
+)
+
+// CreateMntNsFilterMap creates and fills an eBPF map that can be used
+// to filter by mount namespace in the different tracers.
+func CreateMntNsFilterMap(t *testing.T, mountNsIDs ...uint64) *ebpf.Map {
+	t.Helper()
+
+	const one = uint32(1)
+
+	mntnsSpec := &ebpf.MapSpec{
+		Name:       "filter_map_" + t.Name(),
+		Type:       ebpf.Hash,
+		KeySize:    8,
+		ValueSize:  4,
+		MaxEntries: 1024,
+	}
+	m, err := ebpf.NewMap(mntnsSpec)
+	if err != nil {
+		t.Fatalf("Failed to create eBPF map: %s", err)
+	}
+
+	for _, mountnsid := range mountNsIDs {
+		if err := m.Put(mountnsid, one); err != nil {
+			m.Close()
+			t.Fatalf("Failed to update eBPF map: %s", err)
+		}
+	}
+
+	return m
+}
+
+// RequireRoot skips the test if the not running as root
+func RequireRoot(t *testing.T) {
+	t.Helper()
+
+	if unix.Getuid() != 0 {
+		t.Skip("Test requires root")
+	}
+}
+
+func NewRunnerWithTest(t *testing.T, config *RunnerConfig) *Runner {
+	t.Helper()
+
+	runner, err := NewRunner(config)
+	if err != nil {
+		t.Fatalf("Creating runner: %s", err)
+	}
+
+	t.Cleanup(runner.Close)
+
+	return runner
+}
+
+func RunWithRunner(t *testing.T, runner *Runner, f func() error) {
+	t.Helper()
+
+	if err := runner.Run(f); err != nil {
+		t.Fatalf("Error generating event: %s", err)
+	}
+}
+
+type ValidateEventType[Event any, Extra any] func(*testing.T, *RunnerInfo, Extra, []Event)
+
+// ExpectNoEvent doesn't expect any event to be captured by the tracer.
+func ExpectNoEvent[Event any, Extra any](t *testing.T, _ *RunnerInfo, _ Extra, events []Event) {
+	if len(events) != 0 {
+		t.Fatalf("No events are expected")
+	}
+}
+
+// ExpectAtLeastOneEvent expects that at least one of the captures events matches.
+func ExpectAtLeastOneEvent[Event any, Extra any](getEvent func(info *RunnerInfo, extra Extra) *Event) ValidateEventType[Event, Extra] {
+	return func(t *testing.T, info *RunnerInfo, extra Extra, events []Event) {
+		expectedEvent := getEvent(info, extra)
+
+		for _, event := range events {
+			if reflect.DeepEqual(expectedEvent, &event) {
+				return
+			}
+		}
+
+		// Provide extra info when only a single event was captured
+		if len(events) == 1 {
+			t.Fatalf("Event doesn't match:\n%s",
+				cmp.Diff(expectedEvent, &events[0]))
+		}
+		t.Fatalf("Event wasn't captured")
+	}
+}
+
+// ExpectOneEvent expects only matching event to be captured.
+func ExpectOneEvent[Event any, Extra any](getEvent func(info *RunnerInfo, extra Extra) *Event) ValidateEventType[Event, Extra] {
+	return func(t *testing.T, info *RunnerInfo, extra Extra, events []Event) {
+		expectedEvent := getEvent(info, extra)
+
+		if len(events) != 1 {
+			t.Fatalf("More than one event found")
+		}
+
+		if !reflect.DeepEqual(expectedEvent, &events[0]) {
+			t.Fatalf("Event doesn't match:\n%s",
+				cmp.Diff(expectedEvent, &events[0]))
+		}
+	}
+}

--- a/pkg/gadgets/internal/test/runner.go
+++ b/pkg/gadgets/internal/test/runner.go
@@ -1,0 +1,183 @@
+//go:build linux
+// +build linux
+
+// Copyright 2022 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+// RunnerConfig defines how the runner should behave.
+// TODO: We could implement more options like unsharing the network
+// namespace, running on a different group ID, etc.
+type RunnerConfig struct {
+	// User ID to run under
+	UID int
+}
+
+// RunnerInfo contains information about the runner and it's used by the
+// tests to verify that the generated events have the correct value for
+// fields like PID, UID and MountNsID.
+type RunnerInfo struct {
+	Pid       int
+	Comm      string
+	UID       int
+	MountNsID uint64
+}
+
+// Runner is a helper type to execute tests in different conditions. It
+// creates a go routine that is executed in a different mount namespace,
+// user ID, etc. to simulate events hapenning inside containers.
+type Runner struct {
+	config *RunnerConfig
+
+	tasks   chan func() error
+	replies chan error
+	Info    *RunnerInfo
+}
+
+func NewRunner(config *RunnerConfig) (*Runner, error) {
+	if config == nil {
+		config = &RunnerConfig{}
+	}
+	r := &Runner{
+		config:  config,
+		tasks:   make(chan func() error),
+		replies: make(chan error),
+	}
+
+	go r.runLoop()
+
+	if err := <-r.replies; err != nil {
+		r.Close()
+		return nil, err
+	}
+
+	return r, nil
+}
+
+func (r *Runner) Run(f func() error) error {
+	r.tasks <- f
+	return <-r.replies
+}
+
+func (r *Runner) Close() {
+	if r.tasks != nil {
+		close(r.tasks)
+		r.tasks = nil
+	}
+	if r.replies != nil {
+		close(r.replies)
+		r.replies = nil
+	}
+}
+
+func (r *Runner) runLoop() {
+	// Don't switch thread in the following code
+	runtime.LockOSThread()
+	// We aren't calling runtime.UnlockOSThread() to let this thread
+	// die because some changes are not recoverable, like switching
+	// to a non-root UID.
+
+	mntns, err := createMntNamespace()
+	if err != nil {
+		r.replies <- fmt.Errorf("creating mount namespace: %w", err)
+		return
+	}
+	defer unix.Close(mntns)
+
+	if r.config.UID != 0 {
+		// syscall.Setuid() can't be used here because it'll
+		// change the UID of all threads and we only need to
+		// change the one of this thread.
+		// https://github.com/golang/go/commit/d1b1145cace8b968307f9311ff611e4bb810710c
+		_, _, errno := syscall.Syscall(syscall.SYS_SETUID, uintptr(r.config.UID), 0, 0)
+		if errno != 0 {
+			r.replies <- fmt.Errorf("setting uid: %w", err)
+			return
+		}
+	}
+
+	pid := os.Getpid()
+	tid := unix.Gettid()
+
+	mountnsid, err := getMntNamespaceInode(pid, tid)
+	if err != nil {
+		r.replies <- fmt.Errorf("getting namespace inode: %w", err)
+		return
+	}
+
+	comm, err := os.Executable()
+	if err != nil {
+		r.replies <- fmt.Errorf("getting current executable: %w", err)
+		return
+	}
+
+	r.Info = &RunnerInfo{
+		Pid:       pid,
+		Comm:      filepath.Base(comm),
+		UID:       r.config.UID,
+		MountNsID: mountnsid,
+	}
+
+	// Indicate it's ready to process tasks
+	r.replies <- nil
+
+	for task := range r.tasks {
+		r.replies <- task()
+	}
+}
+
+func createMntNamespace() (int, error) {
+	if err := unix.Unshare(syscall.CLONE_NEWNS); err != nil {
+		return -1, err
+	}
+	return getMntNsHandle()
+}
+
+func getMntNamespaceInode(pid, tid int) (uint64, error) {
+	fileinfo, err := os.Stat(fmt.Sprintf("/proc/%d/task/%d/ns/mnt", pid, tid))
+	if err != nil {
+		return 0, err
+	}
+	stat, ok := fileinfo.Sys().(*syscall.Stat_t)
+	if !ok {
+		return 0, errors.New("not a syscall.Stat_t")
+	}
+	return stat.Ino, nil
+}
+
+// getMntNsHandle gets a handle to the current thread mount namespace.
+func getMntNsHandle() (int, error) {
+	pid := os.Getpid()
+	tid := unix.Gettid()
+
+	path := fmt.Sprintf("/proc/%d/task/%d/ns/mnt", pid, tid)
+
+	fd, err := unix.Open(path, unix.O_RDONLY|unix.O_CLOEXEC, 0)
+	if err != nil {
+		return -1, err
+	}
+	return fd, nil
+}

--- a/pkg/gadgets/trace/bind/tracer/tracer.go
+++ b/pkg/gadgets/trace/bind/tracer/tracer.go
@@ -106,7 +106,6 @@ func (t *Tracer) Stop() {
 
 	if t.reader != nil {
 		t.reader.Close()
-		t.reader = nil
 	}
 
 	t.objs.Close()

--- a/pkg/gadgets/trace/capabilities/tracer/tracer.go
+++ b/pkg/gadgets/trace/capabilities/tracer/tracer.go
@@ -118,7 +118,6 @@ func (t *Tracer) Stop() {
 
 	if t.reader != nil {
 		t.reader.Close()
-		t.reader = nil
 	}
 
 	t.objs.Close()

--- a/pkg/gadgets/trace/exec/tracer/tracer.go
+++ b/pkg/gadgets/trace/exec/tracer/tracer.go
@@ -75,7 +75,6 @@ func (t *Tracer) Stop() {
 
 	if t.reader != nil {
 		t.reader.Close()
-		t.reader = nil
 	}
 
 	t.objs.Close()

--- a/pkg/gadgets/trace/exec/tracer/tracer_test.go
+++ b/pkg/gadgets/trace/exec/tracer/tracer_test.go
@@ -1,0 +1,309 @@
+//go:build linux
+// +build linux
+
+// Copyright 2022 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tracer_test
+
+import (
+	"fmt"
+	"os/exec"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	utilstest "github.com/kinvolk/inspektor-gadget/pkg/gadgets/internal/test"
+	"github.com/kinvolk/inspektor-gadget/pkg/gadgets/trace/exec/tracer"
+	"github.com/kinvolk/inspektor-gadget/pkg/gadgets/trace/exec/types"
+	eventtypes "github.com/kinvolk/inspektor-gadget/pkg/types"
+)
+
+func TestExecTracerCreate(t *testing.T) {
+	t.Parallel()
+
+	utilstest.RequireRoot(t)
+
+	tracer, err := tracer.NewTracer(&tracer.Config{}, nil,
+		func(types.Event) {})
+	if err != nil {
+		t.Fatalf("Error creating tracer: %s", err)
+	}
+	if tracer == nil {
+		t.Fatal("Returned tracer was nil")
+	}
+	t.Cleanup(tracer.Stop)
+}
+
+func TestExecTracerStopIdempotent(t *testing.T) {
+	t.Parallel()
+
+	utilstest.RequireRoot(t)
+
+	tracer, err := tracer.NewTracer(&tracer.Config{}, nil,
+		func(types.Event) {})
+	if err != nil {
+		t.Fatalf("Error creating tracer: %s", err)
+	}
+	if tracer == nil {
+		t.Fatal("Returned tracer was nil")
+	}
+
+	// Check that a double stop doesn't cause issues
+	tracer.Stop()
+	tracer.Stop()
+}
+
+func createTracer(
+	t *testing.T, config *tracer.Config, callback func(types.Event),
+) *tracer.Tracer {
+	t.Helper()
+
+	tracer, err := tracer.NewTracer(config, nil, callback)
+	if err != nil {
+		t.Fatalf("Error creating tracer: %s", err)
+	}
+	t.Cleanup(tracer.Stop)
+
+	return tracer
+}
+
+func TestExecTracer(t *testing.T) {
+	t.Parallel()
+
+	utilstest.RequireRoot(t)
+
+	const unprivilegedUID = int(1435)
+
+	manyArgs := []string{}
+	// 19 is DEFAULT_MAXARGS - 1 (-1 because args[0] is on the first position).
+	for i := 0; i < 19; i++ {
+		manyArgs = append(manyArgs, "/dev/null")
+	}
+
+	type test struct {
+		getTracerConfig func(info *utilstest.RunnerInfo) *tracer.Config
+		runnerConfig    *utilstest.RunnerConfig
+		generateEvent   func() (int, error)
+		validateEvent   func(t *testing.T, info *utilstest.RunnerInfo, catPid int, events []types.Event)
+	}
+
+	for name, test := range map[string]test{
+		"captures_all_events_with_no_filters_configured": {
+			getTracerConfig: func(info *utilstest.RunnerInfo) *tracer.Config {
+				return &tracer.Config{}
+			},
+			generateEvent: generateEvent,
+			validateEvent: utilstest.ExpectAtLeastOneEvent(func(info *utilstest.RunnerInfo, catPid int) *types.Event {
+				return &types.Event{
+					Event: eventtypes.Event{
+						Type: eventtypes.NORMAL,
+					},
+					Pid:       uint32(catPid),
+					Ppid:      uint32(info.Pid),
+					UID:       uint32(info.UID),
+					MountNsID: info.MountNsID,
+					Retval:    0,
+					Comm:      "cat",
+					Args:      []string{"/bin/cat", "/dev/null"},
+				}
+			}),
+		},
+		"captures_no_events_with_no_matching_filter": {
+			getTracerConfig: func(info *utilstest.RunnerInfo) *tracer.Config {
+				return &tracer.Config{
+					MountnsMap: utilstest.CreateMntNsFilterMap(t, 0),
+				}
+			},
+			generateEvent: generateEvent,
+			validateEvent: utilstest.ExpectNoEvent[types.Event, int],
+		},
+		"captures_events_with_matching_filter": {
+			getTracerConfig: func(info *utilstest.RunnerInfo) *tracer.Config {
+				return &tracer.Config{
+					MountnsMap: utilstest.CreateMntNsFilterMap(t, info.MountNsID),
+				}
+			},
+			generateEvent: generateEvent,
+			validateEvent: utilstest.ExpectOneEvent(func(info *utilstest.RunnerInfo, catPid int) *types.Event {
+				return &types.Event{
+					Event: eventtypes.Event{
+						Type: eventtypes.NORMAL,
+					},
+					Pid:       uint32(catPid),
+					Ppid:      uint32(info.Pid),
+					UID:       uint32(info.UID),
+					MountNsID: info.MountNsID,
+					Retval:    0,
+					Comm:      "cat",
+					Args:      []string{"/bin/cat", "/dev/null"},
+				}
+			}),
+		},
+		"event_has_UID_of_user_generating_event": {
+			getTracerConfig: func(info *utilstest.RunnerInfo) *tracer.Config {
+				return &tracer.Config{
+					MountnsMap: utilstest.CreateMntNsFilterMap(t, info.MountNsID),
+				}
+			},
+			runnerConfig:  &utilstest.RunnerConfig{UID: unprivilegedUID},
+			generateEvent: generateEvent,
+			validateEvent: func(t *testing.T, info *utilstest.RunnerInfo, _ int, events []types.Event) {
+				if len(events) != 1 {
+					t.Fatalf("one event expected")
+				}
+
+				if events[0].UID != uint32(info.UID) {
+					t.Fatalf("event has bad UID: %d, expected: %d", events[0].UID, info.UID)
+				}
+			},
+		},
+		"truncates_captured_args_in_trace_to_maximum_possible_length": {
+			getTracerConfig: func(info *utilstest.RunnerInfo) *tracer.Config {
+				return &tracer.Config{
+					MountnsMap: utilstest.CreateMntNsFilterMap(t, info.MountNsID),
+				}
+			},
+			generateEvent: func() (int, error) {
+				args := append(manyArgs, "/dev/null")
+				cmd := exec.Command("/bin/cat", args...)
+				if err := cmd.Run(); err != nil {
+					return 0, fmt.Errorf("running command: %w", err)
+				}
+
+				return cmd.Process.Pid, nil
+			},
+			validateEvent: func(t *testing.T, info *utilstest.RunnerInfo, _ int, events []types.Event) {
+				if len(events) != 1 {
+					t.Fatalf("one event expected")
+				}
+
+				if diff := cmp.Diff(events[0].Args, append([]string{"/bin/cat"}, manyArgs...)); diff != "" {
+					t.Fatalf("event has bad args, diff: \n%s", diff)
+				}
+			},
+		},
+	} {
+		test := test
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			events := []types.Event{}
+			eventCallback := func(event types.Event) {
+				events = append(events, event)
+			}
+
+			runner := utilstest.NewRunnerWithTest(t, test.runnerConfig)
+
+			createTracer(t, test.getTracerConfig(runner.Info), eventCallback)
+
+			var catPid int
+
+			utilstest.RunWithRunner(t, runner, func() error {
+				var err error
+				catPid, err = test.generateEvent()
+				return err
+			})
+
+			// Give some time for the tracer to capture the events
+			time.Sleep(100 * time.Millisecond)
+
+			test.validateEvent(t, runner.Info, catPid, events)
+		})
+	}
+}
+
+func TestExecTracerMultipleMntNsIDsFilter(t *testing.T) {
+	t.Parallel()
+
+	utilstest.RequireRoot(t)
+
+	events := []types.Event{}
+	eventCallback := func(event types.Event) {
+		events = append(events, event)
+	}
+
+	// struct with only fields we want to check on this test
+	type expectedEvent struct {
+		mntNsID uint64
+		catPid  int
+	}
+
+	const n int = 5
+	runners := make([]*utilstest.Runner, n)
+	expectedEvents := make([]expectedEvent, n)
+	mntNsIDs := make([]uint64, n)
+
+	for i := 0; i < n; i++ {
+		runners[i] = utilstest.NewRunnerWithTest(t, nil)
+		mntNsIDs[i] = runners[i].Info.MountNsID
+		expectedEvents[i].mntNsID = runners[i].Info.MountNsID
+	}
+
+	// Filter events from all runners but last one
+	config := &tracer.Config{
+		MountnsMap: utilstest.CreateMntNsFilterMap(t, mntNsIDs[:n-1]...),
+	}
+
+	createTracer(t, config, eventCallback)
+
+	for i := 0; i < n; i++ {
+		utilstest.RunWithRunner(t, runners[i], func() error {
+			var err error
+			expectedEvents[i].catPid, err = generateEvent()
+			return err
+		})
+	}
+
+	// Give some time for the tracer to capture the events
+	time.Sleep(100 * time.Millisecond)
+
+	if len(events) != n-1 {
+		t.Fatalf("%d events were expected, %d found", n, len(events))
+	}
+
+	// Pop last event since it shouldn't have been captured
+	expectedEvents = expectedEvents[:n-1]
+
+	// Order or events is not guaranteed, then we need to sort before comparing
+	sort.Slice(expectedEvents, func(i, j int) bool {
+		return expectedEvents[i].mntNsID < expectedEvents[j].mntNsID
+	})
+	sort.Slice(events, func(i, j int) bool {
+		return events[i].MountNsID < events[j].MountNsID
+	})
+
+	for i := 0; i < n-1; i++ {
+		if events[i].MountNsID != expectedEvents[i].mntNsID {
+			t.Fatalf("Captured event has bad MountNsID")
+		}
+
+		if events[i].Pid != uint32(expectedEvents[i].catPid) {
+			t.Fatalf("Captured event has bad PID")
+		}
+	}
+}
+
+// Function to generate an event used most of the times.
+// Returns pid of executed process.
+func generateEvent() (int, error) {
+	cmd := exec.Command("/bin/cat", "/dev/null")
+	if err := cmd.Run(); err != nil {
+		return 0, fmt.Errorf("running command: %w", err)
+	}
+
+	return cmd.Process.Pid, nil
+}

--- a/pkg/gadgets/trace/fsslower/tracer/tracer.go
+++ b/pkg/gadgets/trace/fsslower/tracer/tracer.go
@@ -131,7 +131,6 @@ func (t *Tracer) Stop() {
 
 	if t.reader != nil {
 		t.reader.Close()
-		t.reader = nil
 	}
 
 	t.objs.Close()

--- a/pkg/gadgets/trace/mount/tracer/tracer.go
+++ b/pkg/gadgets/trace/mount/tracer/tracer.go
@@ -79,7 +79,6 @@ func (t *Tracer) Stop() {
 
 	if t.reader != nil {
 		t.reader.Close()
-		t.reader = nil
 	}
 
 	t.objs.Close()

--- a/pkg/gadgets/trace/oomkill/tracer/tracer.go
+++ b/pkg/gadgets/trace/oomkill/tracer/tracer.go
@@ -74,7 +74,6 @@ func (t *Tracer) stop() {
 
 	if t.reader != nil {
 		t.reader.Close()
-		t.reader = nil
 	}
 
 	t.objs.Close()

--- a/pkg/gadgets/trace/open/tracer/tracer.go
+++ b/pkg/gadgets/trace/open/tracer/tracer.go
@@ -80,7 +80,6 @@ func (t *Tracer) Stop() {
 
 	if t.reader != nil {
 		t.reader.Close()
-		t.reader = nil
 	}
 
 	t.objs.Close()

--- a/pkg/gadgets/trace/open/tracer/tracer_test.go
+++ b/pkg/gadgets/trace/open/tracer/tracer_test.go
@@ -1,0 +1,333 @@
+//go:build linux
+// +build linux
+
+// Copyright 2022 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tracer_test
+
+import (
+	"fmt"
+	"sort"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/unix"
+
+	utilstest "github.com/kinvolk/inspektor-gadget/pkg/gadgets/internal/test"
+	"github.com/kinvolk/inspektor-gadget/pkg/gadgets/trace/open/tracer"
+	"github.com/kinvolk/inspektor-gadget/pkg/gadgets/trace/open/types"
+	eventtypes "github.com/kinvolk/inspektor-gadget/pkg/types"
+)
+
+func TestOpenTracerCreate(t *testing.T) {
+	t.Parallel()
+
+	utilstest.RequireRoot(t)
+
+	eventCallback := func(types.Event) {}
+
+	tracer, err := tracer.NewTracer(&tracer.Config{}, nil, eventCallback)
+	if err != nil {
+		t.Fatalf("Error creating tracer: %s", err)
+	}
+	if tracer == nil {
+		t.Fatal("Returned tracer was nil")
+	}
+	t.Cleanup(tracer.Stop)
+}
+
+func TestOpenTracerStopIdempotent(t *testing.T) {
+	t.Parallel()
+
+	utilstest.RequireRoot(t)
+
+	eventCallback := func(types.Event) {}
+
+	tracer, err := tracer.NewTracer(&tracer.Config{}, nil, eventCallback)
+	if err != nil {
+		t.Fatalf("Error creating tracer: %s", err)
+	}
+	if tracer == nil {
+		t.Fatal("Returned tracer was nil")
+	}
+
+	// Check that a double stop doesn't cause issues
+	tracer.Stop()
+	tracer.Stop()
+}
+
+func createTracer(
+	t *testing.T, config *tracer.Config, callback func(types.Event),
+) *tracer.Tracer {
+	t.Helper()
+
+	tracer, err := tracer.NewTracer(config, nil, callback)
+	if err != nil {
+		t.Fatalf("Error creating tracer: %s", err)
+	}
+	t.Cleanup(tracer.Stop)
+
+	return tracer
+}
+
+func TestOpenTracer(t *testing.T) {
+	t.Parallel()
+
+	utilstest.RequireRoot(t)
+
+	const unprivilegedUID = int(1435)
+
+	type test struct {
+		getTracerConfig func(info *utilstest.RunnerInfo) *tracer.Config
+		runnerConfig    *utilstest.RunnerConfig
+		generateEvent   func() (int, error)
+		validateEvent   func(*testing.T, *utilstest.RunnerInfo, int, []types.Event)
+	}
+
+	for name, test := range map[string]test{
+		"captures_all_events_with_no_filters_configured": {
+			getTracerConfig: func(info *utilstest.RunnerInfo) *tracer.Config {
+				return &tracer.Config{}
+			},
+			generateEvent: generateEvent,
+			validateEvent: utilstest.ExpectAtLeastOneEvent(func(info *utilstest.RunnerInfo, fd int) *types.Event {
+				return &types.Event{
+					Event: eventtypes.Event{
+						Type: eventtypes.NORMAL,
+					},
+					MountNsID: info.MountNsID,
+					Pid:       uint32(info.Pid),
+					UID:       uint32(info.UID),
+					Comm:      info.Comm,
+					Fd:        fd,
+					Ret:       fd,
+					Err:       0,
+					Path:      "/dev/null",
+				}
+			}),
+		},
+		"captures_no_events_with_no_matching_filter": {
+			getTracerConfig: func(info *utilstest.RunnerInfo) *tracer.Config {
+				return &tracer.Config{
+					MountnsMap: utilstest.CreateMntNsFilterMap(t, 0),
+				}
+			},
+			generateEvent: generateEvent,
+			validateEvent: utilstest.ExpectNoEvent[types.Event, int],
+		},
+		"captures_events_with_matching_filter": {
+			getTracerConfig: func(info *utilstest.RunnerInfo) *tracer.Config {
+				return &tracer.Config{
+					MountnsMap: utilstest.CreateMntNsFilterMap(t, info.MountNsID),
+				}
+			},
+			generateEvent: generateEvent,
+			validateEvent: utilstest.ExpectOneEvent(func(info *utilstest.RunnerInfo, fd int) *types.Event {
+				return &types.Event{
+					Event: eventtypes.Event{
+						Type: eventtypes.NORMAL,
+					},
+					MountNsID: info.MountNsID,
+					Pid:       uint32(info.Pid),
+					UID:       uint32(info.UID),
+					Comm:      info.Comm,
+					Fd:        fd,
+					Ret:       fd,
+					Err:       0,
+					Path:      "/dev/null",
+				}
+			}),
+		},
+		"event_has_UID_of_user_generating_event": {
+			getTracerConfig: func(info *utilstest.RunnerInfo) *tracer.Config {
+				return &tracer.Config{
+					MountnsMap: utilstest.CreateMntNsFilterMap(t, info.MountNsID),
+				}
+			},
+			runnerConfig:  &utilstest.RunnerConfig{UID: unprivilegedUID},
+			generateEvent: generateEvent,
+			validateEvent: func(t *testing.T, info *utilstest.RunnerInfo, _ int, events []types.Event) {
+				if len(events) != 1 {
+					t.Fatalf("one event expected")
+				}
+
+				if events[0].UID != uint32(info.UID) {
+					t.Fatalf("event has bad UID: %d, expected: %d", events[0].UID, info.UID)
+				}
+			},
+		},
+		"event_has_correct_error": {
+			getTracerConfig: func(info *utilstest.RunnerInfo) *tracer.Config {
+				return &tracer.Config{
+					MountnsMap: utilstest.CreateMntNsFilterMap(t, info.MountNsID),
+				}
+			},
+			generateEvent: func() (int, error) {
+				_, err := unix.Open("non-existing-file", 0, 0)
+				if err == nil {
+					return 0, fmt.Errorf("error was expected")
+				}
+
+				return -1, nil
+			},
+			validateEvent: func(t *testing.T, info *utilstest.RunnerInfo, _ int, events []types.Event) {
+				if len(events) != 1 {
+					t.Fatalf("one event expected")
+				}
+
+				if events[0].Err != int(unix.ENOENT) {
+					t.Fatalf("event has bad Err: %d, expected: %d", events[0].Err, unix.ENOENT)
+				}
+			},
+		},
+		"event_has_correct_ret_on_error": {
+			getTracerConfig: func(info *utilstest.RunnerInfo) *tracer.Config {
+				return &tracer.Config{
+					MountnsMap: utilstest.CreateMntNsFilterMap(t, info.MountNsID),
+				}
+			},
+			generateEvent: func() (int, error) {
+				_, err := unix.Open("non-existing-file", 0, 0)
+				if err == nil {
+					return 0, fmt.Errorf("error was expected")
+				}
+
+				return -1, nil
+			},
+			validateEvent: func(t *testing.T, info *utilstest.RunnerInfo, _ int, events []types.Event) {
+				if len(events) != 1 {
+					t.Fatalf("one event expected")
+				}
+
+				if events[0].Ret != -int(unix.ENOENT) {
+					t.Fatalf("event has bad Ret: %d, expected: %d", events[0].Err, -int(unix.ENOENT))
+				}
+			},
+		},
+	} {
+		test := test
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			events := []types.Event{}
+			eventCallback := func(event types.Event) {
+				events = append(events, event)
+			}
+
+			runner := utilstest.NewRunnerWithTest(t, test.runnerConfig)
+
+			createTracer(t, test.getTracerConfig(runner.Info), eventCallback)
+
+			var fd int
+
+			utilstest.RunWithRunner(t, runner, func() error {
+				var err error
+				fd, err = test.generateEvent()
+				return err
+			})
+
+			// Give some time for the tracer to capture the events
+			time.Sleep(100 * time.Millisecond)
+
+			test.validateEvent(t, runner.Info, fd, events)
+		})
+
+	}
+}
+
+func TestOpenTracerMultipleMntNsIDsFilter(t *testing.T) {
+	t.Parallel()
+
+	utilstest.RequireRoot(t)
+
+	events := []types.Event{}
+	eventCallback := func(event types.Event) {
+		events = append(events, event)
+	}
+
+	// struct with only fields we want to check on this test
+	type expectedEvent struct {
+		mntNsID uint64
+		fd      int
+	}
+
+	const n int = 5
+	runners := make([]*utilstest.Runner, n)
+	expectedEvents := make([]expectedEvent, n)
+	mntNsIDs := make([]uint64, n)
+
+	for i := 0; i < n; i++ {
+		runners[i] = utilstest.NewRunnerWithTest(t, nil)
+		mntNsIDs[i] = runners[i].Info.MountNsID
+		expectedEvents[i].mntNsID = runners[i].Info.MountNsID
+	}
+
+	// Filter events from all runners but last one
+	config := &tracer.Config{
+		MountnsMap: utilstest.CreateMntNsFilterMap(t, mntNsIDs[:n-1]...),
+	}
+
+	createTracer(t, config, eventCallback)
+
+	for i := 0; i < n; i++ {
+		utilstest.RunWithRunner(t, runners[i], func() error {
+			var err error
+			expectedEvents[i].fd, err = generateEvent()
+			return err
+		})
+	}
+
+	// Give some time for the tracer to capture the events
+	time.Sleep(100 * time.Millisecond)
+
+	if len(events) != n-1 {
+		t.Fatalf("%d events were expected, %d found", n, len(events))
+	}
+
+	// Pop last event since it shouldn't have been captured
+	expectedEvents = expectedEvents[:n-1]
+
+	// Order or events is not guaranteed, then we need to sort before comparing
+	sort.Slice(expectedEvents, func(i, j int) bool {
+		return expectedEvents[i].mntNsID < expectedEvents[j].mntNsID
+	})
+	sort.Slice(events, func(i, j int) bool {
+		return events[i].MountNsID < events[j].MountNsID
+	})
+
+	for i := 0; i < n-1; i++ {
+		if events[i].MountNsID != expectedEvents[i].mntNsID {
+			t.Fatalf("Captured event has bad MountNsID")
+		}
+
+		if events[i].Fd != expectedEvents[i].fd {
+			t.Fatalf("Captured event has bad Fd")
+		}
+	}
+}
+
+// Function to generate an event used most of the times.
+// Returns fd of opened file.
+func generateEvent() (int, error) {
+	fd, err := unix.Open("/dev/null", 0, 0)
+	if err != nil {
+		return 0, fmt.Errorf("opening file: %w", err)
+	}
+
+	unix.Close(fd)
+
+	return fd, nil
+}

--- a/pkg/gadgets/trace/signal/tracer/tracer.go
+++ b/pkg/gadgets/trace/signal/tracer/tracer.go
@@ -113,7 +113,6 @@ func (t *Tracer) Stop() {
 
 	if t.reader != nil {
 		t.reader.Close()
-		t.reader = nil
 	}
 
 	t.objs.Close()

--- a/pkg/gadgets/trace/tcp/tracer/tracer.go
+++ b/pkg/gadgets/trace/tcp/tracer/tracer.go
@@ -120,7 +120,6 @@ func (t *Tracer) Stop() {
 
 	if t.reader != nil {
 		t.reader.Close()
-		t.reader = nil
 	}
 
 	t.objs.Close()


### PR DESCRIPTION
This PR proposes a reusable logic to implement unit tests for the different gadgets. Motivation to add unit tests can be found in https://github.com/kinvolk/inspektor-gadget/issues/817.

## How to test 

One easy way to try it is to run the new tests `make gadget-unit-tests`, but it's not so interesting as tested as expected to pass. A more interesting way is to introduce bugs and check how they're detected by those tests:

```bash
# add one to the pid
$ git diff pkg/gadgets/trace/exec/
diff --git pkg/gadgets/trace/exec/tracer/tracer.go pkg/gadgets/trace/exec/tracer/tracer.go
index ac7d88c7..87481b19 100644
--- pkg/gadgets/trace/exec/tracer/tracer.go
+++ pkg/gadgets/trace/exec/tracer/tracer.go
@@ -153,7 +153,7 @@ func (t *Tracer) run() {
                        Event: eventtypes.Event{
                                Type: eventtypes.NORMAL,
                        },
-                       Pid:       uint32(eventC.pid),
+                       Pid:       uint32(eventC.pid) + 1,
                        Ppid:      uint32(eventC.ppid),
                        UID:       uint32(eventC.uid),
                        MountNsID: uint64(eventC.mntns_id),

$ go test -test.v -exec sudo ./pkg/gadgets/trace/exec/...
=== RUN   TestCreateTracer
--- PASS: TestCreateTracer (0.26s)
=== RUN   TestTracer
    helpers.go:83: "test filtering": event doesn't match:
          &types.Event{
          	Event: {Type: "normal"},
        - 	Pid:   667740,
        + 	Pid:   667741,
          	Ppid:  667701,
          	UID:   0,
          	... // 4 identical fields
          }
--- FAIL: TestTracer (0.43s)
FAIL
FAIL	github.com/kinvolk/inspektor-gadget/pkg/gadgets/trace/exec/tracer	0.702s
?   	github.com/kinvolk/inspektor-gadget/pkg/gadgets/trace/exec/types	[no test files]
FAIL

# remove field
$ git diff pkg/gadgets/trace/exec/
diff --git pkg/gadgets/trace/exec/tracer/tracer.go pkg/gadgets/trace/exec/tracer/tracer.go
index ac7d88c7..e9d3d798 100644
--- pkg/gadgets/trace/exec/tracer/tracer.go
+++ pkg/gadgets/trace/exec/tracer/tracer.go
@@ -158,7 +158,7 @@ func (t *Tracer) run() {
                        UID:       uint32(eventC.uid),
                        MountNsID: uint64(eventC.mntns_id),
                        Retval:    int(eventC.retval),
-                       Comm:      C.GoString(&eventC.comm[0]),
+                       //Comm:      C.GoString(&eventC.comm[0]),
                }
 
                argsCount := 0

$ go test -test.v -exec sudo ./pkg/gadgets/trace/exec/...
=== RUN   TestCreateTracer
--- PASS: TestCreateTracer (0.27s)
=== RUN   TestTracer
    helpers.go:83: "test without filtering": event doesn't match:
          &types.Event{
          	... // 4 identical fields
          	MountNsID: 4026532601,
          	Retval:    0,
        - 	Comm:      "cat",
        + 	Comm:      "",
          	Args:      {"/bin/cat", "/dev/null"},
          }
--- FAIL: TestTracer (0.22s)
FAIL
FAIL	github.com/kinvolk/inspektor-gadget/pkg/gadgets/trace/exec/tracer	0.510s
?   	github.com/kinvolk/inspektor-gadget/pkg/gadgets/trace/exec/types	[no test files]
FAIL

# break filtering by mountns logic 
$ git diff pkg/gadgets/trace/exec/
diff --git pkg/gadgets/trace/exec/tracer/tracer.go pkg/gadgets/trace/exec/tracer/tracer.go
index ac7d88c7..f7727935 100644
--- pkg/gadgets/trace/exec/tracer/tracer.go
+++ pkg/gadgets/trace/exec/tracer/tracer.go
@@ -91,7 +91,7 @@ func (t *Tracer) start() error {
        filterByMntNs := false
 
        if t.config.MountnsMap != nil {
-               filterByMntNs = true
+               filterByMntNs = false
                mapReplacements["mount_ns_set"] = t.config.MountnsMap
        }
 
$ go test -test.v -exec sudo ./pkg/gadgets/trace/exec/...
=== RUN   TestCreateTracer
--- PASS: TestCreateTracer (0.24s)
=== RUN   TestTracer
    helpers.go:83: "test filtering (no event should be captured)": no events are expected
--- FAIL: TestTracer (1.08s)
FAIL
FAIL	github.com/kinvolk/inspektor-gadget/pkg/gadgets/trace/exec/tracer	1.332s
?   	github.com/kinvolk/inspektor-gadget/pkg/gadgets/trace/exec/types	[no test files]
FAIL
```


