### PR TITLE
pkg/gadgets/top/ebpf: add information about referenced maps and their size

### DIFF
--- a/cmd/kubectl-gadget/top/ebpf.go
+++ b/cmd/kubectl-gadget/top/ebpf.go
@@ -28,6 +28,7 @@ import (
 	gadgetv1alpha1 "github.com/kinvolk/inspektor-gadget/pkg/apis/gadget/v1alpha1"
 	"github.com/kinvolk/inspektor-gadget/pkg/gadgets/top/ebpf/types"
 
+	"github.com/docker/go-units"
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
 )
@@ -62,6 +63,8 @@ func newEbpfCmd() *cobra.Command {
 				"comm",
 				"runtime",
 				"runcount",
+				"mapmemory",
+				"mapcount",
 			},
 		},
 	}
@@ -79,6 +82,8 @@ func newEbpfCmd() *cobra.Command {
 		"totalruncount": 13,
 		"cumulruntime":  12,
 		"cumulruncount": 13,
+		"mapmemory":     14,
+		"mapcount":      8,
 	}
 
 	cmd := &cobra.Command{
@@ -281,6 +286,10 @@ func (p *EbpfParser) TransformStats(stats *types.Stats) string {
 				sb.WriteString(fmt.Sprintf("%*v", p.ColumnsWidth[col], time.Duration(stats.CumulativeRuntime)))
 			case "cumulruncount":
 				sb.WriteString(fmt.Sprintf("%*d", p.ColumnsWidth[col], stats.CumulativeRunCount))
+			case "mapmemory":
+				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], units.BytesSize(float64(stats.MapMemory))))
+			case "mapcount":
+				sb.WriteString(fmt.Sprintf("%*d", p.ColumnsWidth[col], stats.MapCount))
 			}
 			sb.WriteRune(' ')
 		}

--- a/docs/gadgets/ebpftop.md
+++ b/docs/gadgets/ebpftop.md
@@ -8,7 +8,7 @@ ebpftop shows cpu time used by ebpf programs.
 The following parameters are supported:
  - interval: Output interval, in seconds. (default 1)
  - max_rows: Maximum rows to print. (default 20)
- - sort_by: The field to sort the results by (all,runtime,runcount,progid,totalruntime,totalruncount,cumulruntime,cumulruncount). (default all)
+ - sort_by: The field to sort the results by (all,runtime,runcount,progid,totalruntime,totalruncount,cumulruntime,cumulruncount,mapmemory,mapcount). (default all)
 
 ### Example CR
 
@@ -26,7 +26,7 @@ spec:
   parameters:
     interval: "1"
     max_rows: "50"
-    sort_by: all # all, runtime, runcount, progid, totalruntime, totalruncount, cumulruntime and cumulrouncount are allowed
+    sort_by: all # all, runtime, runcount, progid, totalruntime, totalruncount, cumulruntime, cumulrouncount, mapmemory and mapcount are allowed
 ```
 
 ### Operations

--- a/docs/guides/top/ebpf.md
+++ b/docs/guides/top/ebpf.md
@@ -14,10 +14,10 @@ So first, start `top ebpf` in a terminal. You should see something like:
 
 ```bash
 $ kubectl gadget top ebpf
-NODE             PROGID   TYPE             NAME             PID     COMM                      RUNTIME   RUNCOUNT
-minikube         6344     Tracing          ig_top_ebpf_it   540621  gadgettracerman          86.911µs       1071
-minikube         62       CGroupDevice                      2378    systemd                        0s          0
-minikube         48       CGroupSKB                         2378    systemd                        0s          0
+NODE             PROGID   TYPE             NAME             PID     COMM                      RUNTIME   RUNCOUNT      MAPMEMORY MAPCOUNT
+minikube         503      Tracing          ig_top_ebpf_it   573222  gadgettracerman           54.09µs       1069            12B        1
+minikube         187      CGroupDevice                                                        2.292µs          1             0B        0
+minikube         13       CGroupSKB                                                                0s          0             0B        0
 ...
 ```
 
@@ -27,10 +27,10 @@ Now, in a second terminal, start `top file` on the _gadget_ namespace to get som
 
 ```bash
 $ kubectl gadget top file -n gadget
