### PR TITLE
pkg/gadgets/top/ebpf: introduce cumulruntime and cumulruncount

### DIFF
--- a/cmd/kubectl-gadget/top/ebpf.go
+++ b/cmd/kubectl-gadget/top/ebpf.go
@@ -76,6 +76,8 @@ func newEbpfCmd() *cobra.Command {
 		"runcount":      10,
 		"totalruntime":  12,
 		"totalruncount": 13,
+		"cumulruntime":  12,
+		"cumulruncount": 13,
 	}
 
 	cmd := &cobra.Command{
@@ -274,6 +276,10 @@ func (p *EbpfParser) TransformStats(stats *types.Stats) string {
 				sb.WriteString(fmt.Sprintf("%*v", p.ColumnsWidth[col], time.Duration(stats.TotalRuntime)))
 			case "totalruncount":
 				sb.WriteString(fmt.Sprintf("%*d", p.ColumnsWidth[col], stats.TotalRunCount))
+			case "cumulruntime":
+				sb.WriteString(fmt.Sprintf("%*v", p.ColumnsWidth[col], time.Duration(stats.CumulativeRuntime)))
+			case "cumulruncount":
+				sb.WriteString(fmt.Sprintf("%*d", p.ColumnsWidth[col], stats.CumulativeRunCount))
 			}
 			sb.WriteRune(' ')
 		}

--- a/docs/gadgets/ebpftop.md
+++ b/docs/gadgets/ebpftop.md
@@ -8,7 +8,7 @@ ebpftop shows cpu time used by ebpf programs.
 The following parameters are supported:
  - interval: Output interval, in seconds. (default 1)
  - max_rows: Maximum rows to print. (default 20)
- - sort_by: The field to sort the results by (all,runtime,runcount,progid,totalruntime,totalruncount). (default all)
+ - sort_by: The field to sort the results by (all,runtime,runcount,progid,totalruntime,totalruncount,cumulruntime,cumulruncount). (default all)
 
 ### Example CR
 
@@ -26,7 +26,7 @@ spec:
   parameters:
     interval: "1"
     max_rows: "50"
-    sort_by: all # all, runtime, runcount, progid, totalruntime and totalruncount are allowed
+    sort_by: all # all, runtime, runcount, progid, totalruntime, totalruncount, cumulruntime and cumulrouncount are allowed
 ```
 
 ### Operations

--- a/docs/guides/top/ebpf.md
+++ b/docs/guides/top/ebpf.md
@@ -52,22 +52,18 @@ minikube         53       CGroupDevice                                          
 
 So in this case for example, in the past second `vfs_write_entry` has been called 378 times, which took 3.948619ms.
 
-If you want to get the total runtime and total run count of the eBPF programs, you can call the gadget with the custom
-columns option:
+If you want to get the cumulative runtime and run count of the eBPF programs starting from the beginning of the trace,
+you can call the gadget with the custom-columns option and specify the cumulruntime and cumulruncount columns.
+Combined with the `--sort cumulruntime` and `--timeout 60` parameters, you can for example measure the time spent
+over a minute:
 
 ```bash
