### PR TITLE
pkg/apis: Custom types and const(s) for Trace and TraceConfig

### DIFF
--- a/cmd/gen-doc/gen-doc.go
+++ b/cmd/gen-doc/gen-doc.go
@@ -106,13 +106,13 @@ func main() {
 	for _, gadget := range getTraceFactories() {
 		outputModesSet := gadget.Factory.OutputModesSupported()
 		for k := range outputModesSet {
-			gadget.OutputModes = append(gadget.OutputModes, k)
+			gadget.OutputModes = append(gadget.OutputModes, string(k))
 		}
 		sort.Strings(gadget.OutputModes)
 
 		for name, op := range gadget.Factory.Operations() {
 			gadget.Operations = append(gadget.Operations, GadgetOperation{
-				Name:  name,
+				Name:  string(name),
 				Doc:   op.Doc,
 				Order: op.Order,
 			})

--- a/cmd/kubectl-gadget/advise/network-policy.go
+++ b/cmd/kubectl-gadget/advise/network-policy.go
@@ -24,6 +24,7 @@ import (
 
 	commonutils "github.com/kinvolk/inspektor-gadget/cmd/common/utils"
 	"github.com/kinvolk/inspektor-gadget/cmd/kubectl-gadget/utils"
+	gadgetv1alpha1 "github.com/kinvolk/inspektor-gadget/pkg/apis/gadget/v1alpha1"
 	"github.com/kinvolk/inspektor-gadget/pkg/gadgets/advise/networkpolicy/advisor"
 )
 
@@ -88,9 +89,9 @@ func runNetworkPolicyMonitor(cmd *cobra.Command, args []string) error {
 
 	config := &utils.TraceConfig{
 		GadgetName:       "network-graph",
-		Operation:        "start",
-		TraceOutputMode:  "Stream",
-		TraceOutputState: "Started",
+		Operation:        gadgetv1alpha1.OperationStart,
+		TraceOutputMode:  gadgetv1alpha1.TraceOutputModeStream,
+		TraceOutputState: gadgetv1alpha1.TraceStateStarted,
 		CommonFlags:      &params,
 	}
 	count := 0

--- a/cmd/kubectl-gadget/audit/seccomp.go
+++ b/cmd/kubectl-gadget/audit/seccomp.go
@@ -22,6 +22,7 @@ import (
 	commonaudit "github.com/kinvolk/inspektor-gadget/cmd/common/audit"
 	commonutils "github.com/kinvolk/inspektor-gadget/cmd/common/utils"
 	"github.com/kinvolk/inspektor-gadget/cmd/kubectl-gadget/utils"
+	gadgetv1alpha1 "github.com/kinvolk/inspektor-gadget/pkg/apis/gadget/v1alpha1"
 	"github.com/kinvolk/inspektor-gadget/pkg/gadgets/audit/seccomp/types"
 	eventtypes "github.com/kinvolk/inspektor-gadget/pkg/types"
 
@@ -45,9 +46,9 @@ func newSeccompCmd() *cobra.Command {
 
 			config := &utils.TraceConfig{
 				GadgetName:       "audit-seccomp",
-				Operation:        "start",
-				TraceOutputMode:  "Stream",
-				TraceOutputState: "Started",
+				Operation:        gadgetv1alpha1.OperationStart,
+				TraceOutputMode:  gadgetv1alpha1.TraceOutputModeStream,
+				TraceOutputState: gadgetv1alpha1.TraceStateStarted,
 				CommonFlags:      &commonFlags,
 			}
 

--- a/cmd/kubectl-gadget/profile/profile.go
+++ b/cmd/kubectl-gadget/profile/profile.go
@@ -22,6 +22,7 @@ import (
 
 	commonutils "github.com/kinvolk/inspektor-gadget/cmd/common/utils"
 	"github.com/kinvolk/inspektor-gadget/cmd/kubectl-gadget/utils"
+	gadgetv1alpha1 "github.com/kinvolk/inspektor-gadget/pkg/apis/gadget/v1alpha1"
 	"github.com/spf13/cobra"
 )
 
@@ -45,10 +46,10 @@ type ProfileGadget struct {
 func (g *ProfileGadget) Run() error {
 	traceConfig := &utils.TraceConfig{
 		GadgetName:        g.gadgetName,
-		Operation:         "start",
-		TraceOutputMode:   "Status",
-		TraceOutputState:  "Completed",
-		TraceInitialState: "Started",
+		Operation:         gadgetv1alpha1.OperationStart,
+		TraceOutputMode:   gadgetv1alpha1.TraceOutputModeStatus,
+		TraceOutputState:  gadgetv1alpha1.TraceStateCompleted,
+		TraceInitialState: gadgetv1alpha1.TraceStateStarted,
 		Parameters:        g.params,
 		CommonFlags:       g.commonFlags,
 	}
@@ -84,13 +85,13 @@ func (g *ProfileGadget) Run() error {
 		fmt.Println()
 	}
 
-	err = utils.SetTraceOperation(traceID, "stop")
+	err = utils.SetTraceOperation(traceID, string(gadgetv1alpha1.OperationStop))
 	if err != nil {
 		return commonutils.WrapInErrStopGadget(err)
 	}
 
 	err = utils.PrintTraceOutputFromStatus(traceID,
-		traceConfig.TraceOutputState, g.parser.DisplayResultsCallback)
+		string(traceConfig.TraceOutputState), g.parser.DisplayResultsCallback)
 	if err != nil {
 		return commonutils.WrapInErrGetGadgetOutput(err)
 	}

--- a/cmd/kubectl-gadget/snapshot/snapshot.go
+++ b/cmd/kubectl-gadget/snapshot/snapshot.go
@@ -17,15 +17,16 @@ package snapshot
 import (
 	commonsnapshot "github.com/kinvolk/inspektor-gadget/cmd/common/snapshot"
 	"github.com/kinvolk/inspektor-gadget/cmd/kubectl-gadget/utils"
+	gadgetv1alpha1 "github.com/kinvolk/inspektor-gadget/pkg/apis/gadget/v1alpha1"
 	"github.com/spf13/cobra"
 )
 
 func NewSnapshotTraceConfig(gadgetName string, commonFlags *utils.CommonFlags, params map[string]string) *utils.TraceConfig {
 	return &utils.TraceConfig{
 		GadgetName:       gadgetName,
-		Operation:        "collect",
-		TraceOutputMode:  "Status",
-		TraceOutputState: "Completed",
+		Operation:        gadgetv1alpha1.OperationCollect,
+		TraceOutputMode:  gadgetv1alpha1.TraceOutputModeStatus,
+		TraceOutputState: gadgetv1alpha1.TraceStateCompleted,
 		Parameters:       params,
 		CommonFlags:      commonFlags,
 	}

--- a/cmd/kubectl-gadget/top/block-io.go
+++ b/cmd/kubectl-gadget/top/block-io.go
@@ -28,6 +28,7 @@ import (
 
 	commonutils "github.com/kinvolk/inspektor-gadget/cmd/common/utils"
 	"github.com/kinvolk/inspektor-gadget/cmd/kubectl-gadget/utils"
+	gadgetv1alpha1 "github.com/kinvolk/inspektor-gadget/pkg/apis/gadget/v1alpha1"
 	"github.com/kinvolk/inspektor-gadget/pkg/gadgets/top/block-io/types"
 )
 
@@ -108,9 +109,9 @@ func newBlockIOCmd() *cobra.Command {
 
 			config := &utils.TraceConfig{
 				GadgetName:       "biotop",
-				Operation:        "start",
-				TraceOutputMode:  "Stream",
-				TraceOutputState: "Started",
+				Operation:        gadgetv1alpha1.OperationStart,
+				TraceOutputMode:  gadgetv1alpha1.TraceOutputModeStream,
+				TraceOutputState: gadgetv1alpha1.TraceStateStarted,
 				CommonFlags:      commonFlags,
 				Parameters: map[string]string{
 					types.IntervalParam: strconv.Itoa(flags.OutputInterval),

--- a/cmd/kubectl-gadget/top/ebpf.go
+++ b/cmd/kubectl-gadget/top/ebpf.go
@@ -25,6 +25,7 @@ import (
 
 	commonutils "github.com/kinvolk/inspektor-gadget/cmd/common/utils"
 	"github.com/kinvolk/inspektor-gadget/cmd/kubectl-gadget/utils"
+	gadgetv1alpha1 "github.com/kinvolk/inspektor-gadget/pkg/apis/gadget/v1alpha1"
 	"github.com/kinvolk/inspektor-gadget/pkg/gadgets/top/ebpf/types"
 
 	"github.com/spf13/cobra"
@@ -104,9 +105,9 @@ func newEbpfCmd() *cobra.Command {
 
 			config := &utils.TraceConfig{
 				GadgetName:       "ebpftop",
-				Operation:        "start",
-				TraceOutputMode:  "Stream",
-				TraceOutputState: "Started",
+				Operation:        gadgetv1alpha1.OperationStart,
+				TraceOutputMode:  gadgetv1alpha1.TraceOutputModeStream,
+				TraceOutputState: gadgetv1alpha1.TraceStateStarted,
 				CommonFlags:      commonFlags,
 				Parameters: map[string]string{
 					types.IntervalParam: strconv.Itoa(flags.OutputInterval),

--- a/cmd/kubectl-gadget/top/file.go
+++ b/cmd/kubectl-gadget/top/file.go
@@ -28,6 +28,7 @@ import (
 
 	commonutils "github.com/kinvolk/inspektor-gadget/cmd/common/utils"
 	"github.com/kinvolk/inspektor-gadget/cmd/kubectl-gadget/utils"
+	gadgetv1alpha1 "github.com/kinvolk/inspektor-gadget/pkg/apis/gadget/v1alpha1"
 	"github.com/kinvolk/inspektor-gadget/pkg/gadgets/top/file/types"
 )
 
@@ -110,9 +111,9 @@ func newFileCmd() *cobra.Command {
 
 			config := &utils.TraceConfig{
 				GadgetName:       "filetop",
-				Operation:        "start",
-				TraceOutputMode:  "Stream",
-				TraceOutputState: "Started",
+				Operation:        gadgetv1alpha1.OperationStart,
+				TraceOutputMode:  gadgetv1alpha1.TraceOutputModeStream,
+				TraceOutputState: gadgetv1alpha1.TraceStateStarted,
 				CommonFlags:      commonFlags,
 				Parameters: map[string]string{
 					types.IntervalParam: strconv.Itoa(flags.OutputInterval),

--- a/cmd/kubectl-gadget/top/tcp.go
+++ b/cmd/kubectl-gadget/top/tcp.go
@@ -29,6 +29,7 @@ import (
 
 	commonutils "github.com/kinvolk/inspektor-gadget/cmd/common/utils"
 	"github.com/kinvolk/inspektor-gadget/cmd/kubectl-gadget/utils"
+	gadgetv1alpha1 "github.com/kinvolk/inspektor-gadget/pkg/apis/gadget/v1alpha1"
 	"github.com/kinvolk/inspektor-gadget/pkg/gadgets/top/tcp/types"
 )
 
@@ -122,9 +123,9 @@ func newTCPCmd() *cobra.Command {
 
 			config := &utils.TraceConfig{
 				GadgetName:       "tcptop",
-				Operation:        "start",
-				TraceOutputMode:  "Stream",
-				TraceOutputState: "Started",
+				Operation:        gadgetv1alpha1.OperationStart,
+				TraceOutputMode:  gadgetv1alpha1.TraceOutputModeStream,
+				TraceOutputState: gadgetv1alpha1.TraceStateStarted,
 				CommonFlags:      commonFlags,
 				Parameters:       parameters,
 			}

--- a/cmd/kubectl-gadget/trace/trace.go
+++ b/cmd/kubectl-gadget/trace/trace.go
@@ -21,6 +21,7 @@ import (
 
 	commonutils "github.com/kinvolk/inspektor-gadget/cmd/common/utils"
 	"github.com/kinvolk/inspektor-gadget/cmd/kubectl-gadget/utils"
+	gadgetv1alpha1 "github.com/kinvolk/inspektor-gadget/pkg/apis/gadget/v1alpha1"
 	eventtypes "github.com/kinvolk/inspektor-gadget/pkg/types"
 
 	"github.com/spf13/cobra"
@@ -62,9 +63,9 @@ type TraceGadget[Event TraceEvent] struct {
 func (g *TraceGadget[Event]) Run() error {
 	config := &utils.TraceConfig{
 		GadgetName:       g.name,
-		Operation:        "start",
-		TraceOutputMode:  "Stream",
-		TraceOutputState: "Started",
+		Operation:        gadgetv1alpha1.OperationStart,
+		TraceOutputMode:  gadgetv1alpha1.TraceOutputModeStream,
+		TraceOutputState: gadgetv1alpha1.TraceStateStarted,
 		CommonFlags:      g.commonFlags,
 		Parameters:       g.params,
 	}

--- a/cmd/kubectl-gadget/traceloop.go
+++ b/cmd/kubectl-gadget/traceloop.go
@@ -36,6 +36,7 @@ import (
 
 	commonutils "github.com/kinvolk/inspektor-gadget/cmd/common/utils"
 	"github.com/kinvolk/inspektor-gadget/cmd/kubectl-gadget/utils"
+	gadgetv1alpha1 "github.com/kinvolk/inspektor-gadget/pkg/apis/gadget/v1alpha1"
 	"github.com/kinvolk/inspektor-gadget/pkg/k8sutil"
 	"github.com/kinvolk/traceloop/pkg/tracemeta"
 )
@@ -191,8 +192,8 @@ func runTraceloopStart(cmd *cobra.Command, args []string) error {
 	// Create traceloop trace
 	_, err = utils.CreateTrace(&utils.TraceConfig{
 		GadgetName:      "traceloop",
-		Operation:       "start",
-		TraceOutputMode: "ExternalResource",
+		Operation:       gadgetv1alpha1.OperationStart,
+		TraceOutputMode: gadgetv1alpha1.TraceOutputModeExternalResource,
 		CommonFlags:     &params,
 	})
 	if err != nil {

--- a/cmd/local-gadget/interactive/interactive.go
+++ b/cmd/local-gadget/interactive/interactive.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/chzyer/readline"
 	"github.com/kinvolk/inspektor-gadget/cmd/local-gadget/utils"
+	gadgetv1alpha1 "github.com/kinvolk/inspektor-gadget/pkg/apis/gadget/v1alpha1"
 	localgadgetmanager "github.com/kinvolk/inspektor-gadget/pkg/local-gadget-manager"
 	"github.com/spf13/cobra"
 )
@@ -88,7 +89,7 @@ func newRootCmd(localGadgetManager *localgadgetmanager.LocalGadgetManager) *cobr
 					return
 				}
 				gadget, name := args[0], args[1]
-				err := localGadgetManager.AddTracer(gadget, name, optionContainerSelector, optionOutputMode, nil)
+				err := localGadgetManager.AddTracer(gadget, name, optionContainerSelector, gadgetv1alpha1.TraceOutputMode(optionOutputMode), nil)
 				if err != nil {
 					fmt.Println(err.Error())
 					return
@@ -98,7 +99,7 @@ func newRootCmd(localGadgetManager *localgadgetmanager.LocalGadgetManager) *cobr
 				if len(operations) == 1 {
 					err = localGadgetManager.Operation(name, operations[0])
 				} else {
-					err = localGadgetManager.Operation(name, "start")
+					err = localGadgetManager.Operation(name, gadgetv1alpha1.OperationStart)
 				}
 
 				if err != nil {
@@ -123,7 +124,7 @@ func newRootCmd(localGadgetManager *localgadgetmanager.LocalGadgetManager) *cobr
 					return
 				}
 				name, opname := args[0], args[1]
-				err := localGadgetManager.Operation(name, opname)
+				err := localGadgetManager.Operation(name, gadgetv1alpha1.Operation(opname))
 				if err != nil {
 					fmt.Println(err.Error())
 					return
@@ -316,7 +317,12 @@ func RunInteractiveLocalGadget(commonFlags *utils.CommonFlags) error {
 					}
 					// TODO: this might select the wrong field if flags are placed elsewhere
 					traceName := fields[1]
-					return localGadgetManager.ListOperations(traceName)
+					operations := localGadgetManager.ListOperations(traceName)
+					ret := make([]string, len(operations))
+					for i, op := range operations {
+						ret[i] = string(op)
+					}
+					return ret
 				}),
 			),
 		),

--- a/cmd/local-gadget/snapshot/snapshot.go
+++ b/cmd/local-gadget/snapshot/snapshot.go
@@ -17,13 +17,14 @@ package snapshot
 import (
 	commonsnapshot "github.com/kinvolk/inspektor-gadget/cmd/common/snapshot"
 	"github.com/kinvolk/inspektor-gadget/cmd/local-gadget/utils"
+	gadgetv1alpha1 "github.com/kinvolk/inspektor-gadget/pkg/apis/gadget/v1alpha1"
 	"github.com/spf13/cobra"
 )
 
 func NewSnapshotTraceConfig(gadgetName string, commonFlags *utils.CommonFlags, params map[string]string) *utils.TraceConfig {
 	return &utils.TraceConfig{
 		GadgetName:       gadgetName,
-		TraceOutputState: "Completed",
+		TraceOutputState: gadgetv1alpha1.TraceStateCompleted,
 		Parameters:       params,
 		CommonFlags:      commonFlags,
 	}

--- a/cmd/local-gadget/utils/trace.go
+++ b/cmd/local-gadget/utils/trace.go
@@ -17,6 +17,7 @@ package utils
 import (
 	"fmt"
 
+	gadgetv1alpha1 "github.com/kinvolk/inspektor-gadget/pkg/apis/gadget/v1alpha1"
 	localgadgetmanager "github.com/kinvolk/inspektor-gadget/pkg/local-gadget-manager"
 )
 
@@ -29,7 +30,7 @@ type TraceConfig struct {
 	// For example, trace for *-collector gadget contains output while in
 	// Completed state.
 	// But other gadgets, like dns, can contain output only in Started state.
-	TraceOutputState string
+	TraceOutputState gadgetv1alpha1.TraceState
 
 	// Parameters is used to pass specific gadget configurations.
 	Parameters map[string]string
@@ -63,7 +64,7 @@ func RunTraceAndPrintStatusOutput(config *TraceConfig, customResultsDisplay func
 	if len(operations) == 1 {
 		err = localGadgetManager.Operation(traceName, operations[0])
 	} else {
-		err = localGadgetManager.Operation(traceName, "start")
+		err = localGadgetManager.Operation(traceName, gadgetv1alpha1.OperationStart)
 	}
 
 	if err != nil {

--- a/pkg/apis/gadget/v1alpha1/types.go
+++ b/pkg/apis/gadget/v1alpha1/types.go
@@ -21,6 +21,50 @@ import (
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
+// Operation defines the gadget operation applied to the trace
+type Operation string
+
+const (
+	// OperationStart indicates to start the trace
+	OperationStart Operation = "start"
+	// OperationStop indicates to stop the trace
+	OperationStop Operation = "stop"
+	// OperationGenerate indicates to generate the trace
+	// output e.g seccomp profile
+	OperationGenerate Operation = "generate"
+	// OperationCollect indicates capturing system state
+	// at a specific point in time
+	OperationCollect Operation = "collect"
+)
+
+// RunMode defines running mode for the Trace
+// +kubebuilder:validation:Enum=Auto;Manual
+type RunMode string
+
+const (
+	// RunModeAuto automatically starts the trace as soon
+	// as the resource is created.
+	RunModeAuto RunMode = "Auto"
+	// RunModeManual allows the trace to be controlled by the
+	// "gadget.kinvolk.io/operation" annotation.
+	RunModeManual RunMode = "Manual"
+)
+
+// TraceOutputMode defines output mode for the Trace
+// +kubebuilder:validation:Enum=Status;Stream;File;ExternalResource
+type TraceOutputMode string
+
+const (
+	// TraceOutputModeStatus indicates to store the output in the trace "Status.Output" field
+	TraceOutputModeStatus TraceOutputMode = "Status"
+	// TraceOutputModeStream indicates to stream events. This stream can be accessed through the Stream() api on the gadget tracer manager
+	TraceOutputModeStream TraceOutputMode = "Stream"
+	// TraceOutputModeFile indicates to save output into a file
+	TraceOutputModeFile TraceOutputMode = "File"
+	// TraceOutputModeExternalResource indicates to create an external resource, as a seccomp profile
+	TraceOutputModeExternalResource TraceOutputMode = "ExternalResource"
+)
+
 // ContainerFilter filters events based on different criteria
 type ContainerFilter struct {
 	// Namespace selects events from this pod namespace
@@ -50,15 +94,14 @@ type TraceSpec struct {
 	// RunMode is "Auto" to automatically start the trace as soon as the
 	// resource is created, or "Manual" to be controlled by the
 	// "gadget.kinvolk.io/operation" annotation
-	RunMode string `json:"runMode,omitempty"`
+	RunMode RunMode `json:"runMode,omitempty"`
 
 	// Filter is to tell the gadget to filter events based on namespace,
 	// pod name, labels or container name
 	Filter *ContainerFilter `json:"filter,omitempty"`
 
 	// OutputMode is "Status", "Stream", "File" or "ExternalResource"
-	// +kubebuilder:validation:Enum=Status;Stream;File;ExternalResource
-	OutputMode string `json:"outputMode,omitempty"`
+	OutputMode TraceOutputMode `json:"outputMode,omitempty"`
 
 	// Output allows a gadget to output the results in the specified
 	// location.
@@ -77,14 +120,26 @@ type TraceSpec struct {
 	Parameters map[string]string `json:"parameters,omitempty"`
 }
 
+// TraceState defines state for the trace
+// +kubebuilder:validation:Enum=Started;Stopped;Completed
+type TraceState string
+
+const (
+	// TraceStateStarted indicates trace is in started state
+	TraceStateStarted TraceState = "Started"
+	// TraceStateStopped indicates trace is in stopped state
+	TraceStateStopped TraceState = "Stopped"
+	// TraceStateCompleted indicates trace is in completed state
+	TraceStateCompleted TraceState = "Completed"
+)
+
 // TraceStatus defines the observed state of Trace
 type TraceStatus struct {
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 
 	// State is "Started", "Stopped" or "Completed"
-	// +kubebuilder:validation:Enum=Started;Stopped;Completed
-	State string `json:"state,omitempty"`
+	State TraceState `json:"state,omitempty"`
 
 	// Output is the output of the gadget
 	Output string `json:"output,omitempty"`

--- a/pkg/controllers/trace_controller.go
+++ b/pkg/controllers/trace_controller.go
@@ -161,7 +161,7 @@ func (r *TraceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 
 		return ctrl.Result{}, nil
 	}
-	if trace.Spec.RunMode != "Manual" {
+	if trace.Spec.RunMode != gadgetv1alpha1.RunModeManual {
 		setTraceOpError(ctx, r.Client, req.NamespacedName.String(),
 			trace, fmt.Sprintf("Unsupported RunMode %q for gadget %q",
 				trace.Spec.RunMode, trace.Spec.Gadget))
@@ -236,7 +236,7 @@ func (r *TraceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 	}
 
 	// Check operation is supported for this specific gadget
-	gadgetOperation, ok := factory.Operations()[op]
+	gadgetOperation, ok := factory.Operations()[gadgetv1alpha1.Operation(op)]
 	if !ok {
 		setTraceOpError(ctx, r.Client, req.NamespacedName.String(),
 			trace, fmt.Sprintf("Unsupported operation %q for gadget %q",

--- a/pkg/gadget-collection/gadgets/audit/seccomp/gadget.go
+++ b/pkg/gadget-collection/gadgets/audit/seccomp/gadget.go
@@ -54,9 +54,9 @@ one of those two conditions:
 `
 }
 
-func (f *TraceFactory) OutputModesSupported() map[string]struct{} {
-	return map[string]struct{}{
-		"Stream": {},
+func (f *TraceFactory) OutputModesSupported() map[gadgetv1alpha1.TraceOutputMode]struct{} {
+	return map[gadgetv1alpha1.TraceOutputMode]struct{}{
+		gadgetv1alpha1.TraceOutputModeStream: {},
 	}
 }
 
@@ -68,20 +68,20 @@ func deleteTrace(name string, t interface{}) {
 	}
 }
 
-func (f *TraceFactory) Operations() map[string]gadgets.TraceOperation {
+func (f *TraceFactory) Operations() map[gadgetv1alpha1.Operation]gadgets.TraceOperation {
 	n := func() interface{} {
 		return &Trace{
 			helpers: f.Helpers,
 		}
 	}
-	return map[string]gadgets.TraceOperation{
-		"start": {
+	return map[gadgetv1alpha1.Operation]gadgets.TraceOperation{
+		gadgetv1alpha1.OperationStart: {
 			Doc: "Start audit seccomp",
 			Operation: func(name string, trace *gadgetv1alpha1.Trace) {
 				f.LookupOrCreate(name, n).(*Trace).Start(trace)
 			},
 		},
-		"stop": {
+		gadgetv1alpha1.OperationStop: {
 			Doc: "Stop audit seccomp",
 			Operation: func(name string, trace *gadgetv1alpha1.Trace) {
 				f.LookupOrCreate(name, n).(*Trace).Stop(trace)
@@ -92,7 +92,7 @@ func (f *TraceFactory) Operations() map[string]gadgets.TraceOperation {
 
 func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 	if t.started {
-		trace.Status.State = "Started"
+		trace.Status.State = gadgetv1alpha1.TraceStateStarted
 		return
 	}
 
@@ -125,7 +125,7 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 	}
 	t.started = true
 
-	trace.Status.State = "Started"
+	trace.Status.State = gadgetv1alpha1.TraceStateStarted
 }
 
 func (t *Trace) Stop(trace *gadgetv1alpha1.Trace) {
@@ -139,5 +139,5 @@ func (t *Trace) Stop(trace *gadgetv1alpha1.Trace) {
 
 	t.started = false
 
-	trace.Status.State = "Stopped"
+	trace.Status.State = gadgetv1alpha1.TraceStateStopped
 }

--- a/pkg/gadget-collection/gadgets/interface.go
+++ b/pkg/gadget-collection/gadgets/interface.go
@@ -40,11 +40,11 @@ type TraceFactory interface {
 
 	// Operations gives the list of operations on a gadget that users can
 	// call via the gadget.kinvolk.io/operation annotation.
-	Operations() map[string]TraceOperation
+	Operations() map[gadgetv1alpha1.Operation]TraceOperation
 
 	// OutputModesSupported returns the set of OutputMode supported by the
 	// gadget.
-	OutputModesSupported() map[string]struct{}
+	OutputModesSupported() map[gadgetv1alpha1.TraceOutputMode]struct{}
 }
 
 type TraceFactoryWithScheme interface {
@@ -145,10 +145,10 @@ func (f *BaseFactory) Delete(name string) {
 	delete(f.traces, name)
 }
 
-func (f *BaseFactory) Operations() map[string]TraceOperation {
-	return map[string]TraceOperation{}
+func (f *BaseFactory) Operations() map[gadgetv1alpha1.Operation]TraceOperation {
+	return map[gadgetv1alpha1.Operation]TraceOperation{}
 }
 
-func (f *BaseFactory) OutputModesSupported() map[string]struct{} {
-	return map[string]struct{}{}
+func (f *BaseFactory) OutputModesSupported() map[gadgetv1alpha1.TraceOutputMode]struct{} {
+	return map[gadgetv1alpha1.TraceOutputMode]struct{}{}
 }

--- a/pkg/gadget-collection/gadgets/profile/block-io/gadget.go
+++ b/pkg/gadget-collection/gadgets/profile/block-io/gadget.go
@@ -51,9 +51,9 @@ distribution of I/O latency (time), giving this as a histogram when it is
 stopped.`
 }
 
-func (f *TraceFactory) OutputModesSupported() map[string]struct{} {
-	return map[string]struct{}{
-		"Status": {},
+func (f *TraceFactory) OutputModesSupported() map[gadgetv1alpha1.TraceOutputMode]struct{} {
+	return map[gadgetv1alpha1.TraceOutputMode]struct{}{
+		gadgetv1alpha1.TraceOutputModeStatus: {},
 	}
 }
 
@@ -64,19 +64,19 @@ func deleteTrace(name string, t interface{}) {
 	}
 }
 
-func (f *TraceFactory) Operations() map[string]gadgets.TraceOperation {
+func (f *TraceFactory) Operations() map[gadgetv1alpha1.Operation]gadgets.TraceOperation {
 	n := func() interface{} {
 		return &Trace{}
 	}
 
-	return map[string]gadgets.TraceOperation{
-		"start": {
+	return map[gadgetv1alpha1.Operation]gadgets.TraceOperation{
+		gadgetv1alpha1.OperationStart: {
 			Doc: "Start biolatency",
 			Operation: func(name string, trace *gadgetv1alpha1.Trace) {
 				f.LookupOrCreate(name, n).(*Trace).Start(trace)
 			},
 		},
-		"stop": {
+		gadgetv1alpha1.OperationStop: {
 			Doc: "Stop biolatency and store results",
 			Operation: func(name string, trace *gadgetv1alpha1.Trace) {
 				f.LookupOrCreate(name, n).(*Trace).Stop(trace)
@@ -92,7 +92,7 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 	}
 
 	if t.started {
-		trace.Status.State = "Started"
+		trace.Status.State = gadgetv1alpha1.TraceStateStarted
 		return
 	}
 
@@ -114,7 +114,7 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 	t.started = true
 
 	trace.Status.Output = ""
-	trace.Status.State = "Started"
+	trace.Status.State = gadgetv1alpha1.TraceStateStarted
 	return
 }
 
@@ -134,6 +134,6 @@ func (t *Trace) Stop(trace *gadgetv1alpha1.Trace) {
 	t.started = false
 
 	trace.Status.Output = output
-	trace.Status.State = "Completed"
+	trace.Status.State = gadgetv1alpha1.TraceStateCompleted
 	return
 }

--- a/pkg/gadget-collection/gadgets/profile/cpu/gadget.go
+++ b/pkg/gadget-collection/gadgets/profile/cpu/gadget.go
@@ -50,9 +50,9 @@ func (f *TraceFactory) Description() string {
 	return `Analyze CPU performance by sampling stack traces`
 }
 
-func (f *TraceFactory) OutputModesSupported() map[string]struct{} {
-	return map[string]struct{}{
-		"Status": {},
+func (f *TraceFactory) OutputModesSupported() map[gadgetv1alpha1.TraceOutputMode]struct{} {
+	return map[gadgetv1alpha1.TraceOutputMode]struct{}{
+		gadgetv1alpha1.TraceOutputModeStatus: {},
 	}
 }
 
@@ -63,21 +63,21 @@ func deleteTrace(name string, t interface{}) {
 	}
 }
 
-func (f *TraceFactory) Operations() map[string]gadgets.TraceOperation {
+func (f *TraceFactory) Operations() map[gadgetv1alpha1.Operation]gadgets.TraceOperation {
 	n := func() interface{} {
 		return &Trace{
 			helpers: f.Helpers,
 		}
 	}
 
-	return map[string]gadgets.TraceOperation{
-		"start": {
+	return map[gadgetv1alpha1.Operation]gadgets.TraceOperation{
+		gadgetv1alpha1.OperationStart: {
 			Doc: "Start profile",
 			Operation: func(name string, trace *gadgetv1alpha1.Trace) {
 				f.LookupOrCreate(name, n).(*Trace).Start(trace)
 			},
 		},
-		"stop": {
+		gadgetv1alpha1.OperationStop: {
 			Doc: "Stop profile and store results",
 			Operation: func(name string, trace *gadgetv1alpha1.Trace) {
 				f.LookupOrCreate(name, n).(*Trace).Stop(trace)
@@ -88,7 +88,7 @@ func (f *TraceFactory) Operations() map[string]gadgets.TraceOperation {
 
 func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 	if t.started {
-		trace.Status.State = "Started"
+		trace.Status.State = gadgetv1alpha1.TraceStateStarted
 		return
 	}
 
@@ -125,7 +125,7 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 	t.started = true
 
 	trace.Status.Output = ""
-	trace.Status.State = "Started"
+	trace.Status.State = gadgetv1alpha1.TraceStateStarted
 }
 
 func (t *Trace) Stop(trace *gadgetv1alpha1.Trace) {
@@ -144,5 +144,5 @@ func (t *Trace) Stop(trace *gadgetv1alpha1.Trace) {
 	t.started = false
 
 	trace.Status.Output = output
-	trace.Status.State = "Completed"
+	trace.Status.State = gadgetv1alpha1.TraceStateCompleted
 }

--- a/pkg/gadget-collection/gadgets/snapshot/process/gadget.go
+++ b/pkg/gadget-collection/gadgets/snapshot/process/gadget.go
@@ -39,21 +39,21 @@ func (f *TraceFactory) Description() string {
 	return `The process-collector gadget gathers information about running processes`
 }
 
-func (f *TraceFactory) OutputModesSupported() map[string]struct{} {
-	return map[string]struct{}{
-		"Status": {},
+func (f *TraceFactory) OutputModesSupported() map[gadgetv1alpha1.TraceOutputMode]struct{} {
+	return map[gadgetv1alpha1.TraceOutputMode]struct{}{
+		gadgetv1alpha1.TraceOutputModeStatus: {},
 	}
 }
 
-func (f *TraceFactory) Operations() map[string]gadgets.TraceOperation {
+func (f *TraceFactory) Operations() map[gadgetv1alpha1.Operation]gadgets.TraceOperation {
 	n := func() interface{} {
 		return &Trace{
 			helpers: f.Helpers,
 		}
 	}
 
-	return map[string]gadgets.TraceOperation{
-		"collect": {
+	return map[gadgetv1alpha1.Operation]gadgets.TraceOperation{
+		gadgetv1alpha1.OperationCollect: {
 			Doc: "Create a snapshot of the currently running processes. " +
 				"Once taken, the snapshot is not updated automatically. " +
 				"However one can call the collect operation again at any time to update the snapshot.",
@@ -79,7 +79,7 @@ func (t *Trace) Collect(trace *gadgetv1alpha1.Trace) {
 
 	if len(events) == 0 {
 		trace.Status.OperationWarning = "No container matches the requested filter"
-		trace.Status.State = "Completed"
+		trace.Status.State = gadgetv1alpha1.TraceStateCompleted
 		return
 	}
 
@@ -90,5 +90,5 @@ func (t *Trace) Collect(trace *gadgetv1alpha1.Trace) {
 	}
 
 	trace.Status.Output = string(output)
-	trace.Status.State = "Completed"
+	trace.Status.State = gadgetv1alpha1.TraceStateCompleted
 }

--- a/pkg/gadget-collection/gadgets/snapshot/socket/gadget.go
+++ b/pkg/gadget-collection/gadgets/snapshot/socket/gadget.go
@@ -42,21 +42,21 @@ func (f *TraceFactory) Description() string {
 	return `The socket-collector gadget gathers information about TCP and UDP sockets.`
 }
 
-func (f *TraceFactory) OutputModesSupported() map[string]struct{} {
-	return map[string]struct{}{
-		"Status": {},
+func (f *TraceFactory) OutputModesSupported() map[gadgetv1alpha1.TraceOutputMode]struct{} {
+	return map[gadgetv1alpha1.TraceOutputMode]struct{}{
+		gadgetv1alpha1.TraceOutputModeStatus: {},
 	}
 }
 
-func (f *TraceFactory) Operations() map[string]gadgets.TraceOperation {
+func (f *TraceFactory) Operations() map[gadgetv1alpha1.Operation]gadgets.TraceOperation {
 	n := func() interface{} {
 		return &Trace{
 			helpers: f.Helpers,
 		}
 	}
 
-	return map[string]gadgets.TraceOperation{
-		"collect": {
+	return map[gadgetv1alpha1.Operation]gadgets.TraceOperation{
+		gadgetv1alpha1.OperationCollect: {
 			Doc: "Create a snapshot of the currently open TCP and UDP sockets. " +
 				"Once taken, the snapshot is not updated automatically. " +
 				"However one can call the collect operation again at any time to update the snapshot.",
@@ -77,7 +77,7 @@ func (t *Trace) Collect(trace *gadgetv1alpha1.Trace) {
 	filteredContainers := t.helpers.GetContainersBySelector(selector)
 	if len(filteredContainers) == 0 {
 		trace.Status.OperationWarning = "No container matches the requested filter"
-		trace.Status.State = "Completed"
+		trace.Status.State = gadgetv1alpha1.TraceStateCompleted
 		return
 	}
 
@@ -136,5 +136,5 @@ func (t *Trace) Collect(trace *gadgetv1alpha1.Trace) {
 	}
 
 	trace.Status.Output = string(output)
-	trace.Status.State = "Completed"
+	trace.Status.State = gadgetv1alpha1.TraceStateCompleted
 }

--- a/pkg/gadget-collection/gadgets/top/block-io/gadget.go
+++ b/pkg/gadget-collection/gadgets/top/block-io/gadget.go
@@ -59,9 +59,9 @@ The following parameters are supported:
 		types.SortByParam, strings.Join(types.SortBySlice, ","), types.SortByDefault)
 }
 
-func (f *TraceFactory) OutputModesSupported() map[string]struct{} {
-	return map[string]struct{}{
-		"Stream": {},
+func (f *TraceFactory) OutputModesSupported() map[gadgetv1alpha1.TraceOutputMode]struct{} {
+	return map[gadgetv1alpha1.TraceOutputMode]struct{}{
+		gadgetv1alpha1.TraceOutputModeStream: {},
 	}
 }
 
@@ -72,21 +72,21 @@ func deleteTrace(name string, t interface{}) {
 	}
 }
 
-func (f *TraceFactory) Operations() map[string]gadgets.TraceOperation {
+func (f *TraceFactory) Operations() map[gadgetv1alpha1.Operation]gadgets.TraceOperation {
 	n := func() interface{} {
 		return &Trace{
 			helpers: f.Helpers,
 		}
 	}
 
-	return map[string]gadgets.TraceOperation{
-		"start": {
+	return map[gadgetv1alpha1.Operation]gadgets.TraceOperation{
+		gadgetv1alpha1.OperationStart: {
 			Doc: "Start biotop gadget",
 			Operation: func(name string, trace *gadgetv1alpha1.Trace) {
 				f.LookupOrCreate(name, n).(*Trace).Start(trace)
 			},
 		},
-		"stop": {
+		gadgetv1alpha1.OperationStop: {
 			Doc: "Stop biotop gadget",
 			Operation: func(name string, trace *gadgetv1alpha1.Trace) {
 				f.LookupOrCreate(name, n).(*Trace).Stop(trace)
@@ -97,7 +97,7 @@ func (f *TraceFactory) Operations() map[string]gadgets.TraceOperation {
 
 func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 	if t.started {
-		trace.Status.State = "Started"
+		trace.Status.State = gadgetv1alpha1.TraceStateStarted
 		return
 	}
 
@@ -166,7 +166,7 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 	t.tracer = tracer
 	t.started = true
 
-	trace.Status.State = "Started"
+	trace.Status.State = gadgetv1alpha1.TraceStateStarted
 }
 
 func (t *Trace) Stop(trace *gadgetv1alpha1.Trace) {
@@ -179,5 +179,5 @@ func (t *Trace) Stop(trace *gadgetv1alpha1.Trace) {
 	t.tracer = nil
 	t.started = false
 
-	trace.Status.State = "Stopped"
+	trace.Status.State = gadgetv1alpha1.TraceStateStopped
 }

--- a/pkg/gadget-collection/gadgets/top/ebpf/gadget.go
+++ b/pkg/gadget-collection/gadgets/top/ebpf/gadget.go
@@ -62,9 +62,9 @@ The following parameters are supported:
 		types.SortByParam, strings.Join(types.SortBySlice, ","), types.SortByDefault)
 }
 
-func (f *TraceFactory) OutputModesSupported() map[string]struct{} {
-	return map[string]struct{}{
-		"Stream": {},
+func (f *TraceFactory) OutputModesSupported() map[gadgetv1alpha1.TraceOutputMode]struct{} {
+	return map[gadgetv1alpha1.TraceOutputMode]struct{}{
+		gadgetv1alpha1.TraceOutputModeStream: {},
 	}
 }
 
@@ -75,21 +75,21 @@ func deleteTrace(name string, t interface{}) {
 	}
 }
 
-func (f *TraceFactory) Operations() map[string]gadgets.TraceOperation {
+func (f *TraceFactory) Operations() map[gadgetv1alpha1.Operation]gadgets.TraceOperation {
 	n := func() interface{} {
 		return &Trace{
 			helpers: f.Helpers,
 		}
 	}
 
-	return map[string]gadgets.TraceOperation{
-		"start": {
+	return map[gadgetv1alpha1.Operation]gadgets.TraceOperation{
+		gadgetv1alpha1.OperationStart: {
 			Doc: "Start ebpftop gadget",
 			Operation: func(name string, trace *gadgetv1alpha1.Trace) {
 				f.LookupOrCreate(name, n).(*Trace).Start(trace)
 			},
 		},
-		"stop": {
+		gadgetv1alpha1.OperationStop: {
 			Doc: "Stop ebpftop gadget",
 			Operation: func(name string, trace *gadgetv1alpha1.Trace) {
 				f.LookupOrCreate(name, n).(*Trace).Stop(trace)
@@ -100,7 +100,7 @@ func (f *TraceFactory) Operations() map[string]gadgets.TraceOperation {
 
 func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 	if t.started {
-		trace.Status.State = "Started"
+		trace.Status.State = gadgetv1alpha1.TraceStateStarted
 		return
 	}
 
@@ -164,7 +164,7 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 	t.tracer = tracer
 	t.started = true
 
-	trace.Status.State = "Started"
+	trace.Status.State = gadgetv1alpha1.TraceStateStarted
 }
 
 func (t *Trace) Stop(trace *gadgetv1alpha1.Trace) {
@@ -178,7 +178,7 @@ func (t *Trace) Stop(trace *gadgetv1alpha1.Trace) {
 		trace.Status.OperationWarning = err.Error()
 	}
 
-	trace.Status.State = "Stopped"
+	trace.Status.State = gadgetv1alpha1.TraceStateStopped
 }
 
 func (t *Trace) stop() error {

--- a/pkg/gadget-collection/gadgets/top/file/gadget.go
+++ b/pkg/gadget-collection/gadgets/top/file/gadget.go
@@ -61,9 +61,9 @@ The following parameters are supported:
 		types.AllFilesParam, types.AllFilesDefault)
 }
 
-func (f *TraceFactory) OutputModesSupported() map[string]struct{} {
-	return map[string]struct{}{
-		"Stream": {},
+func (f *TraceFactory) OutputModesSupported() map[gadgetv1alpha1.TraceOutputMode]struct{} {
+	return map[gadgetv1alpha1.TraceOutputMode]struct{}{
+		gadgetv1alpha1.TraceOutputModeStream: {},
 	}
 }
 
@@ -74,21 +74,21 @@ func deleteTrace(name string, t interface{}) {
 	}
 }
 
-func (f *TraceFactory) Operations() map[string]gadgets.TraceOperation {
+func (f *TraceFactory) Operations() map[gadgetv1alpha1.Operation]gadgets.TraceOperation {
 	n := func() interface{} {
 		return &Trace{
 			helpers: f.Helpers,
 		}
 	}
 
-	return map[string]gadgets.TraceOperation{
-		"start": {
+	return map[gadgetv1alpha1.Operation]gadgets.TraceOperation{
+		gadgetv1alpha1.OperationStart: {
 			Doc: "Start filetop gadget",
 			Operation: func(name string, trace *gadgetv1alpha1.Trace) {
 				f.LookupOrCreate(name, n).(*Trace).Start(trace)
 			},
 		},
-		"stop": {
+		gadgetv1alpha1.OperationStop: {
 			Doc: "Stop filetop gadget",
 			Operation: func(name string, trace *gadgetv1alpha1.Trace) {
 				f.LookupOrCreate(name, n).(*Trace).Stop(trace)
@@ -99,7 +99,7 @@ func (f *TraceFactory) Operations() map[string]gadgets.TraceOperation {
 
 func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 	if t.started {
-		trace.Status.State = "Started"
+		trace.Status.State = gadgetv1alpha1.TraceStateStarted
 		return
 	}
 
@@ -179,7 +179,7 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 	t.tracer = tracer
 	t.started = true
 
-	trace.Status.State = "Started"
+	trace.Status.State = gadgetv1alpha1.TraceStateStarted
 }
 
 func (t *Trace) Stop(trace *gadgetv1alpha1.Trace) {
@@ -192,5 +192,5 @@ func (t *Trace) Stop(trace *gadgetv1alpha1.Trace) {
 	t.tracer = nil
 	t.started = false
 
-	trace.Status.State = "Stopped"
+	trace.Status.State = gadgetv1alpha1.TraceStateStopped
 }

--- a/pkg/gadget-collection/gadgets/top/tcp/gadget.go
+++ b/pkg/gadget-collection/gadgets/top/tcp/gadget.go
@@ -62,9 +62,9 @@ The following parameters are supported:
 		types.PidParam, types.FamilyParam)
 }
 
-func (f *TraceFactory) OutputModesSupported() map[string]struct{} {
-	return map[string]struct{}{
-		"Stream": {},
+func (f *TraceFactory) OutputModesSupported() map[gadgetv1alpha1.TraceOutputMode]struct{} {
+	return map[gadgetv1alpha1.TraceOutputMode]struct{}{
+		gadgetv1alpha1.TraceOutputModeStream: {},
 	}
 }
 
@@ -75,21 +75,21 @@ func deleteTrace(name string, t interface{}) {
 	}
 }
 
-func (f *TraceFactory) Operations() map[string]gadgets.TraceOperation {
+func (f *TraceFactory) Operations() map[gadgetv1alpha1.Operation]gadgets.TraceOperation {
 	n := func() interface{} {
 		return &Trace{
 			helpers: f.Helpers,
 		}
 	}
 
-	return map[string]gadgets.TraceOperation{
-		"start": {
+	return map[gadgetv1alpha1.Operation]gadgets.TraceOperation{
+		gadgetv1alpha1.OperationStart: {
 			Doc: "Start tcptop gadget",
 			Operation: func(name string, trace *gadgetv1alpha1.Trace) {
 				f.LookupOrCreate(name, n).(*Trace).Start(trace)
 			},
 		},
-		"stop": {
+		gadgetv1alpha1.OperationStop: {
 			Doc: "Stop tcptop gadget",
 			Operation: func(name string, trace *gadgetv1alpha1.Trace) {
 				f.LookupOrCreate(name, n).(*Trace).Stop(trace)
@@ -100,7 +100,7 @@ func (f *TraceFactory) Operations() map[string]gadgets.TraceOperation {
 
 func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 	if t.started {
-		trace.Status.State = "Started"
+		trace.Status.State = gadgetv1alpha1.TraceStateStarted
 		return
 	}
 
@@ -191,7 +191,7 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 	t.tracer = tracer
 	t.started = true
 
-	trace.Status.State = "Started"
+	trace.Status.State = gadgetv1alpha1.TraceStateStarted
 }
 
 func (t *Trace) Stop(trace *gadgetv1alpha1.Trace) {
@@ -204,5 +204,5 @@ func (t *Trace) Stop(trace *gadgetv1alpha1.Trace) {
 	t.tracer = nil
 	t.started = false
 
-	trace.Status.State = "Stopped"
+	trace.Status.State = gadgetv1alpha1.TraceStateStopped
 }

--- a/pkg/gadget-collection/gadgets/trace/bind/gadget.go
+++ b/pkg/gadget-collection/gadgets/trace/bind/gadget.go
@@ -53,9 +53,9 @@ func (f *TraceFactory) Description() string {
 	return `bindsnoop traces the kernel functions performing socket binding.`
 }
 
-func (f *TraceFactory) OutputModesSupported() map[string]struct{} {
-	return map[string]struct{}{
-		"Stream": {},
+func (f *TraceFactory) OutputModesSupported() map[gadgetv1alpha1.TraceOutputMode]struct{} {
+	return map[gadgetv1alpha1.TraceOutputMode]struct{}{
+		gadgetv1alpha1.TraceOutputModeStream: {},
 	}
 }
 
@@ -66,21 +66,21 @@ func deleteTrace(name string, t interface{}) {
 	}
 }
 
-func (f *TraceFactory) Operations() map[string]gadgets.TraceOperation {
+func (f *TraceFactory) Operations() map[gadgetv1alpha1.Operation]gadgets.TraceOperation {
 	n := func() interface{} {
 		return &Trace{
 			helpers: f.Helpers,
 		}
 	}
 
-	return map[string]gadgets.TraceOperation{
-		"start": {
+	return map[gadgetv1alpha1.Operation]gadgets.TraceOperation{
+		gadgetv1alpha1.OperationStart: {
 			Doc: "Start bindsnoop gadget",
 			Operation: func(name string, trace *gadgetv1alpha1.Trace) {
 				f.LookupOrCreate(name, n).(*Trace).Start(trace)
 			},
 		},
-		"stop": {
+		gadgetv1alpha1.OperationStop: {
 			Doc: "Stop bindsnoop gadget",
 			Operation: func(name string, trace *gadgetv1alpha1.Trace) {
 				f.LookupOrCreate(name, n).(*Trace).Stop(trace)
@@ -91,7 +91,7 @@ func (f *TraceFactory) Operations() map[string]gadgets.TraceOperation {
 
 func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 	if t.started {
-		trace.Status.State = "Started"
+		trace.Status.State = gadgetv1alpha1.TraceStateStarted
 		return
 	}
 
@@ -175,7 +175,7 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 
 	t.started = true
 
-	trace.Status.State = "Started"
+	trace.Status.State = gadgetv1alpha1.TraceStateStarted
 }
 
 func (t *Trace) Stop(trace *gadgetv1alpha1.Trace) {
@@ -188,5 +188,5 @@ func (t *Trace) Stop(trace *gadgetv1alpha1.Trace) {
 	t.tracer = nil
 	t.started = false
 
-	trace.Status.State = "Stopped"
+	trace.Status.State = gadgetv1alpha1.TraceStateStopped
 }

--- a/pkg/gadget-collection/gadgets/trace/capabilities/gadget.go
+++ b/pkg/gadget-collection/gadgets/trace/capabilities/gadget.go
@@ -51,9 +51,9 @@ func (f *TraceFactory) Description() string {
 	return `capabilities traces security capability checks"`
 }
 
-func (f *TraceFactory) OutputModesSupported() map[string]struct{} {
-	return map[string]struct{}{
-		"Stream": {},
+func (f *TraceFactory) OutputModesSupported() map[gadgetv1alpha1.TraceOutputMode]struct{} {
+	return map[gadgetv1alpha1.TraceOutputMode]struct{}{
+		gadgetv1alpha1.TraceOutputModeStream: {},
 	}
 }
 
@@ -64,21 +64,21 @@ func deleteTrace(name string, t interface{}) {
 	}
 }
 
-func (f *TraceFactory) Operations() map[string]gadgets.TraceOperation {
+func (f *TraceFactory) Operations() map[gadgetv1alpha1.Operation]gadgets.TraceOperation {
 	n := func() interface{} {
 		return &Trace{
 			helpers: f.Helpers,
 		}
 	}
 
-	return map[string]gadgets.TraceOperation{
-		"start": {
+	return map[gadgetv1alpha1.Operation]gadgets.TraceOperation{
+		gadgetv1alpha1.OperationStart: {
 			Doc: "Start capabilities gadget",
 			Operation: func(name string, trace *gadgetv1alpha1.Trace) {
 				f.LookupOrCreate(name, n).(*Trace).Start(trace)
 			},
 		},
-		"stop": {
+		gadgetv1alpha1.OperationStop: {
 			Doc: "Stop capabilities gadget",
 			Operation: func(name string, trace *gadgetv1alpha1.Trace) {
 				f.LookupOrCreate(name, n).(*Trace).Stop(trace)
@@ -89,7 +89,7 @@ func (f *TraceFactory) Operations() map[string]gadgets.TraceOperation {
 
 func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 	if t.started {
-		trace.Status.State = "Started"
+		trace.Status.State = gadgetv1alpha1.TraceStateStarted
 		return
 	}
 
@@ -132,7 +132,7 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 
 	t.started = true
 
-	trace.Status.State = "Started"
+	trace.Status.State = gadgetv1alpha1.TraceStateStarted
 }
 
 func (t *Trace) Stop(trace *gadgetv1alpha1.Trace) {
@@ -144,5 +144,5 @@ func (t *Trace) Stop(trace *gadgetv1alpha1.Trace) {
 	t.tracer.Stop()
 	t.tracer = nil
 	t.started = false
-	trace.Status.State = "Stopped"
+	trace.Status.State = gadgetv1alpha1.TraceStateStopped
 }

--- a/pkg/gadget-collection/gadgets/trace/dns/gadget.go
+++ b/pkg/gadget-collection/gadgets/trace/dns/gadget.go
@@ -60,9 +60,9 @@ func (f *TraceFactory) Description() string {
 	return `The dns gadget traces DNS requests.`
 }
 
-func (f *TraceFactory) OutputModesSupported() map[string]struct{} {
-	return map[string]struct{}{
-		"Stream": {},
+func (f *TraceFactory) OutputModesSupported() map[gadgetv1alpha1.TraceOutputMode]struct{} {
+	return map[gadgetv1alpha1.TraceOutputMode]struct{}{
+		gadgetv1alpha1.TraceOutputModeStream: {},
 	}
 }
 
@@ -75,7 +75,7 @@ func deleteTrace(name string, t interface{}) {
 	}
 }
 
-func (f *TraceFactory) Operations() map[string]gadgets.TraceOperation {
+func (f *TraceFactory) Operations() map[gadgetv1alpha1.Operation]gadgets.TraceOperation {
 	n := func() interface{} {
 		return &Trace{
 			client:    f.Client,
@@ -84,14 +84,14 @@ func (f *TraceFactory) Operations() map[string]gadgets.TraceOperation {
 		}
 	}
 
-	return map[string]gadgets.TraceOperation{
-		"start": {
+	return map[gadgetv1alpha1.Operation]gadgets.TraceOperation{
+		gadgetv1alpha1.OperationStart: {
 			Doc: "Start dns",
 			Operation: func(name string, trace *gadgetv1alpha1.Trace) {
 				f.LookupOrCreate(name, n).(*Trace).Start(trace)
 			},
 		},
-		"stop": {
+		gadgetv1alpha1.OperationStop: {
 			Doc: "Stop dns and store results",
 			Operation: func(name string, trace *gadgetv1alpha1.Trace) {
 				f.LookupOrCreate(name, n).(*Trace).Stop(trace)
@@ -149,7 +149,7 @@ func (t *Trace) publishEvent(
 
 func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 	if t.started {
-		trace.Status.State = "Started"
+		trace.Status.State = gadgetv1alpha1.TraceStateStarted
 		return
 	}
 
@@ -220,7 +220,7 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 	}
 	t.started = true
 
-	trace.Status.State = "Started"
+	trace.Status.State = gadgetv1alpha1.TraceStateStarted
 }
 
 func (t *Trace) Stop(trace *gadgetv1alpha1.Trace) {
@@ -234,5 +234,5 @@ func (t *Trace) Stop(trace *gadgetv1alpha1.Trace) {
 	t.tracer = nil
 	t.started = false
 
-	trace.Status.State = "Stopped"
+	trace.Status.State = gadgetv1alpha1.TraceStateStopped
 }

--- a/pkg/gadget-collection/gadgets/trace/exec/gadget.go
+++ b/pkg/gadget-collection/gadgets/trace/exec/gadget.go
@@ -51,9 +51,9 @@ func (f *TraceFactory) Description() string {
 	return `execsnoop shows new created processes, with container details.`
 }
 
-func (f *TraceFactory) OutputModesSupported() map[string]struct{} {
-	return map[string]struct{}{
-		"Stream": {},
+func (f *TraceFactory) OutputModesSupported() map[gadgetv1alpha1.TraceOutputMode]struct{} {
+	return map[gadgetv1alpha1.TraceOutputMode]struct{}{
+		gadgetv1alpha1.TraceOutputModeStream: {},
 	}
 }
 
@@ -64,21 +64,21 @@ func deleteTrace(name string, t interface{}) {
 	}
 }
 
-func (f *TraceFactory) Operations() map[string]gadgets.TraceOperation {
+func (f *TraceFactory) Operations() map[gadgetv1alpha1.Operation]gadgets.TraceOperation {
 	n := func() interface{} {
 		return &Trace{
 			helpers: f.Helpers,
 		}
 	}
 
-	return map[string]gadgets.TraceOperation{
-		"start": {
+	return map[gadgetv1alpha1.Operation]gadgets.TraceOperation{
+		gadgetv1alpha1.OperationStart: {
 			Doc: "Start execsnoop gadget",
 			Operation: func(name string, trace *gadgetv1alpha1.Trace) {
 				f.LookupOrCreate(name, n).(*Trace).Start(trace)
 			},
 		},
-		"stop": {
+		gadgetv1alpha1.OperationStop: {
 			Doc: "Stop execsnoop gadget",
 			Operation: func(name string, trace *gadgetv1alpha1.Trace) {
 				f.LookupOrCreate(name, n).(*Trace).Stop(trace)
@@ -89,7 +89,7 @@ func (f *TraceFactory) Operations() map[string]gadgets.TraceOperation {
 
 func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 	if t.started {
-		trace.Status.State = "Started"
+		trace.Status.State = gadgetv1alpha1.TraceStateStarted
 		return
 	}
 
@@ -131,7 +131,7 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 
 	t.started = true
 
-	trace.Status.State = "Started"
+	trace.Status.State = gadgetv1alpha1.TraceStateStarted
 }
 
 func (t *Trace) Stop(trace *gadgetv1alpha1.Trace) {
@@ -144,5 +144,5 @@ func (t *Trace) Stop(trace *gadgetv1alpha1.Trace) {
 	t.tracer = nil
 	t.started = false
 
-	trace.Status.State = "Stopped"
+	trace.Status.State = gadgetv1alpha1.TraceStateStopped
 }

--- a/pkg/gadget-collection/gadgets/trace/fsslower/gadget.go
+++ b/pkg/gadget-collection/gadgets/trace/fsslower/gadget.go
@@ -58,9 +58,9 @@ The following parameters are supported:
 	return fmt.Sprintf(t, strings.Join(validFilesystems, ", "), types.MinLatencyDefault)
 }
 
-func (f *TraceFactory) OutputModesSupported() map[string]struct{} {
-	return map[string]struct{}{
-		"Stream": {},
+func (f *TraceFactory) OutputModesSupported() map[gadgetv1alpha1.TraceOutputMode]struct{} {
+	return map[gadgetv1alpha1.TraceOutputMode]struct{}{
+		gadgetv1alpha1.TraceOutputModeStream: {},
 	}
 }
 
@@ -71,21 +71,21 @@ func deleteTrace(name string, t interface{}) {
 	}
 }
 
-func (f *TraceFactory) Operations() map[string]gadgets.TraceOperation {
+func (f *TraceFactory) Operations() map[gadgetv1alpha1.Operation]gadgets.TraceOperation {
 	n := func() interface{} {
 		return &Trace{
 			helpers: f.Helpers,
 		}
 	}
 
-	return map[string]gadgets.TraceOperation{
-		"start": {
+	return map[gadgetv1alpha1.Operation]gadgets.TraceOperation{
+		gadgetv1alpha1.OperationStart: {
 			Doc: "Start fsslower gadget",
 			Operation: func(name string, trace *gadgetv1alpha1.Trace) {
 				f.LookupOrCreate(name, n).(*Trace).Start(trace)
 			},
 		},
-		"stop": {
+		gadgetv1alpha1.OperationStop: {
 			Doc: "Stop fsslower gadget",
 			Operation: func(name string, trace *gadgetv1alpha1.Trace) {
 				f.LookupOrCreate(name, n).(*Trace).Stop(trace)
@@ -96,7 +96,7 @@ func (f *TraceFactory) Operations() map[string]gadgets.TraceOperation {
 
 func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 	if t.started {
-		trace.Status.State = "Started"
+		trace.Status.State = gadgetv1alpha1.TraceStateStarted
 		return
 	}
 
@@ -157,7 +157,7 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 
 	t.started = true
 
-	trace.Status.State = "Started"
+	trace.Status.State = gadgetv1alpha1.TraceStateStarted
 }
 
 func (t *Trace) Stop(trace *gadgetv1alpha1.Trace) {
@@ -170,5 +170,5 @@ func (t *Trace) Stop(trace *gadgetv1alpha1.Trace) {
 	t.tracer = nil
 	t.started = false
 
-	trace.Status.State = "Stopped"
+	trace.Status.State = gadgetv1alpha1.TraceStateStopped
 }

--- a/pkg/gadget-collection/gadgets/trace/mount/gadget.go
+++ b/pkg/gadget-collection/gadgets/trace/mount/gadget.go
@@ -52,9 +52,9 @@ func (f *TraceFactory) Description() string {
 	return `mountsnoop traces mount and umount syscalls`
 }
 
-func (f *TraceFactory) OutputModesSupported() map[string]struct{} {
-	return map[string]struct{}{
-		"Stream": {},
+func (f *TraceFactory) OutputModesSupported() map[gadgetv1alpha1.TraceOutputMode]struct{} {
+	return map[gadgetv1alpha1.TraceOutputMode]struct{}{
+		gadgetv1alpha1.TraceOutputModeStream: {},
 	}
 }
 
@@ -65,21 +65,21 @@ func deleteTrace(name string, t interface{}) {
 	}
 }
 
-func (f *TraceFactory) Operations() map[string]gadgets.TraceOperation {
+func (f *TraceFactory) Operations() map[gadgetv1alpha1.Operation]gadgets.TraceOperation {
 	n := func() interface{} {
 		return &Trace{
 			helpers: f.Helpers,
 		}
 	}
 
-	return map[string]gadgets.TraceOperation{
-		"start": {
+	return map[gadgetv1alpha1.Operation]gadgets.TraceOperation{
+		gadgetv1alpha1.OperationStart: {
 			Doc: "Start mountsnoop gadget",
 			Operation: func(name string, trace *gadgetv1alpha1.Trace) {
 				f.LookupOrCreate(name, n).(*Trace).Start(trace)
 			},
 		},
-		"stop": {
+		gadgetv1alpha1.OperationStop: {
 			Doc: "Stop mountsnoop gadget",
 			Operation: func(name string, trace *gadgetv1alpha1.Trace) {
 				f.LookupOrCreate(name, n).(*Trace).Stop(trace)
@@ -90,7 +90,7 @@ func (f *TraceFactory) Operations() map[string]gadgets.TraceOperation {
 
 func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 	if t.started {
-		trace.Status.State = "Started"
+		trace.Status.State = gadgetv1alpha1.TraceStateStarted
 		return
 	}
 
@@ -132,7 +132,7 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 
 	t.started = true
 
-	trace.Status.State = "Started"
+	trace.Status.State = gadgetv1alpha1.TraceStateStarted
 }
 
 func (t *Trace) Stop(trace *gadgetv1alpha1.Trace) {
@@ -145,5 +145,5 @@ func (t *Trace) Stop(trace *gadgetv1alpha1.Trace) {
 	t.tracer = nil
 	t.started = false
 
-	trace.Status.State = "Stopped"
+	trace.Status.State = gadgetv1alpha1.TraceStateStopped
 }

--- a/pkg/gadget-collection/gadgets/trace/network/gadget.go
+++ b/pkg/gadget-collection/gadgets/trace/network/gadget.go
@@ -74,9 +74,9 @@ func (f *TraceFactory) Description() string {
 	return `The network-graph gadget monitors the network activity in the specified pods and records the list of TCP connections and UDP streams.`
 }
 
-func (f *TraceFactory) OutputModesSupported() map[string]struct{} {
-	return map[string]struct{}{
-		"Stream": {},
+func (f *TraceFactory) OutputModesSupported() map[gadgetv1alpha1.TraceOutputMode]struct{} {
+	return map[gadgetv1alpha1.TraceOutputMode]struct{}{
+		gadgetv1alpha1.TraceOutputModeStream: {},
 	}
 }
 
@@ -87,7 +87,7 @@ func deleteTrace(name string, t interface{}) {
 	}
 }
 
-func (f *TraceFactory) Operations() map[string]gadgets.TraceOperation {
+func (f *TraceFactory) Operations() map[gadgetv1alpha1.Operation]gadgets.TraceOperation {
 	n := func() interface{} {
 		return &Trace{
 			client:    f.Client,
@@ -96,14 +96,14 @@ func (f *TraceFactory) Operations() map[string]gadgets.TraceOperation {
 		}
 	}
 
-	return map[string]gadgets.TraceOperation{
-		"start": {
+	return map[gadgetv1alpha1.Operation]gadgets.TraceOperation{
+		gadgetv1alpha1.OperationStart: {
 			Doc: "Start network-graph",
 			Operation: func(name string, trace *gadgetv1alpha1.Trace) {
 				f.LookupOrCreate(name, n).(*Trace).Start(trace)
 			},
 		},
-		"stop": {
+		gadgetv1alpha1.OperationStop: {
 			Doc: "Stop network-graph",
 			Operation: func(name string, trace *gadgetv1alpha1.Trace) {
 				f.LookupOrCreate(name, n).(*Trace).Stop(trace)
@@ -157,7 +157,7 @@ func (t *Trace) publishEvent(
 
 func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 	if t.started {
-		trace.Status.State = "Started"
+		trace.Status.State = gadgetv1alpha1.TraceStateStarted
 		return
 	}
 
@@ -226,7 +226,7 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 	}
 	t.started = true
 
-	trace.Status.State = "Started"
+	trace.Status.State = gadgetv1alpha1.TraceStateStarted
 
 	t.done = make(chan bool)
 	t.detachContainer = make(chan string)
@@ -302,7 +302,7 @@ func (t *Trace) Stop(trace *gadgetv1alpha1.Trace) {
 	}
 
 	t.stop()
-	trace.Status.State = "Stopped"
+	trace.Status.State = gadgetv1alpha1.TraceStateStopped
 }
 
 func (t *Trace) stop() {

--- a/pkg/gadget-collection/gadgets/trace/oomkill/gadget.go
+++ b/pkg/gadget-collection/gadgets/trace/oomkill/gadget.go
@@ -47,9 +47,9 @@ func (f *TraceFactory) Description() string {
 	return `oomkill monitors when OOM killer is triggered and kills a process.`
 }
 
-func (f *TraceFactory) OutputModesSupported() map[string]struct{} {
-	return map[string]struct{}{
-		"Stream": {},
+func (f *TraceFactory) OutputModesSupported() map[gadgetv1alpha1.TraceOutputMode]struct{} {
+	return map[gadgetv1alpha1.TraceOutputMode]struct{}{
+		gadgetv1alpha1.TraceOutputModeStream: {},
 	}
 }
 
@@ -60,21 +60,21 @@ func deleteTrace(name string, t interface{}) {
 	}
 }
 
-func (f *TraceFactory) Operations() map[string]gadgets.TraceOperation {
+func (f *TraceFactory) Operations() map[gadgetv1alpha1.Operation]gadgets.TraceOperation {
 	n := func() interface{} {
 		return &Trace{
 			helpers: f.Helpers,
 		}
 	}
 
-	return map[string]gadgets.TraceOperation{
-		"start": {
+	return map[gadgetv1alpha1.Operation]gadgets.TraceOperation{
+		gadgetv1alpha1.OperationStart: {
 			Doc: "Start oomkill gadget",
 			Operation: func(name string, trace *gadgetv1alpha1.Trace) {
 				f.LookupOrCreate(name, n).(*Trace).Start(trace)
 			},
 		},
-		"stop": {
+		gadgetv1alpha1.OperationStop: {
 			Doc: "Stop oomkill gadget",
 			Operation: func(name string, trace *gadgetv1alpha1.Trace) {
 				f.LookupOrCreate(name, n).(*Trace).Stop(trace)
@@ -85,7 +85,7 @@ func (f *TraceFactory) Operations() map[string]gadgets.TraceOperation {
 
 func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 	if t.started {
-		trace.Status.State = "Started"
+		trace.Status.State = gadgetv1alpha1.TraceStateStarted
 
 		return
 	}
@@ -119,7 +119,7 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 
 	t.started = true
 
-	trace.Status.State = "Started"
+	trace.Status.State = gadgetv1alpha1.TraceStateStarted
 }
 
 func (t *Trace) Stop(trace *gadgetv1alpha1.Trace) {
@@ -132,5 +132,5 @@ func (t *Trace) Stop(trace *gadgetv1alpha1.Trace) {
 	t.tracer = nil
 	t.started = false
 
-	trace.Status.State = "Stopped"
+	trace.Status.State = gadgetv1alpha1.TraceStateStopped
 }

--- a/pkg/gadget-collection/gadgets/trace/open/gadget.go
+++ b/pkg/gadget-collection/gadgets/trace/open/gadget.go
@@ -51,9 +51,9 @@ func (f *TraceFactory) Description() string {
 	return `opensnoop traces open() system calls`
 }
 
-func (f *TraceFactory) OutputModesSupported() map[string]struct{} {
-	return map[string]struct{}{
-		"Stream": {},
+func (f *TraceFactory) OutputModesSupported() map[gadgetv1alpha1.TraceOutputMode]struct{} {
+	return map[gadgetv1alpha1.TraceOutputMode]struct{}{
+		gadgetv1alpha1.TraceOutputModeStream: {},
 	}
 }
 
@@ -64,21 +64,21 @@ func deleteTrace(name string, t interface{}) {
 	}
 }
 
-func (f *TraceFactory) Operations() map[string]gadgets.TraceOperation {
+func (f *TraceFactory) Operations() map[gadgetv1alpha1.Operation]gadgets.TraceOperation {
 	n := func() interface{} {
 		return &Trace{
 			helpers: f.Helpers,
 		}
 	}
 
-	return map[string]gadgets.TraceOperation{
-		"start": {
+	return map[gadgetv1alpha1.Operation]gadgets.TraceOperation{
+		gadgetv1alpha1.OperationStart: {
 			Doc: "Start opensnoop gadget",
 			Operation: func(name string, trace *gadgetv1alpha1.Trace) {
 				f.LookupOrCreate(name, n).(*Trace).Start(trace)
 			},
 		},
-		"stop": {
+		gadgetv1alpha1.OperationStop: {
 			Doc: "Stop opensnoop gadget",
 			Operation: func(name string, trace *gadgetv1alpha1.Trace) {
 				f.LookupOrCreate(name, n).(*Trace).Stop(trace)
@@ -89,7 +89,7 @@ func (f *TraceFactory) Operations() map[string]gadgets.TraceOperation {
 
 func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 	if t.started {
-		trace.Status.State = "Started"
+		trace.Status.State = gadgetv1alpha1.TraceStateStarted
 		return
 	}
 
@@ -130,7 +130,7 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 	}
 
 	t.started = true
-	trace.Status.State = "Started"
+	trace.Status.State = gadgetv1alpha1.TraceStateStarted
 }
 
 func (t *Trace) Stop(trace *gadgetv1alpha1.Trace) {
@@ -143,5 +143,5 @@ func (t *Trace) Stop(trace *gadgetv1alpha1.Trace) {
 	t.tracer = nil
 	t.started = false
 
-	trace.Status.State = "Stopped"
+	trace.Status.State = gadgetv1alpha1.TraceStateStopped
 }

--- a/pkg/gadget-collection/gadgets/trace/signal/gadget.go
+++ b/pkg/gadget-collection/gadgets/trace/signal/gadget.go
@@ -57,9 +57,9 @@ The following parameters are supported:
 `
 }
 
-func (f *TraceFactory) OutputModesSupported() map[string]struct{} {
-	return map[string]struct{}{
-		"Stream": {},
+func (f *TraceFactory) OutputModesSupported() map[gadgetv1alpha1.TraceOutputMode]struct{} {
+	return map[gadgetv1alpha1.TraceOutputMode]struct{}{
+		gadgetv1alpha1.TraceOutputModeStream: {},
 	}
 }
 
@@ -70,21 +70,21 @@ func deleteTrace(name string, t interface{}) {
 	}
 }
 
-func (f *TraceFactory) Operations() map[string]gadgets.TraceOperation {
+func (f *TraceFactory) Operations() map[gadgetv1alpha1.Operation]gadgets.TraceOperation {
 	n := func() interface{} {
 		return &Trace{
 			helpers: f.Helpers,
 		}
 	}
 
-	return map[string]gadgets.TraceOperation{
-		"start": {
+	return map[gadgetv1alpha1.Operation]gadgets.TraceOperation{
+		gadgetv1alpha1.OperationStart: {
 			Doc: "Start sigsnoop gadget",
 			Operation: func(name string, trace *gadgetv1alpha1.Trace) {
 				f.LookupOrCreate(name, n).(*Trace).Start(trace)
 			},
 		},
-		"stop": {
+		gadgetv1alpha1.OperationStop: {
 			Doc: "Stop sigsnoop gadget",
 			Operation: func(name string, trace *gadgetv1alpha1.Trace) {
 				f.LookupOrCreate(name, n).(*Trace).Stop(trace)
@@ -95,7 +95,7 @@ func (f *TraceFactory) Operations() map[string]gadgets.TraceOperation {
 
 func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 	if t.started {
-		trace.Status.State = "Started"
+		trace.Status.State = gadgetv1alpha1.TraceStateStarted
 		return
 	}
 
@@ -160,7 +160,7 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 
 	t.started = true
 
-	trace.Status.State = "Started"
+	trace.Status.State = gadgetv1alpha1.TraceStateStarted
 }
 
 func (t *Trace) Stop(trace *gadgetv1alpha1.Trace) {
@@ -173,5 +173,5 @@ func (t *Trace) Stop(trace *gadgetv1alpha1.Trace) {
 	t.tracer = nil
 	t.started = false
 
-	trace.Status.State = "Stopped"
+	trace.Status.State = gadgetv1alpha1.TraceStateStopped
 }

--- a/pkg/gadget-collection/gadgets/trace/sni/gadget.go
+++ b/pkg/gadget-collection/gadgets/trace/sni/gadget.go
@@ -61,9 +61,9 @@ func (f *TraceFactory) Description() string {
 	return `The snisnoop gadget retrieves Server Name Indication (SNI) from TLS requests.`
 }
 
-func (f *TraceFactory) OutputModesSupported() map[string]struct{} {
-	return map[string]struct{}{
-		"Stream": {},
+func (f *TraceFactory) OutputModesSupported() map[gadgetv1alpha1.TraceOutputMode]struct{} {
+	return map[gadgetv1alpha1.TraceOutputMode]struct{}{
+		gadgetv1alpha1.TraceOutputModeStream: {},
 	}
 }
 
@@ -76,7 +76,7 @@ func deleteTrace(name string, t interface{}) {
 	}
 }
 
-func (f *TraceFactory) Operations() map[string]gadgets.TraceOperation {
+func (f *TraceFactory) Operations() map[gadgetv1alpha1.Operation]gadgets.TraceOperation {
 	n := func() interface{} {
 		return &Trace{
 			client:    f.Client,
@@ -85,14 +85,14 @@ func (f *TraceFactory) Operations() map[string]gadgets.TraceOperation {
 		}
 	}
 
-	return map[string]gadgets.TraceOperation{
-		"start": {
+	return map[gadgetv1alpha1.Operation]gadgets.TraceOperation{
+		gadgetv1alpha1.OperationStart: {
 			Doc: "Start snisnoop",
 			Operation: func(name string, trace *gadgetv1alpha1.Trace) {
 				f.LookupOrCreate(name, n).(*Trace).Start(trace)
 			},
 		},
-		"stop": {
+		gadgetv1alpha1.OperationStop: {
 			Doc: "Stop snisnoop",
 			Operation: func(name string, trace *gadgetv1alpha1.Trace) {
 				f.LookupOrCreate(name, n).(*Trace).Stop(trace)
@@ -109,7 +109,7 @@ func genPubSubKey(name string) pubSubKey {
 
 func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 	if t.started {
-		trace.Status.State = "Started"
+		trace.Status.State = gadgetv1alpha1.TraceStateStarted
 		return
 	}
 
@@ -246,7 +246,7 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 	}
 	t.started = true
 
-	trace.Status.State = "Started"
+	trace.Status.State = gadgetv1alpha1.TraceStateStarted
 }
 
 func (t *Trace) Stop(trace *gadgetv1alpha1.Trace) {
@@ -260,5 +260,5 @@ func (t *Trace) Stop(trace *gadgetv1alpha1.Trace) {
 	t.tracer = nil
 	t.started = false
 
-	trace.Status.State = "Stopped"
+	trace.Status.State = gadgetv1alpha1.TraceStateStopped
 }

--- a/pkg/gadget-collection/gadgets/trace/tcp/gadget.go
+++ b/pkg/gadget-collection/gadgets/trace/tcp/gadget.go
@@ -51,9 +51,9 @@ func (f *TraceFactory) Description() string {
 	return `Trace tcp connect, accept and close`
 }
 
-func (f *TraceFactory) OutputModesSupported() map[string]struct{} {
-	return map[string]struct{}{
-		"Stream": {},
+func (f *TraceFactory) OutputModesSupported() map[gadgetv1alpha1.TraceOutputMode]struct{} {
+	return map[gadgetv1alpha1.TraceOutputMode]struct{}{
+		gadgetv1alpha1.TraceOutputModeStream: {},
 	}
 }
 
@@ -64,21 +64,21 @@ func deleteTrace(name string, t interface{}) {
 	}
 }
 
-func (f *TraceFactory) Operations() map[string]gadgets.TraceOperation {
+func (f *TraceFactory) Operations() map[gadgetv1alpha1.Operation]gadgets.TraceOperation {
 	n := func() interface{} {
 		return &Trace{
 			helpers: f.Helpers,
 		}
 	}
 
-	return map[string]gadgets.TraceOperation{
-		"start": {
+	return map[gadgetv1alpha1.Operation]gadgets.TraceOperation{
+		gadgetv1alpha1.OperationStart: {
 			Doc: "Start tcptracer gadget",
 			Operation: func(name string, trace *gadgetv1alpha1.Trace) {
 				f.LookupOrCreate(name, n).(*Trace).Start(trace)
 			},
 		},
-		"stop": {
+		gadgetv1alpha1.OperationStop: {
 			Doc: "Stop tcptracer gadget",
 			Operation: func(name string, trace *gadgetv1alpha1.Trace) {
 				f.LookupOrCreate(name, n).(*Trace).Stop(trace)
@@ -89,7 +89,7 @@ func (f *TraceFactory) Operations() map[string]gadgets.TraceOperation {
 
 func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 	if t.started {
-		trace.Status.State = "Started"
+		trace.Status.State = gadgetv1alpha1.TraceStateStarted
 		return
 	}
 
@@ -132,7 +132,7 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 
 	t.started = true
 
-	trace.Status.State = "Started"
+	trace.Status.State = gadgetv1alpha1.TraceStateStarted
 }
 
 func (t *Trace) Stop(trace *gadgetv1alpha1.Trace) {
@@ -145,5 +145,5 @@ func (t *Trace) Stop(trace *gadgetv1alpha1.Trace) {
 	t.tracer = nil
 	t.started = false
 
-	trace.Status.State = "Stopped"
+	trace.Status.State = gadgetv1alpha1.TraceStateStopped
 }

--- a/pkg/gadget-collection/gadgets/trace/tcpconnect/gadget.go
+++ b/pkg/gadget-collection/gadgets/trace/tcpconnect/gadget.go
@@ -51,9 +51,9 @@ func (f *TraceFactory) Description() string {
 	return `tcpconnect traces connect() system calls`
 }
 
-func (f *TraceFactory) OutputModesSupported() map[string]struct{} {
-	return map[string]struct{}{
-		"Stream": {},
+func (f *TraceFactory) OutputModesSupported() map[gadgetv1alpha1.TraceOutputMode]struct{} {
+	return map[gadgetv1alpha1.TraceOutputMode]struct{}{
+		gadgetv1alpha1.TraceOutputModeStream: {},
 	}
 }
 
@@ -64,21 +64,21 @@ func deleteTrace(name string, t interface{}) {
 	}
 }
 
-func (f *TraceFactory) Operations() map[string]gadgets.TraceOperation {
+func (f *TraceFactory) Operations() map[gadgetv1alpha1.Operation]gadgets.TraceOperation {
 	n := func() interface{} {
 		return &Trace{
 			helpers: f.Helpers,
 		}
 	}
 
-	return map[string]gadgets.TraceOperation{
-		"start": {
+	return map[gadgetv1alpha1.Operation]gadgets.TraceOperation{
+		gadgetv1alpha1.OperationStart: {
 			Doc: "Start tcpconnect gadget",
 			Operation: func(name string, trace *gadgetv1alpha1.Trace) {
 				f.LookupOrCreate(name, n).(*Trace).Start(trace)
 			},
 		},
-		"stop": {
+		gadgetv1alpha1.OperationStop: {
 			Doc: "Stop tcpconnect gadget",
 			Operation: func(name string, trace *gadgetv1alpha1.Trace) {
 				f.LookupOrCreate(name, n).(*Trace).Stop(trace)
@@ -89,7 +89,7 @@ func (f *TraceFactory) Operations() map[string]gadgets.TraceOperation {
 
 func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 	if t.started {
-		trace.Status.State = "Started"
+		trace.Status.State = gadgetv1alpha1.TraceStateStarted
 		return
 	}
 
@@ -131,7 +131,7 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 
 	t.started = true
 
-	trace.Status.State = "Started"
+	trace.Status.State = gadgetv1alpha1.TraceStateStarted
 }
 
 func (t *Trace) Stop(trace *gadgetv1alpha1.Trace) {
@@ -144,5 +144,5 @@ func (t *Trace) Stop(trace *gadgetv1alpha1.Trace) {
 	t.tracer = nil
 	t.started = false
 
-	trace.Status.State = "Stopped"
+	trace.Status.State = gadgetv1alpha1.TraceStateStopped
 }

--- a/pkg/gadget-collection/gadgets/traceloop/gadget.go
+++ b/pkg/gadget-collection/gadgets/traceloop/gadget.go
@@ -58,9 +58,9 @@ some differences:
 `
 }
 
-func (f *TraceFactory) OutputModesSupported() map[string]struct{} {
-	return map[string]struct{}{
-		"ExternalResource": {},
+func (f *TraceFactory) OutputModesSupported() map[gadgetv1alpha1.TraceOutputMode]struct{} {
+	return map[gadgetv1alpha1.TraceOutputMode]struct{}{
+		gadgetv1alpha1.TraceOutputModeExternalResource: {},
 	}
 }
 
@@ -69,18 +69,18 @@ func deleteTrace(name string, t interface{}) {
 	trace.stop()
 }
 
-func (f *TraceFactory) Operations() map[string]gadgets.TraceOperation {
+func (f *TraceFactory) Operations() map[gadgetv1alpha1.Operation]gadgets.TraceOperation {
 	n := func() interface{} {
 		return &Trace{}
 	}
 
-	return map[string]gadgets.TraceOperation{
-		"start": {
+	return map[gadgetv1alpha1.Operation]gadgets.TraceOperation{
+		gadgetv1alpha1.OperationStart: {
 			Doc: "Start traceloop",
 			Operation: func(name string, trace *gadgetv1alpha1.Trace) {
 				t := f.LookupOrCreate(name, n).(*Trace)
 				if t.started {
-					trace.Status.State = "Started"
+					trace.Status.State = gadgetv1alpha1.TraceStateStarted
 					return
 				}
 
@@ -96,7 +96,7 @@ func (f *TraceFactory) Operations() map[string]gadgets.TraceOperation {
 				f.started = t.started
 			},
 		},
-		"stop": {
+		gadgetv1alpha1.OperationStop: {
 			Doc: "Stop traceloop",
 			Operation: func(name string, trace *gadgetv1alpha1.Trace) {
 				f.mu.Lock()
@@ -146,7 +146,7 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 	}
 	t.started = true
 
-	trace.Status.State = "Started"
+	trace.Status.State = gadgetv1alpha1.TraceStateStarted
 }
 
 func (t *Trace) stop() error {
@@ -185,5 +185,5 @@ func (t *Trace) Stop(trace *gadgetv1alpha1.Trace) {
 		return
 	}
 
-	trace.Status.State = "Stopped"
+	trace.Status.State = gadgetv1alpha1.TraceStateStopped
 }

--- a/pkg/local-gadget-manager/local-gadget-manager_test.go
+++ b/pkg/local-gadget-manager/local-gadget-manager_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/client"
 
+	gadgetv1alpha1 "github.com/kinvolk/inspektor-gadget/pkg/apis/gadget/v1alpha1"
 	containerutils "github.com/kinvolk/inspektor-gadget/pkg/container-utils"
 	ebpftoptypes "github.com/kinvolk/inspektor-gadget/pkg/gadgets/top/ebpf/types"
 	dnstypes "github.com/kinvolk/inspektor-gadget/pkg/gadgets/trace/dns/types"
@@ -207,11 +208,11 @@ func TestSeccomp(t *testing.T) {
 	initialFdList := currentFdList(t)
 
 	containerName := "test-local-gadget-seccomp001"
-	err = localGadgetManager.AddTracer("seccomp", "my-tracer", containerName, "Stream", nil)
+	err = localGadgetManager.AddTracer("seccomp", "my-tracer", containerName, gadgetv1alpha1.TraceOutputModeStream, nil)
 	if err != nil {
 		t.Fatalf("Failed to create tracer: %s", err)
 	}
-	err = localGadgetManager.Operation("my-tracer", "start")
+	err = localGadgetManager.Operation("my-tracer", gadgetv1alpha1.OperationStart)
 	if err != nil {
 		t.Fatalf("Failed to start the tracer: %s", err)
 	}
@@ -258,11 +259,11 @@ func TestAuditSeccomp(t *testing.T) {
 	initialFdList := currentFdList(t)
 
 	containerName := "test-local-gadget-auditseccomp001"
-	err = localGadgetManager.AddTracer("audit-seccomp", "my-tracer", containerName, "Stream", nil)
+	err = localGadgetManager.AddTracer("audit-seccomp", "my-tracer", containerName, gadgetv1alpha1.TraceOutputModeStream, nil)
 	if err != nil {
 		t.Fatalf("Failed to create tracer: %s", err)
 	}
-	err = localGadgetManager.Operation("my-tracer", "start")
+	err = localGadgetManager.Operation("my-tracer", gadgetv1alpha1.OperationStart)
 	if err != nil {
 		t.Fatalf("Failed to start the tracer: %s", err)
 	}
@@ -308,11 +309,11 @@ func TestEbpftop(t *testing.T) {
 	defer localGadgetManager.Close()
 
 	containerName := "test-local-gadget-dns001"
-	err = localGadgetManager.AddTracer("ebpftop", "my-tracer", containerName, "Stream", nil)
+	err = localGadgetManager.AddTracer("ebpftop", "my-tracer", containerName, gadgetv1alpha1.TraceOutputModeStream, nil)
 	if err != nil {
 		t.Fatalf("Failed to create tracer: %s", err)
 	}
-	err = localGadgetManager.Operation("my-tracer", "start")
+	err = localGadgetManager.Operation("my-tracer", gadgetv1alpha1.OperationStart)
 	if err != nil {
 		t.Fatalf("Failed to start the tracer: %s", err)
 	}
@@ -387,11 +388,11 @@ func TestDNS(t *testing.T) {
 	initialFdList := currentFdList(t)
 
 	containerName := "test-local-gadget-dns001"
-	err = localGadgetManager.AddTracer("dns", "my-tracer", containerName, "Stream", nil)
+	err = localGadgetManager.AddTracer("dns", "my-tracer", containerName, gadgetv1alpha1.TraceOutputModeStream, nil)
 	if err != nil {
 		t.Fatalf("Failed to create tracer: %s", err)
 	}
-	err = localGadgetManager.Operation("my-tracer", "start")
+	err = localGadgetManager.Operation("my-tracer", gadgetv1alpha1.OperationStart)
 	if err != nil {
 		t.Fatalf("Failed to start the tracer: %s", err)
 	}
@@ -509,11 +510,11 @@ func TestNetworkGraph(t *testing.T) {
 	initialFdList := currentFdList(t)
 
 	containerName := "test-local-gadget-network-graph001"
-	err = localGadgetManager.AddTracer("network-graph", "my-tracer", containerName, "Stream", nil)
+	err = localGadgetManager.AddTracer("network-graph", "my-tracer", containerName, gadgetv1alpha1.TraceOutputModeStream, nil)
 	if err != nil {
 		t.Fatalf("Failed to create tracer: %s", err)
 	}
-	err = localGadgetManager.Operation("my-tracer", "start")
+	err = localGadgetManager.Operation("my-tracer", gadgetv1alpha1.OperationStart)
 	if err != nil {
 		t.Fatalf("Failed to start the tracer: %s", err)
 	}
@@ -629,11 +630,11 @@ func TestCollector(t *testing.T) {
 	}
 	defer localGadgetManager.Close()
 
-	err = localGadgetManager.AddTracer("socket-collector", "my-tracer1", "my-container", "Status", nil)
+	err = localGadgetManager.AddTracer("socket-collector", "my-tracer1", "my-container", gadgetv1alpha1.TraceOutputModeStatus, nil)
 	if err != nil {
 		t.Fatalf("Failed to create tracer: %s", err)
 	}
-	err = localGadgetManager.Operation("my-tracer1", "collect")
+	err = localGadgetManager.Operation("my-tracer1", gadgetv1alpha1.OperationCollect)
 	if err != nil {
 		t.Fatalf("Failed to run the tracer: %s", err)
 	}

--- a/pkg/resources/crd/bases/gadget.kinvolk.io_traces.yaml
+++ b/pkg/resources/crd/bases/gadget.kinvolk.io_traces.yaml
@@ -87,6 +87,9 @@ spec:
                 description: RunMode is "Auto" to automatically start the trace as
                   soon as the resource is created, or "Manual" to be controlled by
                   the "gadget.kinvolk.io/operation" annotation
+                enum:
+                - Auto
+                - Manual
                 type: string
             type: object
           status:


### PR DESCRIPTION
Introduce custom types and  constants for Trace and TraceConfig. The idea is to have a enum like functionality to remove all the strings literal from the code. 

## Fixes
#771 
