### PR TITLE
ci: Allow running workflow on pull_request to test external contributions

### DIFF
--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -7,7 +7,12 @@ concurrency:
   group: ${{ github.ref }}
   cancel-in-progress: true
 on:
+  pull_request:
   push:
+    branches:
+    - main
+    tags:
+    - 'v*'
 
 # Jobs are given a level in a comment.
 # Jobs of the same level run in parallel.


### PR DESCRIPTION
# Allow running workflow on `pull_request` to test external contributions

According to [the documnetation](https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks), it would add the button because we configured the repo with _Require approval for all outside collaborators_.