-NODE             NAMESPACE        POD              CONTAINER        PID     COMM             READS  WRITES R_Kb    W_Kb    T FILE
-minikube         gadget           gadget-9fnsx     gadget           1272964 runc:[2:INIT]    2      0      0       0       R filesystems
-minikube         gadget           gadget-9fnsx     gadget           1272964 sh               2      0      1       0       R libc-2.31.so
-minikube         gadget           gadget-9fnsx     gadget           540621  gadgettracerman  3      0      1       0       R cmdline
+NODE             NAMESPACE        POD                            CONTAINER        PID     COMM             READS  WRITES R_KB    W_KB    T FILE
+minikube         gadget           gadget-k2mvp                   gadget           575955  runc:[2:INIT]    1      0      0       0       R cap_last_cap
+minikube         gadget           gadget-k2mvp                   gadget           575955  runc:[2:INIT]    2      0      8       0       R group
+minikube         gadget           gadget-k2mvp                   gadget           575955  gadgettracerman  2      0      8       0       R UTC
 ...
 ```
 
@@ -40,17 +40,18 @@ Some eBPF programs of type `Kprobe` should pop up, including their runtime and r
 
 ```bash
 $ kubectl gadget top ebpf
-NODE             PROGID   TYPE             NAME             PID     COMM                      RUNTIME   RUNCOUNT
-minikube         6346     Kprobe           ig_topfile_wr_e  540621  gadgettracerman        3.948619ms        378
-minikube         6345     Kprobe           ig_topfile_rd_e  540621  gadgettracerman         677.012µs       1157
-minikube         6347     Tracing          ig_top_ebpf_it   540621  gadgettracerman          65.069µs       1101
-minikube         26       CGroupDevice                                                        3.667µs          2
-minikube         62       CGroupDevice                      2378    systemd                        0s          0
-minikube         53       CGroupDevice                                                             0s          0
+NODE             PROGID   TYPE             NAME             PID     COMM                      RUNTIME   RUNCOUNT      MAPMEMORY MAPCOUNT
+minikube         506      Kprobe           ig_topfile_rd_e  573222  gadgettracerman         824.589µs       2076       40.95MiB        4
+minikube         505      Tracing          ig_top_ebpf_it   573222  gadgettracerman          47.171µs       1103            12B        1
+minikube         507      Kprobe           ig_topfile_wr_e  573222  gadgettracerman         609.645µs        836       40.95MiB        4
+minikube         187      CGroupDevice                                                        4.417µs          2             0B        0
+minikube         13       CGroupSKB                                                                0s          0             0B        0
+minikube         8        CGroupSKB                                                                0s          0             0B        0
 ...
 ```
 
-So in this case for example, in the past second `vfs_write_entry` has been called 378 times, which took 3.948619ms.
+So in this case for example, in the past second `vfs_write_entry` has been called 647 times, which took 614.455µs.
+The program references 4 maps that have a total maximum size of 40.953 MB (see below for more information on MapMemory).
 
 If you want to get the cumulative runtime and run count of the eBPF programs starting from the beginning of the trace,
 you can call the gadget with the custom-columns option and specify the cumulruntime and cumulruncount columns.
@@ -60,10 +61,22 @@ over a minute:
 ```bash
 $ kubectl-gadget top ebpf -o custom-columns=node,progid,type,name,pid,comm,cumulruntime,cumulruncount --sort cumulruntime --timeout 60
 NODE             PROGID   TYPE             NAME             PID     COMM                 CUMULRUNTIME CUMULRUNCOUNT