-$ kubectl-gadget top ebpf -o custom-columns=node,progid,type,name,runtime,runcount,totalruncount,totalruntime --sort totalruntime
-NODE             PROGID   TYPE             NAME                  RUNTIME   RUNCOUNT  T-RUNCOUNT    T-RUNTIME
-minikube         26       CGroupDevice                                0s          0        3817   2.692936ms
-minikube         6394     TracePoint       tgkill_entry        105.209µs         17         584   2.442174ms
-minikube         6395     TracePoint       tgkill_exit          60.625µs         17         584   1.166054ms
-minikube         6393     TracePoint       sig_trace            38.085µs         17         653     996.16µs
-minikube         6400     Tracing          gadget_ebpftop       37.202µs       1125        3345    258.998µs
-minikube         103      CGroupDevice                                0s          0         101    151.455µs
-minikube         6068     CGroupDevice                                0s          0          22      9.542µs
+$ kubectl-gadget top ebpf -o custom-columns=node,progid,type,name,pid,comm,cumulruntime,cumulruncount --sort cumulruntime --timeout 60
+NODE             PROGID   TYPE             NAME             PID     COMM                 CUMULRUNTIME CUMULRUNCOUNT
+minikube         2598     Tracing          gadget_ebpftop   2215151 gadgettracerman        5.239255ms         61443
+minikube         24       CGroupDevice                                                      147.327µs           224
+minikube         85       CGroupDevice                                                       12.209µs             4
+minikube         60       CGroupDevice                      1765    systemd                        0s             0
+minikube         48       CGroupDevice                      1765    systemd                        0s             0
 ...
 ```
-
-Please keep in mind that collection of the runtime stats is disabled by default for performance reasons and will only
-be enabled by the `top ebpf` gadget for the time it is running. That means that the "total" runtime and run count
-reflect only the time in which `top ebpf` was running.

--- a/pkg/gadgets/top/ebpf/types/types.go
+++ b/pkg/gadgets/top/ebpf/types/types.go
@@ -30,6 +30,8 @@ const (
 	PROGRAMID
 	TOTALRUNTIME
 	TOTALRUNCOUNT
+	CUMULRUNTIME
+	CUMULRUNCOUNT
 )
 
 const (
@@ -51,6 +53,8 @@ var SortBySlice = []string{
 	"progid",
 	"totalruntime",
 	"totalruncount",
+	"cumulruntime",
+	"cumulruncount",
 }
 
 func (s SortBy) String() string {
@@ -84,6 +88,10 @@ func SortStats(stats []Stats, sortBy SortBy) {
 			return a.TotalRuntime > b.TotalRuntime
 		case TOTALRUNCOUNT:
 			return a.TotalRunCount > b.TotalRunCount
+		case CUMULRUNTIME:
+			return a.CumulativeRuntime > b.CumulativeRuntime
+		case CUMULRUNCOUNT:
+			return a.CumulativeRunCount > b.CumulativeRunCount
 		case PROGRAMID:
 			return a.ProgramID > b.ProgramID
 		default:
@@ -103,14 +111,16 @@ type Event struct {
 
 type Stats struct {
 	eventtypes.CommonData
-	ProgramID       uint32     `json:"progid"`
-	Pids            []*PidInfo `json:"pids,omitempty"`
-	Name            string     `json:"name,omitempty"`
-	Type            string     `json:"type,omitempty"`
-	CurrentRuntime  int64      `json:"currentRuntime,omitempty"`
-	CurrentRunCount uint64     `json:"currentRuncount,omitempty"`
-	TotalRuntime    int64      `json:"totalRuntime,omitempty"`
-	TotalRunCount   uint64     `json:"totalRuncount,omitempty"`
+	ProgramID          uint32     `json:"progid"`
+	Pids               []*PidInfo `json:"pids,omitempty"`
+	Name               string     `json:"name,omitempty"`
+	Type               string     `json:"type,omitempty"`
+	CurrentRuntime     int64      `json:"currentRuntime,omitempty"`
+	CurrentRunCount    uint64     `json:"currentRunCount,omitempty"`
+	CumulativeRuntime  int64      `json:"cumulRuntime,omitempty"`
+	CumulativeRunCount uint64     `json:"cumulRunCount,omitempty"`
+	TotalRuntime       int64      `json:"totalRuntime,omitempty"`
+	TotalRunCount      uint64     `json:"totalRunCount,omitempty"`
 }
 
 type PidInfo struct {

--- a/pkg/resources/samples/trace-ebpftop.yaml
+++ b/pkg/resources/samples/trace-ebpftop.yaml
@@ -11,4 +11,4 @@ spec:
   parameters:
     interval: "1"
     max_rows: "50"
-    sort_by: all # all, runtime, runcount, progid, totalruntime and totalruncount are allowed
+    sort_by: all # all, runtime, runcount, progid, totalruntime, totalruncount, cumulruntime and cumulrouncount are allowed


### PR DESCRIPTION
# Introduce cumulruntime and cumulruncount

This PR adds cumulative stats (runtime and run count) that use times and counters relative to the start of the trace (instead of relative to the last interval and absolute values, which are already handled).

I also refactored how previous stats were saved to avoid unnecessary lookups.

## How to use

```
kubectl gadget top ebpf -o custom-columns=node,progid,type,name,runtime,runcount,totalruncount,totalruntime,cumulruncount,cumulruntime --sort totalruntime
```

will output something like this:

```
NODE             PROGID   TYPE             NAME                  RUNTIME   RUNCOUNT TOTALRUNCOUNT TOTALRUNTIME CUMULRUNCOUNT CUMULRUNTIME
minikube         2346     Tracing          gadget_ebpftop        72.92µs       1059         18012   1.676893ms         18012   1.676893ms
minikube         24       CGroupDevice                            9.04µs         32           532    358.576µs            80     47.168µs
minikube         85       CGroupDevice                                0s          0            10     25.543µs             0           0s
minikube         2339     CGroupDevice                                0s          0            12      5.043µs             0           0s
minikube         13       CGroupSKB                                   0s          0             0           0s             0           0s
minikube         8        CGroupSKB                                   0s          0             0           0s             0           0s
```

Fixes #853 