### PR TITLE
pkg/bpfstats: introduce and use HOST_ROOT for bpf_stats_enabled fallback

### DIFF
--- a/pkg/bpfstats/bpfstats.go
+++ b/pkg/bpfstats/bpfstats.go
@@ -19,6 +19,8 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"os"
+	"path/filepath"
 	"sync"
 
 	"github.com/cilium/ebpf"
@@ -63,7 +65,7 @@ func EnableBPFStats() error {
 	s, err := ebpf.EnableStats(unix.BPF_STATS_RUN_TIME)
 	if err != nil {
 		// Use fallback method
-		err = ioutil.WriteFile("/proc/sys/kernel/bpf_stats_enabled", []byte("1"), 0o644)
+		err = ioutil.WriteFile(filepath.Join(os.Getenv("HOST_ROOT"), "/proc/sys/kernel/bpf_stats_enabled"), []byte("1"), 0o644)
 		if err != nil {
 			return fmt.Errorf("could not enable stat collection: %w", err)
 		}
@@ -103,7 +105,7 @@ func DisableBPFStats() error {
 			return fmt.Errorf("could not disable stat collection using BPF(): %w", err)
 		}
 	case MethodSysctl:
-		err := ioutil.WriteFile("/proc/sys/kernel/bpf_stats_enabled", []byte("0"), 0o644)
+		err := ioutil.WriteFile(filepath.Join(os.Getenv("HOST_ROOT"), "/proc/sys/kernel/bpf_stats_enabled"), []byte("0"), 0o644)
 		if err != nil {
 			return fmt.Errorf("could not disable stat collection using sysctl: %w", err)
 		}

--- a/pkg/resources/manifests/deploy.yaml
+++ b/pkg/resources/manifests/deploy.yaml
@@ -159,6 +159,8 @@ spec:
             value: "auto"
           - name: INSPEKTOR_GADGET_OPTION_FALLBACK_POD_INFORMER
             value: "true"
+          - name: HOST_ROOT
+            value: "/host"
         securityContext:
           capabilities:
             add:


### PR DESCRIPTION
# Introduce and use HOST_ROOT for bpf_stats_enabled fallback

Instead of using `/proc/sys/kernel/bpf_stats_enabled` directly, this PR prefixes it with the environment variable `HOST_ROOT`, which defaults to `/host`.

## How to use

This will be enabled by default and used whenever the fallback for enabling ebpf stat collection is used.

Fixes #850 