-minikube         2598     Tracing          ig_top_ebpf_it   2215151 gadgettracerman        5.239255ms         61443
-minikube         24       CGroupDevice                                                      147.327µs           224
-minikube         85       CGroupDevice                                                       12.209µs             4
-minikube         60       CGroupDevice                      1765    systemd                        0s             0
-minikube         48       CGroupDevice                      1765    systemd                        0s             0
+minikube         509      Tracing          ig_top_ebpf_it   573222  gadgettracerman        1.265693ms         15879
+minikube         187      CGroupDevice                                                       40.795µs            48
+minikube         256      CGroupDevice                                                        5.834µs             2
+minikube         13       CGroupSKB                                                                0s             0
+minikube         7        CGroupSKB                                                                0s             0
+minikube         8        CGroupSKB                                                                0s             0
 ...
 ```
+
+### A note about memory usage of maps
+
+The shown value for MapMemory is calculated by using the parameters of the map: `max_entries * (key_size + value_size)`.
+This is the maximum size the map can have, but it doesn't necessarily reflect its current memory allocation. Additionally, maps can
+be used by more than one program and would account towards the MapMemory of all those programs.
+
+Also note:
+* BPF_MAP_TYPE_PERF_EVENT_ARRAY: value_size is not counting the ring buffers, but only their file descriptors (i.e. sizeof(int) = 4 bytes)
+* BPF_MAP_TYPE_{HASH,ARRAY}_OF_MAPS: value_size is not counting the inner maps, but only their file descriptors (i.e. sizeof(int) = 4 bytes)
+* PERCPU maps: the reported size is for one cpu, the multiplication by the number of cpus is left as an exercise to the reader

--- a/pkg/gadgets/top/ebpf/types/types.go
+++ b/pkg/gadgets/top/ebpf/types/types.go
@@ -32,6 +32,8 @@ const (
 	TOTALRUNCOUNT
 	CUMULRUNTIME
 	CUMULRUNCOUNT
+	MAPMEMORY
+	MAPCOUNT
 )
 
 const (
@@ -55,6 +57,8 @@ var SortBySlice = []string{
 	"totalruncount",
 	"cumulruntime",
 	"cumulruncount",
+	"mapmemory",
+	"mapcount",
 }
 
 func (s SortBy) String() string {
@@ -94,6 +98,10 @@ func SortStats(stats []Stats, sortBy SortBy) {
 			return a.CumulativeRunCount > b.CumulativeRunCount
 		case PROGRAMID:
 			return a.ProgramID > b.ProgramID
+		case MAPMEMORY:
+			return a.MapMemory > b.MapMemory
+		case MAPCOUNT:
+			return a.MapCount > b.MapCount
 		default:
 			return a.CurrentRuntime > b.CurrentRuntime && a.CurrentRunCount > b.CurrentRunCount
 		}
@@ -117,6 +125,8 @@ type Stats struct {
 	CumulativeRunCount uint64     `json:"cumulRunCount,omitempty"`
 	TotalRuntime       int64      `json:"totalRuntime,omitempty"`
 	TotalRunCount      uint64     `json:"totalRunCount,omitempty"`
+	MapMemory          uint64     `json:"mapMemory,omitempty"`
+	MapCount           uint32     `json:"mapCount,omitempty"`
 }
 
 type PidInfo struct {

--- a/pkg/resources/samples/trace-ebpftop.yaml
+++ b/pkg/resources/samples/trace-ebpftop.yaml
@@ -11,4 +11,4 @@ spec:
   parameters:
     interval: "1"
     max_rows: "50"
-    sort_by: all # all, runtime, runcount, progid, totalruntime, totalruncount, cumulruntime and cumulrouncount are allowed
+    sort_by: all # all, runtime, runcount, progid, totalruntime, totalruncount, cumulruntime, cumulrouncount, mapmemory and mapcount are allowed


### PR DESCRIPTION
# Add information about number and size of referenced maps

This PR will add the number and the maximum size of the referenced maps to the programs. It does so by getting the referenced map ids using the cilium/ebpf library and then getting information about the defined sizes for that map (then it's basically (keysize+valuesize)*maxentries).

## How to use

```
$ kubectl gadget top ebpf --sort mapmemory
NODE             PROGID   TYPE             NAME             PID     COMM                      RUNTIME   RUNCOUNT      MAPMEMORY MAPCOUNT
minikube         3460     Kprobe           vfs_write_entry  4169649 gadgettracerman         467.908µs        257     40.953 MiB        4
minikube         3459     Kprobe           vfs_read_entry   4169649 gadgettracerman         380.821µs        414     40.953 MiB        4
minikube         3458     Tracing          gadget_ebpftop   4169649 gadgettracerman          90.351µs       1088         12   B        1
minikube         60       CGroupDevice                      1765    systemd                        0s          0          0   B        0
...
```

Fixes #875 