### PR TITLE
pkg/container-utils/docker: Fix bad state

### DIFF
--- a/pkg/container-utils/docker/docker.go
+++ b/pkg/container-utils/docker/docker.go
@@ -214,7 +214,7 @@ func DockerContainerToContainerData(container *dockertypes.Container) *runtimecl
 	return &runtimeclient.ContainerData{
 		ID:      container.ID,
 		Name:    strings.TrimPrefix(container.Names[0], "/"),
-		State:   containerStatusStateToRuntimeClientState(container.Status),
+		State:   containerStatusStateToRuntimeClientState(container.State),
 		Runtime: Name,
 	}
 }


### PR DESCRIPTION
The correct variable to use is State instead of Status. It was causing
to always have the State as "unknown", causing
"./local-gadget list-containers" not to show any docker containers.

Fixes: 6444282dc5d1 ("Replace `PidFromContainerID` for `GetContainerDetails`, providing more details")
