### PR TITLE
container-utils: Add pod info to runtime client's container data

### DIFF
--- a/pkg/container-utils/cri/cri.go
+++ b/pkg/container-utils/cri/cri.go
@@ -153,6 +153,9 @@ func parseContainerDetailsData(runtimeName string, containerStatus *pb.Container
 		},
 	}
 
+	// Fill K8S information.
+	runtimeclient.EnrichWithK8sMetadata(&containerDetailsData.ContainerData, containerStatus.Labels)
+
 	// Parse the extra info and fill the data.
 	err := parseExtraInfo(extraInfo, containerDetailsData)
 	if err != nil {
@@ -277,10 +280,15 @@ func containerStatusStateToRuntimeClientState(containerStatusState pb.ContainerS
 }
 
 func CRIContainerToContainerData(runtimeName string, container *pb.Container) *runtimeclient.ContainerData {
-	return &runtimeclient.ContainerData{
+	containerData := &runtimeclient.ContainerData{
 		ID:      container.Id,
 		Name:    strings.TrimPrefix(container.GetMetadata().Name, "/"),
 		State:   containerStatusStateToRuntimeClientState(container.GetState()),
 		Runtime: runtimeName,
 	}
+
+	// Fill K8S information.
+	runtimeclient.EnrichWithK8sMetadata(containerData, container.Labels)
+
+	return containerData
 }

--- a/pkg/container-utils/runtime-client/interface.go
+++ b/pkg/container-utils/runtime-client/interface.go
@@ -37,6 +37,15 @@ type ContainerData struct {
 	// is useful to distinguish who is the "owner" of each container in a list
 	// of containers collected from multiples runtimes.
 	Runtime string
+
+	// Unique identifier of pod running the container.
+	PodUID string
+
+	// Name of the pod running the container.
+	PodName string
+
+	// Namespace of the pod running the container.
+	PodNamespace string
 }
 
 // ContainerDetailsData contains container extra information returned from the
@@ -79,6 +88,12 @@ const (
 	StateUnknown = "unknown"
 )
 
+const (
+	containerLabelK8sPodName      = "io.kubernetes.pod.name"
+	containerLabelK8sPodNamespace = "io.kubernetes.pod.namespace"
+	containerLabelK8sPodUID       = "io.kubernetes.pod.uid"
+)
+
 // ContainerRuntimeClient defines the interface to communicate with the
 // different container runtimes.
 type ContainerRuntimeClient interface {
@@ -111,4 +126,16 @@ func ParseContainerID(expectedRuntime, containerID string) (string, error) {
 	}
 
 	return split[0], nil
+}
+
+func EnrichWithK8sMetadata(container *ContainerData, labels map[string]string) {
+	if podName, ok := labels[containerLabelK8sPodName]; ok {
+		container.PodName = podName
+	}
+	if podNamespace, ok := labels[containerLabelK8sPodNamespace]; ok {
+		container.PodNamespace = podNamespace
+	}
+	if podUID, ok := labels[containerLabelK8sPodUID]; ok {
+		container.PodUID = podUID
+	}
 }


### PR DESCRIPTION
# Add pod info to runtime client's container data

Add pod UID, name and namespace to the `CotnainerExtendedData` structure.

This is relevant only for containerd and cri-o.

PR has dependency on #819