### PR TITLE
Columns: Improve data handling/output and metadata export

### DIFF
--- a/pkg/columns/columninfo.go
+++ b/pkg/columns/columninfo.go
@@ -1,0 +1,229 @@
+// Copyright 2022 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package columns
+
+import (
+	"fmt"
+	"reflect"
+	"strconv"
+	"strings"
+
+	"github.com/kinvolk/inspektor-gadget/pkg/columns/ellipsis"
+)
+
+type Column[T any] struct {
+	Name         string                // Name of the column; case-insensitive for most use cases
+	Width        int                   // Width to reserve for this column
+	Alignment    Alignment             // Alignment of this column (left or right)
+	Extractor    func(*T) string       // Extractor to be used; this can be defined to transform the output before retrieving the actual value
+	Visible      bool                  // Visible defines whether a column is to be shown by default
+	GroupType    GroupType             // GroupType defines the aggregation method used when grouping this column
+	EllipsisType ellipsis.EllipsisType // EllipsisType defines how to abbreviate this column if the value needs more space than is available
+	FixedWidth   bool                  // FixedWidth forces the Width even when using Auto-Scaling
+	Precision    int                   // Precision defines how many decimals should be shown on float values, default: 2
+	Description  string                // Description can hold a short description of the field that can be used to aid the user
+	Order        int                   // Order defines the default order in which columns are shown
+	Tags         []string              // Tags can be used to dynamically include or exclude columns
+
+	fieldIndex    int          // used for the main struct
+	subFieldIndex []int        // used for embedded structs
+	kind          reflect.Kind // cached kind info from reflection
+	columnType    reflect.Type // cached type info from reflection
+}
+
+func (ci *Column[T]) fromTag(tag string) error {
+	tagInfo := strings.Split(tag, ",")
+	ci.Name = tagInfo[0]
+
+	tagInfo = tagInfo[1:]
+	for _, subTag := range tagInfo {
+		params := strings.SplitN(subTag, ":", 2)
+		paramsLen := len(params)
+		switch params[0] {
+		case "align":
+			if paramsLen == 1 {
+				return fmt.Errorf("missing alignment value for field %q", ci.Name)
+			}
+			switch params[1] {
+			case "left":
+				ci.Alignment = AlignLeft
+			case "right":
+				ci.Alignment = AlignRight
+			default:
+				return fmt.Errorf("invalid alignment %q for field %q", params[1], ci.Name)
+			}
+		case "ellipsis":
+			if paramsLen == 1 {
+				ci.EllipsisType = ellipsis.End
+				continue
+			}
+			switch params[1] {
+			case "end", "":
+				ci.EllipsisType = ellipsis.End
+			case "middle":
+				ci.EllipsisType = ellipsis.Middle
+			case "none":
+				ci.EllipsisType = ellipsis.None
+			case "start":
+				ci.EllipsisType = ellipsis.Start
+			default:
+				return fmt.Errorf("invalid ellipsis value %q for field %q", params[1], ci.Name)
+			}
+		case "fixed":
+			if paramsLen != 1 {
+				return fmt.Errorf("parameter fixed on field %q must not have a value", ci.Name)
+			}
+			ci.FixedWidth = true
+		case "group":
+			if paramsLen == 1 {
+				return fmt.Errorf("missing group value for field %q", ci.Name)
+			}
+			switch params[1] {
+			case "sum":
+				if !ci.columnType.ConvertibleTo(reflect.TypeOf(int(0))) {
+					return fmt.Errorf("cannot use sum on field %q of kind %q", ci.Name, ci.kind.String())
+				}
+				ci.GroupType = GroupTypeSum
+			default:
+				return fmt.Errorf("invalid group value %q for field %q", params[1], ci.Name)
+			}
+		case "hide":
+			if paramsLen != 1 {
+				return fmt.Errorf("parameter hide on field %q must not have a value", ci.Name)
+			}
+			ci.Visible = false
+		case "order":
+			if paramsLen == 1 {
+				return fmt.Errorf("missing width value for field %q", ci.Name)
+			}
+			w, err := strconv.Atoi(params[1])
+			if err != nil {
+				return fmt.Errorf("invalid order value %q for field %q: %w", params[1], ci.Name, err)
+			}
+			ci.Order = w
+		case "precision":
+			if ci.kind != reflect.Float32 && ci.kind != reflect.Float64 {
+				return fmt.Errorf("field %q is not a float field and thereby cannot have precision defined", ci.Name)
+			}
+			if paramsLen == 1 {
+				return fmt.Errorf("missing precision value for field %q", ci.Name)
+			}
+			w, err := strconv.Atoi(params[1])
+			if err != nil {
+				return fmt.Errorf("invalid precision value %q for field %q: %w", params[1], ci.Name, err)
+			}
+			if w < -1 {
+				return fmt.Errorf("negative precision value %q for field %q", params[1], ci.Name)
+			}
+			ci.Precision = w
+		case "width":
+			if paramsLen == 1 {
+				return fmt.Errorf("missing width value for field %q", ci.Name)
+			}
+			w, err := strconv.Atoi(params[1])
+			if err != nil {
+				return fmt.Errorf("invalid width %q for field %q: %w", params[1], ci.Name, err)
+			}
+			ci.Width = w
+		default:
+			return fmt.Errorf("invalid column parameter %q for field %q", params[0], ci.Name)
+		}
+	}
+	return nil
+}
+
+// Get returns the reflected value of an entry for the current column; if given nil, it will return the zero value of
+// the underlying type
+func (ci *Column[T]) Get(entry *T) reflect.Value {
+	if entry == nil {
+		return reflect.Zero(ci.Type())
+	}
+	v := reflect.ValueOf(entry)
+	if ci.Extractor != nil {
+		return reflect.ValueOf(ci.Extractor(v.Interface().(*T)))
+	}
+	return ci.getRawField(v)
+}
+
+// GetRef returns the reflected value of an already reflected entry for the current column; expects v to be valid or
+// will panic
+func (ci *Column[T]) GetRef(v reflect.Value) reflect.Value {
+	if ci.Extractor != nil {
+		return reflect.ValueOf(ci.Extractor(v.Interface().(*T)))
+	}
+	return ci.getRawField(v)
+}
+
+// GetRaw returns the reflected value of an entry for the current column without evaluating the extractor func;
+// if given nil or run on a virtual column, it will return the zero value of the underlying type
+func (ci *Column[T]) GetRaw(entry *T) reflect.Value {
+	if entry == nil || ci.fieldIndex == virtualIndex {
+		return reflect.Zero(ci.Type())
+	}
+	v := reflect.ValueOf(entry)
+	return ci.getRawField(v)
+}
+
+func (ci *Column[T]) getRawField(v reflect.Value) reflect.Value {
+	if v.Kind() == reflect.Pointer {
+		v = v.Elem()
+	}
+	if len(ci.subFieldIndex) > 0 {
+		return ci.getFieldRec(v, ci.subFieldIndex)
+	}
+	return v.Field(ci.fieldIndex)
+}
+
+func (ci *Column[T]) getFieldRec(v reflect.Value, sub []int) reflect.Value {
+	val := v.Field(sub[0])
+	if len(sub) == 1 {
+		return val
+	}
+	return ci.getFieldRec(val, sub[1:])
+}
+
+// Kind returns the underlying kind of the column (always reflect.String in case of virtual columns)
+func (ci *Column[T]) Kind() reflect.Kind {
+	return ci.kind
+}
+
+// Type returns the underlying type of the column
+func (ci *Column[T]) Type() reflect.Type {
+	return ci.columnType
+}
+
+func (ci *Column[T]) HasTag(tag string) bool {
+	for _, curTag := range ci.Tags {
+		if curTag == tag {
+			return true
+		}
+	}
+	return false
+}
+
+func (ci *Column[T]) HasNoTags() bool {
+	if len(ci.Tags) == 0 {
+		return true
+	}
+	return false
+}
+
+// IsEmbedded returns true, if the current column is a member of an embedded struct
+func (ci *Column[T]) IsEmbedded() bool {
+	if len(ci.subFieldIndex) == 0 {
+		return false
+	}
+	return true
+}

--- a/pkg/columns/columninfo_test.go
+++ b/pkg/columns/columninfo_test.go
@@ -1,0 +1,539 @@
+// Copyright 2022 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package columns
+
+import (
+	"testing"
+
+	"github.com/kinvolk/inspektor-gadget/pkg/columns/ellipsis"
+)
+
+func TestColumnsInvalid(t *testing.T) {
+	type testFail1 struct {
+		Unknown string `column:"left,unknown"` // unknown parameter
+	}
+	type testFail2 struct {
+		Unknown1 string `column:"unknown"`
+		Unknown2 string `column:"unknown"` // double name
+	}
+	type testFail3 struct {
+		testFail2
+	}
+	_, err := NewColumns[testFail1]()
+	if err == nil {
+		t.Errorf("succeeded to initialize but expected error")
+	}
+	_, err = NewColumns[testFail2]()
+	if err == nil {
+		t.Errorf("succeeded to initialize but expected error")
+	}
+	_, err = NewColumns[testFail3]()
+	if err == nil {
+		t.Errorf("succeeded to initialize but expected error")
+	}
+}
+
+func TestColumnsAlign(t *testing.T) {
+	type testSuccess1 struct {
+		AlignLeft  string `column:"left,align:left"`
+		AlignRight string `column:"right,align:right"`
+	}
+	type testFail1 struct {
+		Field string `column:"fail,align"`
+	}
+	type testFail2 struct {
+		Field string `column:"fail,align:"`
+	}
+	type testFail3 struct {
+		Field string `column:"fail,align:foo"`
+	}
+	type testFail4 struct {
+		Field string `column:"fail,align:left:bar"`
+	}
+
+	cols, err := NewColumns[testSuccess1]()
+	if err != nil {
+		t.Fatalf("failed to initialize: %v", err)
+	}
+
+	columnName := "left"
+	col, ok := cols.GetColumn(columnName)
+	if !ok {
+		t.Fatalf("expected column %q to exist", columnName)
+	}
+	if col.Alignment != AlignLeft {
+		t.Errorf("expected alignment for column %q to be %q", columnName, "AlignLeft")
+	}
+
+	columnName = "right"
+	col, ok = cols.GetColumn(columnName)
+	if !ok {
+		t.Fatalf("expected column %q to exist", columnName)
+	}
+	if col.Alignment != AlignRight {
+		t.Errorf("expected alignment for column %q to be %q", columnName, "AlignRight")
+	}
+
+	_, err = NewColumns[testFail1]()
+	if err == nil {
+		t.Errorf("succeeded to initialize but expected error")
+	}
+	_, err = NewColumns[testFail2]()
+	if err == nil {
+		t.Errorf("succeeded to initialize but expected error")
+	}
+	_, err = NewColumns[testFail3]()
+	if err == nil {
+		t.Errorf("succeeded to initialize but expected error")
+	}
+	_, err = NewColumns[testFail4]()
+	if err == nil {
+		t.Errorf("succeeded to initialize but expected error")
+	}
+}
+
+func TestColumnsEllipsis(t *testing.T) {
+	type testSuccess1 struct {
+		EllipsisEmpty      string `column:"empty,ellipsis"`
+		EllipsisEmptyColon string `column:"emptyColon,ellipsis:"`
+		EllipsisNone       string `column:"none,ellipsis:none"`
+		EllipsisStart      string `column:"start,ellipsis:start"`
+		EllipsisEnd        string `column:"end,ellipsis:end"`
+		EllipsisMiddle     string `column:"middle,ellipsis:middle"`
+	}
+	type testFail1 struct {
+		Field string `column:"fail,ellipsis:foo"`
+	}
+	type testFail2 struct {
+		Field string `column:"fail,ellipsis:left:bar"`
+	}
+
+	type check struct {
+		Name  string
+		Value ellipsis.EllipsisType
+	}
+
+	cols, err := NewColumns[testSuccess1]()
+	if err != nil {
+		t.Fatalf("failed to initialize: %v", err)
+	}
+
+	checks := []check{
+		{"empty", cols.options.DefaultEllipsis},
+		{"emptyColon", cols.options.DefaultEllipsis},
+		{"none", ellipsis.None},
+		{"start", ellipsis.Start},
+		{"end", ellipsis.End},
+		{"middle", ellipsis.Middle},
+	}
+
+	checkEllipsis := func(chk check) {
+		t.Run(chk.Name, func(t *testing.T) {
+			col, ok := cols.GetColumn(chk.Name)
+			if !ok {
+				t.Fatalf("expected column %q to exist", chk.Name)
+			}
+			if col.EllipsisType != chk.Value {
+				t.Errorf("expected ellipsis for column %q to be %q, got %q", chk.Name, chk.Value.String(), col.EllipsisType.String())
+			}
+		})
+	}
+	for _, chk := range checks {
+		checkEllipsis(chk)
+	}
+
+	_, err = NewColumns[testFail1]()
+	if err == nil {
+		t.Errorf("succeeded to initialize but expected error")
+	}
+	_, err = NewColumns[testFail2]()
+	if err == nil {
+		t.Errorf("succeeded to initialize but expected error")
+	}
+}
+
+func TestColumnsFixed(t *testing.T) {
+	type testSuccess1 struct {
+		Field string `column:"field,fixed"`
+	}
+	type testFail1 struct {
+		Field string `column:"fail,fixed:foo"` // with param
+	}
+
+	cols, err := NewColumns[testSuccess1]()
+	if err != nil {
+		t.Fatalf("failed to initialize: %v", err)
+	}
+	col, ok := cols.GetColumn("field")
+	if !ok {
+		t.Fatalf("expected column %q to exist", "field")
+	}
+	if !col.FixedWidth {
+		t.Fatalf("expected column %q to have FixedWidth set", "field")
+	}
+
+	_, err = NewColumns[testFail1]()
+	if err == nil {
+		t.Errorf("succeeded to initialize but expected error")
+	}
+}
+
+func TestColumnsGroup(t *testing.T) {
+	type testSuccess1 struct {
+		FieldInt     int64   `column:"int,group:sum"`
+		FieldUint    int64   `column:"uint,group:sum"`
+		FieldFloat32 float32 `column:"float32,group:sum"`
+		FieldFloat64 float64 `column:"float64,group:sum"`
+	}
+	type testFail1 struct {
+		Field int64 `column:"fail,group"` // no param
+	}
+	type testFail2 struct {
+		Field int64 `column:"fail,group:"` // empty param
+	}
+	type testFail3 struct {
+		Field int64 `column:"fail,group:foo"` // invalid param
+	}
+	type testFail4 struct {
+		Field int64 `column:"fail,group:sum:bar"` // double param
+	}
+	type testFail5 struct {
+		Field string `column:"fail,group:sum"` // wrong type
+	}
+
+	cols, err := NewColumns[testSuccess1]()
+	if err != nil {
+		t.Fatalf("failed to initialize: %v", err)
+	}
+	if col, ok := cols.GetColumn("int"); !ok || col.GroupType != GroupTypeSum {
+		t.Errorf("expected column %q to have GroupType %q", "int", "GroupTypeSum")
+	}
+	if col, ok := cols.GetColumn("uint"); !ok || col.GroupType != GroupTypeSum {
+		t.Errorf("expected column %q to have GroupType %q", "uint", "GroupTypeSum")
+	}
+	if col, ok := cols.GetColumn("float32"); !ok || col.GroupType != GroupTypeSum {
+		t.Errorf("expected column %q to have GroupType %q", "float32", "GroupTypeSum")
+	}
+	if col, ok := cols.GetColumn("float64"); !ok || col.GroupType != GroupTypeSum {
+		t.Errorf("expected column %q to have GroupType %q", "float64", "GroupTypeSum")
+	}
+
+	_, err = NewColumns[testFail1]()
+	if err == nil {
+		t.Errorf("succeeded to initialize but expected error")
+	}
+	_, err = NewColumns[testFail2]()
+	if err == nil {
+		t.Errorf("succeeded to initialize but expected error")
+	}
+	_, err = NewColumns[testFail3]()
+	if err == nil {
+		t.Errorf("succeeded to initialize but expected error")
+	}
+	_, err = NewColumns[testFail4]()
+	if err == nil {
+		t.Errorf("succeeded to initialize but expected error")
+	}
+	_, err = NewColumns[testFail5]()
+	if err == nil {
+		t.Errorf("succeeded to initialize but expected error")
+	}
+}
+
+func TestColumnsHide(t *testing.T) {
+	type testSuccess1 struct {
+		Field string `column:"field,hide"`
+	}
+	type testFail1 struct {
+		Field string `column:"fail,hide:foo"` // with param
+	}
+
+	cols, err := NewColumns[testSuccess1]()
+	if err != nil {
+		t.Fatalf("failed to initialize: %v", err)
+	}
+	col, ok := cols.GetColumn("field")
+	if !ok {
+		t.Fatalf("expected column %q to exist", "field")
+	}
+	if col.Visible {
+		t.Fatalf("expected column %q to have Hide set", "field")
+	}
+
+	_, err = NewColumns[testFail1]()
+	if err == nil {
+		t.Errorf("succeeded to initialize but expected error")
+	}
+}
+
+func TestColumnsOrder(t *testing.T) {
+	type testSuccess1 struct {
+		FieldWidth int64 `column:"int,order:4"`
+	}
+	type testFail1 struct {
+		Field int64 `column:"fail,order"` // no param
+	}
+	type testFail2 struct {
+		Field int64 `column:"fail,order:"` // empty param
+	}
+	type testFail3 struct {
+		Field int64 `column:"fail,order:foo"` // invalid param
+	}
+	type testFail4 struct {
+		Field int64 `column:"fail,order:sum:bar"` // double param
+	}
+
+	cols, err := NewColumns[testSuccess1]()
+	if err != nil {
+		t.Fatalf("failed to initialize: %v", err)
+	}
+	if col, ok := cols.GetColumn("int"); !ok || col.Order != 4 {
+		t.Errorf("expected column %q to have Order set to %d", "int", 4)
+	}
+
+	_, err = NewColumns[testFail1]()
+	if err == nil {
+		t.Errorf("succeeded to initialize but expected error")
+	}
+	_, err = NewColumns[testFail2]()
+	if err == nil {
+		t.Errorf("succeeded to initialize but expected error")
+	}
+	_, err = NewColumns[testFail3]()
+	if err == nil {
+		t.Errorf("succeeded to initialize but expected error")
+	}
+	_, err = NewColumns[testFail4]()
+	if err == nil {
+		t.Errorf("succeeded to initialize but expected error")
+	}
+}
+
+func TestColumnsPrecision(t *testing.T) {
+	type testSuccess1 struct {
+		Float32 float32 `column:"float32,precision:4"`
+		Float64 float64 `column:"float64,precision:4"`
+	}
+	type testFail1 struct {
+		Field1 float32 `column:"fail,precision"`
+	}
+	type testFail2 struct {
+		Field float32 `column:"fail,precision:"`
+	}
+	type testFail3 struct {
+		Field float32 `column:"fail,precision:foo"`
+	}
+	type testFail4 struct {
+		Field float32 `column:"fail,precision:-2"`
+	}
+	type testFail5 struct {
+		Field1 float64 `column:"fail,precision"`
+	}
+	type testFail6 struct {
+		Field float64 `column:"fail,precision:"`
+	}
+	type testFail7 struct {
+		Field float64 `column:"fail,precision:foo"`
+	}
+	type testFail8 struct {
+		Field float64 `column:"fail,precision:-2"`
+	}
+	type testFail9 struct {
+		Field string `column:"fail,precision:2"`
+	}
+
+	cols, err := NewColumns[testSuccess1]()
+	if err != nil {
+		t.Fatalf("failed to initialize: %v", err)
+	}
+	if col, ok := cols.GetColumn("float32"); !ok || col.Precision != 4 {
+		t.Errorf("expected column %q to have Precision set to %d", "float32", 4)
+	}
+	if col, ok := cols.GetColumn("float64"); !ok || col.Precision != 4 {
+		t.Errorf("expected column %q to have Precision set to %d", "float64", 4)
+	}
+
+	_, err = NewColumns[testFail1]()
+	if err == nil {
+		t.Errorf("succeeded to initialize but expected error")
+	}
+	_, err = NewColumns[testFail2]()
+	if err == nil {
+		t.Errorf("succeeded to initialize but expected error")
+	}
+	_, err = NewColumns[testFail3]()
+	if err == nil {
+		t.Errorf("succeeded to initialize but expected error")
+	}
+	_, err = NewColumns[testFail4]()
+	if err == nil {
+		t.Errorf("succeeded to initialize but expected error")
+	}
+	_, err = NewColumns[testFail5]()
+	if err == nil {
+		t.Errorf("succeeded to initialize but expected error")
+	}
+	_, err = NewColumns[testFail6]()
+	if err == nil {
+		t.Errorf("succeeded to initialize but expected error")
+	}
+	_, err = NewColumns[testFail7]()
+	if err == nil {
+		t.Errorf("succeeded to initialize but expected error")
+	}
+	_, err = NewColumns[testFail8]()
+	if err == nil {
+		t.Errorf("succeeded to initialize but expected error")
+	}
+	_, err = NewColumns[testFail9]()
+	if err == nil {
+		t.Errorf("succeeded to initialize but expected error")
+	}
+}
+
+func TestColumnsWidth(t *testing.T) {
+	type testSuccess1 struct {
+		FieldWidth int64 `column:"int,width:4"`
+	}
+	type testFail1 struct {
+		Field int64 `column:"fail,width"` // no param
+	}
+	type testFail2 struct {
+		Field int64 `column:"fail,width:"` // empty param
+	}
+	type testFail3 struct {
+		Field int64 `column:"fail,width:foo"` // invalid param
+	}
+	type testFail4 struct {
+		Field int64 `column:"fail,width:sum:bar"` // double param
+	}
+
+	cols, err := NewColumns[testSuccess1]()
+	if err != nil {
+		t.Fatalf("failed to initialize: %v", err)
+	}
+	if col, ok := cols.GetColumn("int"); !ok || col.Width != 4 {
+		t.Errorf("expected column %q to have Width set to %d", "int", 4)
+	}
+
+	_, err = NewColumns[testFail1]()
+	if err == nil {
+		t.Errorf("succeeded to initialize but expected error")
+	}
+	_, err = NewColumns[testFail2]()
+	if err == nil {
+		t.Errorf("succeeded to initialize but expected error")
+	}
+	_, err = NewColumns[testFail3]()
+	if err == nil {
+		t.Errorf("succeeded to initialize but expected error")
+	}
+	_, err = NewColumns[testFail4]()
+	if err == nil {
+		t.Errorf("succeeded to initialize but expected error")
+	}
+}
+
+func TestWithoutColumnTag(t *testing.T) {
+	type Main struct {
+		StringField string
+		IntField    int
+	}
+	cols, err := NewColumns[Main](WithRequireColumnDefinition(false))
+	if err != nil {
+		t.Errorf("failed to initialize: %v", err)
+	}
+
+	if _, ok := cols.GetColumn("StringField"); !ok {
+		t.Errorf("expected a StringField column")
+	}
+}
+
+func TestColumnFilters(t *testing.T) {
+	type Embedded struct {
+		EmbeddedString string `column:"embeddedString" columnTags:"test"`
+	}
+	type Main struct {
+		Embedded
+		MainString string `column:"mainString" columnTags:"test2"`
+	}
+	cols, err := NewColumns[Main](WithRequireColumnDefinition(false))
+	if err != nil {
+		t.Errorf("failed to initialize: %v", err)
+	}
+
+	colMap := cols.GetColumnMap(Or(WithEmbedded(true), WithTag("test")))
+	if _, ok := colMap.GetColumn("embeddedString"); !ok {
+		t.Errorf("expected an embeddedString column after applying filters")
+	}
+
+	colMap = cols.GetColumnMap(Or(WithEmbedded(false), WithoutTag("test")))
+	if _, ok := colMap.GetColumn("mainString"); !ok {
+		t.Errorf("expected a mainString column after applying filters")
+	}
+
+	orderedColumns := cols.GetOrderedColumns(And(WithTags([]string{"test2"}), WithoutTags([]string{"test"})))
+	if len(orderedColumns) != 1 || orderedColumns[0].Name != "mainString" {
+		t.Errorf("expected a mainString column after getting ordered columns using filters")
+	}
+
+	orderedColumns = cols.GetOrderedColumns(WithoutTags([]string{"test"})) // missing path
+	if len(orderedColumns) != 1 || orderedColumns[0].Name != "mainString" {
+		t.Errorf("expected a mainString column after getting ordered columns using filters")
+	}
+}
+
+func TestColumnMatcher(t *testing.T) {
+	type Embedded struct {
+		EmbeddedString string `column:"embeddedString" columnTags:"test"`
+	}
+	type Main struct {
+		Embedded
+		MainString string `column:"mainString" columnTags:"test2"`
+	}
+
+	cols, err := NewColumns[Main]()
+	if err != nil {
+		t.Errorf("failed to initialize: %v", err)
+	}
+
+	c, ok := cols.GetColumn("embeddedString")
+	if !ok {
+		t.Errorf("expected there to be an embeddedString column")
+	}
+	if !c.IsEmbedded() {
+		t.Errorf("expected the embedded field to be identified as embedded")
+	}
+	if !c.HasTag("test") {
+		t.Errorf("expected the embedded field to have tag 'test'")
+	}
+	if c.HasTag("test2") {
+		t.Errorf("didn't expect the embedded field to have tag 'test2'")
+	}
+
+	c, ok = cols.GetColumn("mainString")
+	if !ok {
+		t.Errorf("expected there to be a mainString column")
+	}
+	if c.IsEmbedded() {
+		t.Errorf("expected mainString to not be identified as embedded")
+	}
+	if !c.HasTag("test2") {
+		t.Errorf("expected mainString to have tag 'test2'")
+	}
+	if c.HasTag("test") {
+		t.Errorf("didn't expect mainString to have tag 'test'")
+	}
+}

--- a/pkg/columns/columns.go
+++ b/pkg/columns/columns.go
@@ -1,0 +1,280 @@
+// Copyright 2022 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package columns
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+)
+
+type ColumnMap[T any] map[string]*Column[T]
+
+type Columns[T any] struct {
+	// columns map[string]*Column[T]
+	ColumnMap[T]
+	options *Options
+}
+
+const virtualIndex = -1
+
+var stringType = reflect.TypeOf("") // used for virtual columns and columns with a custom extractor
+
+// MustCreateColumns creates a new column helper and panics if it cannot successfully be created; useful if you
+// want to initialize Columns as a global variable inside a package (similar to regexp.MustCompile)
+func MustCreateColumns[T any](options ...Option) *Columns[T] {
+	cols, err := NewColumns[T](options...)
+	if err != nil {
+		panic(err)
+	}
+	return cols
+}
+
+// NewColumns creates a new column helper. T must be of type struct and
+// its fields must contain the column tags.
+func NewColumns[T any](options ...Option) (*Columns[T], error) {
+	opts := GetDefault()
+	for _, o := range options {
+		o(opts)
+	}
+
+	entryPrototype := new(T)
+
+	t := reflect.TypeOf(entryPrototype)
+	if t.Kind() == reflect.Pointer {
+		t = t.Elem()
+	}
+
+	// Generics sadly don't provide a way to constraint to a type like struct{}, so we need to check here
+	if t.Kind() != reflect.Struct {
+		return nil, fmt.Errorf("NewColumns works only on structs")
+	}
+
+	columns := &Columns[T]{
+		ColumnMap: make(ColumnMap[T]),
+		options:   opts,
+	}
+
+	err := columns.iterateFields(t, nil)
+	if err != nil {
+		return nil, fmt.Errorf("error trying to initialize columns on type %s: %w", t.String(), err)
+	}
+
+	return columns, nil
+}
+
+// GetColumn returns a specific column by its name
+func (c ColumnMap[T]) GetColumn(columnName string) (*Column[T], bool) {
+	column, ok := c[strings.ToLower(columnName)]
+	return column, ok
+}
+
+// GetColumnMap returns a map of column names to their Column, filtered by filters
+func (c ColumnMap[T]) GetColumnMap(filters ...ColumnFilter) ColumnMap[T] {
+	if len(filters) == 0 {
+		return c
+	}
+	// return a new copy
+	res := make(map[string]*Column[T])
+
+filter:
+	for columnName, column := range c {
+		for _, f := range filters {
+			if !f(column) {
+				continue filter
+			}
+		}
+		res[columnName] = column
+	}
+	return res
+}
+
+// GetOrderedColumns returns an ordered list of columns according to their order values, filtered by filters
+func (c ColumnMap[T]) GetOrderedColumns(filters ...ColumnFilter) []*Column[T] {
+	columns := make([]*Column[T], 0, len(c))
+
+filter:
+	for _, column := range c {
+		for _, f := range filters {
+			if !f(column) {
+				continue filter
+			}
+		}
+		columns = append(columns, column)
+	}
+	sort.Slice(columns, func(i, j int) bool {
+		return columns[i].Order < columns[j].Order
+	})
+	return columns
+}
+
+// GetColumnNames returns a list of column names, ordered by the column order values
+func (c ColumnMap[T]) GetColumnNames(filters ...ColumnFilter) []string {
+	columns := make([]string, 0, len(c))
+	sorted := c.GetOrderedColumns(filters...)
+	for _, column := range sorted {
+		columns = append(columns, column.Name)
+	}
+	return columns
+}
+
+// VerifyColumnNames takes a list of column names and returns two lists, one containing the valid column names
+// and another containing the invalid column names. Prefixes like "-" for descending sorting will be ignored.
+func (c ColumnMap[T]) VerifyColumnNames(columnNames []string) (valid []string, invalid []string) {
+	for _, cname := range columnNames {
+		cname = strings.ToLower(cname)
+
+		// Strip prefixes
+		cname = strings.TrimPrefix(cname, "-")
+
+		if _, ok := c[cname]; ok {
+			valid = append(valid, cname)
+			continue
+		}
+		invalid = append(invalid, cname)
+	}
+	return
+}
+
+func (c *Columns[T]) iterateFields(t reflect.Type, sub []int) error {
+	for i := 0; i < t.NumField(); i++ {
+		f := t.Field(i)
+		if f.Anonymous {
+			err := c.iterateFields(f.Type, append(append([]int{}, sub...), i))
+			if err != nil {
+				return err
+			}
+			continue
+		}
+
+		tag := f.Tag.Get("column")
+		if tag == "" && c.options.RequireColumnDefinition {
+			continue
+		}
+
+		if tag == "" {
+			// set the name, so it will get picked up
+			tag = f.Name
+		}
+
+		column := &Column[T]{
+			Width:        c.options.DefaultWidth,
+			EllipsisType: c.options.DefaultEllipsis,
+			Alignment:    c.options.DefaultAlignment,
+			Visible:      true,
+			Precision:    2,
+
+			Order: len(c.ColumnMap) * 10,
+		}
+
+		if sub == nil {
+			column.fieldIndex = i
+		} else {
+			// Nested structs
+			column.subFieldIndex = append(append([]int{}, sub...), i)
+		}
+
+		// store kind for faster lookups if required
+		column.kind = f.Type.Kind()
+		column.columnType = f.Type
+
+		// read information from tag
+		err := column.fromTag(tag)
+		if err != nil {
+			return fmt.Errorf("error parsing tag for %q on field %q: %w", t.Name(), f.Name, err)
+		}
+
+		// add optional description
+		column.Description = f.Tag.Get("columnDesc")
+
+		// add optional tags
+		if tags := f.Tag.Get("columnTags"); tags != "" {
+			column.Tags = strings.Split(strings.ToLower(tags), ",")
+		}
+
+		lowerName := strings.ToLower(column.Name)
+		if _, ok := c.ColumnMap[lowerName]; ok {
+			return fmt.Errorf("duplicate column %q for %q", lowerName, t.Name())
+		}
+
+		c.ColumnMap[lowerName] = column
+	}
+
+	return nil
+}
+
+// AddColumn adds a virtual column to the table. This virtual column requires at least a
+// name and an Extractor
+func (c *Columns[T]) AddColumn(column Column[T]) error {
+	if column.Name == "" {
+		return errors.New("no name set for column")
+	}
+
+	columnName := strings.ToLower(column.Name)
+	if _, ok := c.ColumnMap[columnName]; ok {
+		return fmt.Errorf("column already exists: %q", columnName)
+	}
+
+	if column.Extractor == nil {
+		return fmt.Errorf("no extractor set for column %q", column.Name)
+	}
+
+	c.ColumnMap[columnName] = &column
+
+	if column.Width == 0 {
+		column.Width = c.options.DefaultWidth
+	}
+
+	column.fieldIndex = virtualIndex
+
+	// We expect kind to be of type reflect.String because we always use the extractor func for
+	// virtual columns
+	column.kind = reflect.String
+	column.columnType = stringType
+	return nil
+}
+
+// MustAddColumn adds a new column and panics if it cannot successfully do so
+func (c *Columns[T]) MustAddColumn(column Column[T]) {
+	err := c.AddColumn(column)
+	if err != nil {
+		panic(err)
+	}
+}
+
+// SetExtractor sets the extractor function for a specific column
+func (c *Columns[T]) SetExtractor(columnName string, extractor func(*T) string) error {
+	if extractor == nil {
+		return fmt.Errorf("extractor func must be non-nil")
+	}
+	column, ok := c.ColumnMap[strings.ToLower(columnName)]
+	if !ok {
+		return fmt.Errorf("could not set extractor for unknown field %q", columnName)
+	}
+	column.kind = reflect.String
+	column.Extractor = extractor
+	column.columnType = stringType
+	return nil
+}
+
+// MustSetExtractor adds a new extractor to a column and panics if it cannot successfully do so
+func (c *Columns[T]) MustSetExtractor(columnName string, extractor func(*T) string) {
+	err := c.SetExtractor(columnName, extractor)
+	if err != nil {
+		panic(err)
+	}
+}

--- a/pkg/columns/columns_test.go
+++ b/pkg/columns/columns_test.go
@@ -1,0 +1,337 @@
+// Copyright 2022 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package columns
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestColumnMap(t *testing.T) {
+	type testStruct struct {
+		StringField string `column:"stringField"`
+		IntField    int    `column:"intField"`
+	}
+	cols, err := NewColumns[testStruct]()
+	if err != nil {
+		t.Fatalf("could not initialize: %v", err)
+	}
+	columnMap := cols.GetColumnMap()
+	if _, ok := columnMap["stringfield"]; !ok {
+		t.Errorf("expected stringfield in column map")
+	}
+	if _, ok := columnMap["intfield"]; !ok {
+		t.Errorf("expected stringfield in column map")
+	}
+}
+
+func TestEmptyStruct(t *testing.T) {
+	type testStruct struct {
+		StringField string
+		IntField    int
+	}
+	cols, err := NewColumns[testStruct]()
+	if err != nil {
+		t.Fatalf("could not initialize: %v", err)
+	}
+	columnMap := cols.GetColumnMap()
+	if len(columnMap) != 0 {
+		t.Errorf("expected empty column map")
+	}
+}
+
+func TestGetColumnNames(t *testing.T) {
+	type testStruct struct {
+		StringField string `column:"stringField,order:500"`
+		IntField    int    `column:"intField,order:200"`
+	}
+	cols, err := NewColumns[testStruct]()
+	if err != nil {
+		t.Fatalf("could not initialize: %v", err)
+	}
+	ocols := cols.GetColumnNames()
+	if len(ocols) != 2 {
+		t.Fatalf("expected two columns")
+	}
+	if ocols[0] != "intField" {
+		t.Errorf("expected first entry to be intField")
+	}
+	if ocols[1] != "stringField" {
+		t.Errorf("expected second entry to be stringField")
+	}
+}
+
+func TestGetSortedColumns(t *testing.T) {
+	type testStruct struct {
+		StringField string `column:"stringField,order:500"`
+		IntField    int    `column:"intField,order:200"`
+	}
+	cols, err := NewColumns[testStruct]()
+	if err != nil {
+		t.Fatalf("could not initialize: %v", err)
+	}
+	ocols := cols.GetOrderedColumns()
+	if len(ocols) != 2 {
+		t.Fatalf("expected two columns")
+	}
+	if ocols[0].Name != "intField" {
+		t.Errorf("expected first entry to be intField")
+	}
+	if ocols[1].Name != "stringField" {
+		t.Errorf("expected second entry to be stringField")
+	}
+}
+
+func TestGetters(t *testing.T) {
+	type embeddedStruct struct {
+		EmbeddedString string `column:"embeddedString"`
+	}
+	type testStruct struct {
+		embeddedStruct
+		StringField string `column:"stringField"`
+		IntField    int    `column:"intField"`
+	}
+	cols, err := NewColumns[testStruct]()
+	if err != nil {
+		t.Fatalf("could not initialize: %v", err)
+	}
+
+	// String tests
+	col, ok := cols.GetColumn("StRiNgFiElD")
+	if !ok {
+		t.Errorf("expected to get valid column")
+	}
+	if col.Kind() != reflect.String {
+		t.Errorf("expected Kind() to be reflect.String")
+	}
+
+	_, ok = col.Get(nil).Interface().(string)
+	if !ok {
+		t.Errorf("expected returned value to be of type string")
+	}
+	str, ok := col.Get(&testStruct{StringField: "demo"}).Interface().(string)
+	if !ok {
+		t.Errorf("expected returned value to be of type string")
+	}
+	if str != "demo" {
+		t.Errorf("expected returned value to be string 'demo'")
+	}
+	// Raw access should return the same
+	str, ok = col.GetRaw(&testStruct{StringField: "demo"}).Interface().(string)
+	if !ok {
+		t.Errorf("expected returned value to be of type string")
+	}
+	if str != "demo" {
+		t.Errorf("expected returned value to be string 'demo'")
+	}
+
+	// Int tests
+	col, ok = cols.GetColumn("InTfIeLd")
+	if !ok {
+		t.Errorf("expected to get valid column")
+	}
+
+	i, ok := col.Get(&testStruct{IntField: 5}).Interface().(int)
+	if !ok {
+		t.Errorf("expected returned value to be of type int")
+	}
+	if i != 5 {
+		t.Errorf("expected returned value to be int with value 5")
+	}
+
+	_, ok = cols.GetColumn("uNkNoWn")
+	if ok {
+		t.Errorf("expected no column")
+	}
+
+	// Embedded string tests
+	col, ok = cols.GetColumn("embeddedstring")
+	if !ok {
+		t.Errorf("expected to get valid column")
+	}
+
+	_, ok = col.Get(nil).Interface().(string)
+	if !ok {
+		t.Errorf("expected returned value to be of type string")
+	}
+	str, ok = col.Get(&testStruct{embeddedStruct: embeddedStruct{EmbeddedString: "demo"}}).Interface().(string)
+	if !ok {
+		t.Errorf("expected returned value to be of type string")
+	}
+	if str != "demo" {
+		t.Errorf("expected returned value to be string 'demo'")
+	}
+
+	// Reflection access
+	refStruct := reflect.ValueOf(&testStruct{embeddedStruct: embeddedStruct{EmbeddedString: "demo"}})
+	str, ok = col.GetRef(refStruct).Interface().(string)
+	if !ok {
+		t.Errorf("expected returned value to be of type string")
+	}
+	if str != "demo" {
+		t.Errorf("expected returned value to be string 'demo'")
+	}
+}
+
+func TestInvalidType(t *testing.T) {
+	_, err := NewColumns[int]()
+	if err == nil {
+		t.Errorf("expected error trying to initialize on non-struct")
+	}
+}
+
+func TestMustCreateHelper(t *testing.T) {
+	type testStruct struct {
+		StringField string `column:"stringField"`
+	}
+	MustCreateColumns[testStruct]()
+
+	defer func() {
+		if err := recover(); err == nil {
+			t.Errorf("expected panic")
+		}
+	}()
+	MustCreateColumns[int]()
+}
+
+func TestExtractor(t *testing.T) {
+	type testStruct struct {
+		StringField string `column:"stringField"`
+	}
+	cols, err := NewColumns[testStruct]()
+	if err != nil {
+		t.Fatalf("could not initialize: %v", err)
+	}
+
+	err = cols.SetExtractor("sTrInGfIeLd", func(t *testStruct) string {
+		return "empty"
+	})
+	if err != nil {
+		t.Errorf("could not set extractor: %v", err)
+	}
+
+	err = cols.SetExtractor("unknown", func(t *testStruct) string {
+		return "empty"
+	})
+	if err == nil {
+		t.Errorf("expected error when setting extractor on non-existing field")
+	}
+
+	err = cols.SetExtractor("sTrInGfIeLd", nil)
+	if err == nil {
+		t.Errorf("expected error when setting nil-extractor")
+	}
+}
+
+func TestVirtualColumns(t *testing.T) {
+	type testStruct struct {
+		StringField string `column:"stringField"`
+	}
+
+	cols, err := NewColumns[testStruct]()
+	if err != nil {
+		t.Fatalf("could not initialize: %v", err)
+	}
+
+	err = cols.AddColumn(Column[testStruct]{
+		Name: "vcol",
+	})
+	if err == nil {
+		t.Errorf("expected error when adding column without extractor func")
+	}
+
+	err = cols.AddColumn(Column[testStruct]{
+		Extractor: func(_ *testStruct) string {
+			return ""
+		},
+	})
+	if err == nil {
+		t.Errorf("expected error when adding column without name")
+	}
+
+	err = cols.AddColumn(Column[testStruct]{
+		Name: "stringfield",
+		Extractor: func(_ *testStruct) string {
+			return ""
+		},
+	})
+	if err == nil {
+		t.Errorf("expected error when adding column with already existing name")
+	}
+
+	err = cols.AddColumn(Column[testStruct]{
+		Name: "foobar",
+		Extractor: func(t *testStruct) string {
+			return "FooBar"
+		},
+	})
+	if err != nil {
+		t.Errorf("could not add virtual column")
+	}
+
+	col, ok := cols.GetColumn("foobar")
+	if !ok {
+		t.Errorf("expected to get the virtual column")
+	}
+	_, ok = col.Get(nil).Interface().(string)
+	if !ok {
+		t.Errorf("expected returned value to be of type string")
+	}
+	str, ok := col.Get(&testStruct{}).Interface().(string)
+	if !ok {
+		t.Errorf("expected returned value to be of type string")
+	}
+	if str != "FooBar" {
+		t.Errorf("expected returned value to be string 'FooBar'")
+	}
+
+	// Test GetRef also
+	str, ok = col.GetRef(reflect.ValueOf(&testStruct{})).Interface().(string)
+	if !ok {
+		t.Errorf("expected returned value to be of type string")
+	}
+	if str != "FooBar" {
+		t.Errorf("expected returned value to be string 'FooBar'")
+	}
+
+	// Raw access should return an empty string
+	str, ok = col.GetRaw(&testStruct{}).Interface().(string)
+	if !ok {
+		t.Errorf("expected returned value to be of type string")
+	}
+	if str != "" {
+		t.Errorf("expected empty string when calling GetRaw() on a virtual column")
+	}
+}
+
+func TestVerifyColumnNames(t *testing.T) {
+	type testStruct struct {
+		StringField string `column:"stringField"`
+		IntField    string `column:"intField"`
+	}
+
+	cols, err := NewColumns[testStruct]()
+	if err != nil {
+		t.Fatalf("could not initialize: %v", err)
+	}
+
+	valid, invalid := cols.VerifyColumnNames([]string{"-stringField", "intField", "notExistingField", "notExistingField2"})
+	if len(valid) != 2 {
+		t.Errorf("expected VerifyColumnNames to return 2 valid entries")
+	}
+	if len(invalid) != 2 {
+		t.Errorf("expected VerifyColumnNames to return 2 invalid entries")
+	}
+}

--- a/pkg/columns/doc.go
+++ b/pkg/columns/doc.go
@@ -1,0 +1,93 @@
+// Copyright 2022 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*
+Package columns is a library that helps to carry data structs in a more generic way using a combination of reflection and
+generics. It can work with any type of struct (and arrays of those), providing useful functions like sorting, grouping,
+filtering and printing. How columns are handled can be configured using tags along the struct definition. This keeps
+metadata and type data in the same place, avoiding extra and/or duplicated code and thereby the likelihood of typos/errors.
+
+Columns just has to be initialized by passing a prototype of the struct. Afterwards you can use all helper functions
+(sorting, grouping, etc.) on it.
+
+# How does it work?
+
+You simply add a "column" tag to members of the struct you want to handle, like so:
+
+	type Event struct {
+		Node  string `json:"node" column:"node,width:12,ellipsis:middle"`
+		PID   int    `json:"pid" column:"PID,hide,align:right,width:6"`
+		Comm  string `json:"comm" column:"Comm"`
+		Name  string `json:"name" column:"Name"`
+		Dummy string `json:"dummy"`
+		Time  int64  `json:"time" column:"Time,align:right,width:24,group:sum"`
+	}
+
+Let's briefly analyze:
+
+  - All fields that have a column tag will be considered, that means the `Dummy` field will not be considered.
+  - Each column tag starts with the name of the field. This name is case-insensitive (and an error will be thrown if
+    multiple fields share the same name.)
+  - Additional information on the fields are added as a comma separated list after the name of the column; key and value
+    (if applicable) are separated by a colon (see `attributes` below)
+
+You initialize `Columns` by passing it the type of the struct you want to use, like so:
+
+	cols, err := columns.NewColumns[Event]()
+
+The parameter could be used for specific options, passing nil will use the defaults.
+
+# Attributes
+
+	| Attribute | Value(s)               | Description                                                                                                          |
+	|-----------|------------------------|----------------------------------------------------------------------------------------------------------------------|
+	| align     | left,right             | defines the alignment of the column (whitespace before or after the value)                                           |
+	| ellipsis  | none,left,right,middle | defines how situations of content exceeding the given space should be handled, eg: where to place the ellipsis ("…") |
+	| fixed     | none                   | defines that this column will have a fixed width, even when auto-scaling is enabled                                  |
+	| group     | sum                    | defines what should happen with the field whenever entries are grouped (see grouping)                                |
+	| hide      | none                   | specifies that this column is not to be considered by default (see custom columns)                                   |
+	| precision | int                    | specifies the precision of floats (number of decimals)                                                               |
+	| width     | int                    | defines the space allocated for the column                                                                           |
+
+# Virtual Columns or Custom Extractors
+
+Sometimes it's necessary to add columns on the fly or have special treatment when extracting values. This can be
+achieved by specifying a virtual column or custom extractors.
+
+Say that for example you have a struct with a (by default) not printable member `Foo` that you still want to output.
+
+	type Event struct {
+		Node  string `json:"node" column:"node,width:12,ellipsis:middle"`
+		Foo   []byte
+	}
+
+You can do that by adding a virtual column:
+
+	cols.AddColumn(columns.ColumnInfo[Event]{
+		Name:  "foo",
+		Width: 14,
+		Extractor: func(e *Event) string {
+			return string(e.Foo)
+		},
+	})
+
+This will convert the []byte to a string before printing it.
+
+You can also just override the default extractor like so:
+
+	cols.SetExtractor("node", func(a *Event) string {
+		return "Foobar"
+	})
+*/
+package columns

--- a/pkg/columns/ellipsis/doc.go
+++ b/pkg/columns/ellipsis/doc.go
@@ -1,0 +1,20 @@
+// Copyright 2022 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*
+Package ellipsis helps to truncate text at a specific width and adding an optional ellipsis ("…") to indicate that
+the text has been truncated. Use the different [EllipsisType] to define how and where the truncation should take place, if
+necessary.
+*/
+package ellipsis

--- a/pkg/columns/ellipsis/ellipsis.go
+++ b/pkg/columns/ellipsis/ellipsis.go
@@ -1,0 +1,79 @@
+// Copyright 2022 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ellipsis
+
+type EllipsisType int
+
+const (
+	None   EllipsisType = iota // None simply cuts the text if it is too long
+	End                        // End cuts an overflowing string one character before reaching the maximum width and adds an ellipsis ("…").
+	Start                      // Start lets the overflowing string start with an ellipsis ("…") followed by the last X characters, where X is the maximum length - 1.
+	Middle                     // Middle uses the first and last characters of an overflowing string, merging them in the middle with an ellipsis ("…").
+)
+
+const ellipsisRune = rune('…')
+
+func (et EllipsisType) String() string {
+	switch et {
+	default:
+		fallthrough
+	case None:
+		return "None"
+	case End:
+		return "End"
+	case Start:
+		return "Start"
+	case Middle:
+		return "Middle"
+	}
+}
+
+func ShortenString(str string, maxLength int, ellipsisType EllipsisType) string {
+	return string(Shorten([]rune(str), maxLength, ellipsisType))
+}
+
+func Shorten(rs []rune, maxLength int, ellipsisType EllipsisType) []rune {
+	if maxLength <= 0 {
+		return []rune{}
+	}
+
+	slen := len(rs)
+
+	if slen <= maxLength {
+		return rs
+	}
+
+	if maxLength <= 1 && ellipsisType != None {
+		return []rune{ellipsisRune}
+	}
+
+	switch ellipsisType {
+	default:
+		fallthrough
+	case None:
+		return rs[:maxLength]
+	case Start:
+		return append([]rune{ellipsisRune}, rs[slen-maxLength+1:]...)
+	case End:
+		return append(rs[:maxLength-1], ellipsisRune)
+	case Middle:
+		mid := maxLength / 2
+		end := mid
+		if maxLength%2 == 0 {
+			end -= 1
+		}
+		return append(append(rs[:mid], ellipsisRune), rs[slen-end:]...)
+	}
+}

--- a/pkg/columns/ellipsis/ellipsis_test.go
+++ b/pkg/columns/ellipsis/ellipsis_test.go
@@ -1,0 +1,206 @@
+// Copyright 2022 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ellipsis
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestEllipsis(t *testing.T) {
+	type ellipsisTest struct {
+		Input     string
+		MaxLength int
+		Type      EllipsisType
+		Result    string
+	}
+
+	ellipsisTests := []ellipsisTest{
+		{
+			Input:     "Demo",
+			MaxLength: 8,
+			Type:      None,
+			Result:    "Demo",
+		},
+		{
+			Input:     "D",
+			MaxLength: 1,
+			Type:      None,
+			Result:    "D",
+		},
+		{
+			Input:     "Demo1234",
+			MaxLength: 4,
+			Type:      None,
+			Result:    "Demo",
+		},
+		{
+			Input:     "Demo1234",
+			MaxLength: 4,
+			Type:      End,
+			Result:    "Dem…",
+		},
+		{
+			Input:     "Demo1234",
+			MaxLength: 4,
+			Type:      Start,
+			Result:    "…234",
+		},
+		{
+			Input:     "Demo1234",
+			MaxLength: 4,
+			Type:      Middle,
+			Result:    "De…4",
+		},
+		{
+			Input:     "Demo1234",
+			MaxLength: 5,
+			Type:      Middle,
+			Result:    "De…34",
+		},
+		{
+			Input:     "Demo🖐🖐🖐🖐",
+			MaxLength: 8,
+			Type:      None,
+			Result:    "Demo🖐🖐🖐🖐",
+		},
+		{
+			Input:     "A",
+			MaxLength: 1,
+			Type:      None,
+			Result:    "A",
+		},
+		{
+			Input:     "Demo",
+			MaxLength: 0,
+			Type:      None,
+			Result:    "",
+		},
+		{
+			Input:     "Demo",
+			MaxLength: 1,
+			Type:      None,
+			Result:    "D",
+		},
+		{
+			Input:     "Demo",
+			MaxLength: 1,
+			Type:      Start,
+			Result:    "…",
+		},
+		{
+			Input:     "Demo",
+			MaxLength: 1,
+			Type:      End,
+			Result:    "…",
+		},
+		{
+			Input:     "Demo",
+			MaxLength: 1,
+			Type:      Middle,
+			Result:    "…",
+		},
+		{
+			Input:     "Exact",
+			MaxLength: 5,
+			Type:      None,
+			Result:    "Exact",
+		},
+		{
+			Input:     "Exact",
+			MaxLength: 5,
+			Type:      Start,
+			Result:    "Exact",
+		},
+		{
+			Input:     "Exact",
+			MaxLength: 5,
+			Type:      End,
+			Result:    "Exact",
+		},
+		{
+			Input:     "Exact",
+			MaxLength: 5,
+			Type:      Middle,
+			Result:    "Exact",
+		},
+		{
+			Input:     "Demo",
+			MaxLength: 3,
+			Type:      -1,
+			Result:    "Dem",
+		},
+		{
+			Input:     "",
+			MaxLength: 5,
+			Type:      None,
+			Result:    "",
+		},
+		{
+			Input:     "",
+			MaxLength: 5,
+			Type:      Start,
+			Result:    "",
+		},
+		{
+			Input:     "",
+			MaxLength: 5,
+			Type:      End,
+			Result:    "",
+		},
+		{
+			Input:     "",
+			MaxLength: 5,
+			Type:      Middle,
+			Result:    "",
+		},
+		{
+			Input:     "Demo",
+			MaxLength: 4,
+			Type:      None,
+			Result:    "Demo",
+		},
+	}
+
+	for _, test := range ellipsisTests {
+		t.Run(fmt.Sprintf("%s_%d@%s", test.Input, test.MaxLength, test.Type.String()), func(t *testing.T) {
+			if res := Shorten([]rune(test.Input), test.MaxLength, test.Type); string(res) != test.Result {
+				t.Errorf("%q (%d): got %q, expected %q", test.Input, test.MaxLength, res, test.Result)
+			}
+		})
+	}
+}
+
+func FuzzEllipsis(f *testing.F) {
+	f.Add("inputString", 5)
+	f.Fuzz(func(t *testing.T, inputString string, maxLength int) {
+		correctedLength := maxLength
+		if maxLength < 0 {
+			correctedLength = 0
+		}
+		if out := Shorten([]rune(inputString), maxLength, None); len(out) > correctedLength {
+			t.Errorf("None of %q (%d): wrong output %q of length %d", inputString, maxLength, out, len(out))
+		}
+		if out := Shorten([]rune(inputString), maxLength, End); len(out) > correctedLength {
+			t.Errorf("End of %q (%d): wrong output %q of length %d", inputString, maxLength, out, len(out))
+		}
+		if out := Shorten([]rune(inputString), maxLength, Start); len(out) > correctedLength {
+			t.Errorf("Start of %q (%d): wrong output %q of length %d", inputString, maxLength, out, len(out))
+		}
+		if out := Shorten([]rune(inputString), maxLength, Middle); len(out) > correctedLength {
+			t.Errorf("Middle of %q (%d): wrong output %q of length %d", inputString, maxLength, out, len(out))
+		}
+	})
+}

--- a/pkg/columns/ellipsis/examples_test.go
+++ b/pkg/columns/ellipsis/examples_test.go
@@ -1,0 +1,33 @@
+// Copyright 2022 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ellipsis_test
+
+import (
+	"fmt"
+
+	"github.com/kinvolk/inspektor-gadget/pkg/columns/ellipsis"
+)
+
+func ExampleShortenString() {
+	fmt.Println(ellipsis.ShortenString("Foobar123", 8, ellipsis.None))
+	fmt.Println(ellipsis.ShortenString("Foobar123", 8, ellipsis.Start))
+	fmt.Println(ellipsis.ShortenString("Foobar123", 8, ellipsis.End))
+	fmt.Println(ellipsis.ShortenString("Foobar123", 8, ellipsis.Middle))
+	// Output:
+	// Foobar12
+	// …obar123
+	// Foobar1…
+	// Foob…123
+}

--- a/pkg/columns/example_test.go
+++ b/pkg/columns/example_test.go
@@ -1,0 +1,105 @@
+// Copyright 2022 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package columns_test
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+
+	"github.com/kinvolk/inspektor-gadget/pkg/columns"
+	"github.com/kinvolk/inspektor-gadget/pkg/columns/filter"
+	"github.com/kinvolk/inspektor-gadget/pkg/columns/formatter/textcolumns"
+	"github.com/kinvolk/inspektor-gadget/pkg/columns/sort"
+)
+
+type Employee struct {
+	Name       string `column:"name" columnTags:"sensitive"`
+	Age        int    `column:"age" columnTags:"sensitive"`
+	Department string `column:"department"`
+}
+
+var Employees = []*Employee{
+	{"Alice", 32, "Security"},
+	{"Bob", 26, "Security"},
+	{"Eve", 99, "Security also"},
+}
+
+// Defining the column helper here lets the program crash on start if there are
+// errors in the syntax
+var employeeColumns = columns.MustCreateColumns[Employee]()
+
+func Example() {
+	out := bytes.NewBuffer(nil)
+
+	// Get columnMap
+	cmap := employeeColumns.GetColumnMap()
+
+	// Get a new formatter
+	formatter := textcolumns.NewFormatter(cmap, textcolumns.WithRowDivider(textcolumns.DividerDash))
+
+	// Output the whole table
+	formatter.WriteTable(out, Employees)
+
+	out.WriteString("\n")
+
+	// Reverse the order by name and output again
+	sort.SortEntries[Employee](cmap, Employees, []string{"-name"})
+	formatter.WriteTable(out, Employees)
+
+	out.WriteString("\n")
+
+	// Now only get security personell
+	securityOnly, err := filter.FilterEntries[Employee](cmap, Employees, []string{"department:Security"})
+	if err != nil {
+		panic(err)
+	}
+	formatter.WriteTable(out, securityOnly)
+
+	out.WriteString("\n")
+
+	// Confidentiality!
+	formatter = textcolumns.NewFormatter(employeeColumns.GetColumnMap(columns.WithoutTag("sensitive")), textcolumns.WithRowDivider(textcolumns.DividerDash))
+	formatter.WriteTable(out, securityOnly)
+
+	// Split output by newline and remove whitespace at the end of each line to match test output below
+	outLines := strings.Split(out.String(), "\n")
+	for _, line := range outLines {
+		fmt.Println(strings.TrimRight(line, " "))
+	}
+
+	// Output:
+	// NAME             AGE              DEPARTMENT
+	// ——————————————————————————————————————————————————
+	// Alice            32               Security
+	// Bob              26               Security
+	// Eve              99               Security also
+	//
+	// NAME             AGE              DEPARTMENT
+	// ——————————————————————————————————————————————————
+	// Eve              99               Security also
+	// Bob              26               Security
+	// Alice            32               Security
+	//
+	// NAME             AGE              DEPARTMENT
+	// ——————————————————————————————————————————————————
+	// Bob              26               Security
+	// Alice            32               Security
+	//
+	// DEPARTMENT
+	// ————————————————
+	// Security
+	// Security
+}

--- a/pkg/columns/examples/gadget/gadget.go
+++ b/pkg/columns/examples/gadget/gadget.go
@@ -1,0 +1,107 @@
+// Copyright 2022 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/kinvolk/inspektor-gadget/pkg/columns"
+	"github.com/kinvolk/inspektor-gadget/pkg/columns/formatter/textcolumns"
+)
+
+type Kubernetes struct {
+	Node      string `column:"node" columnTags:"kubernetes"`
+	Container string `column:"container" columnTags:"kubernetes"`
+	Pod       string `column:"pod" columnTags:"kubernetes"`
+}
+
+type Runtime struct {
+	Runtime string `column:"runtime" columnTags:"runtime"`
+}
+
+type GadgetData struct {
+	Kubernetes
+	Runtime
+	GadgetData string `column:"gadgetData"`
+}
+
+var GadgetOutput = []*GadgetData{
+	{
+		Kubernetes: Kubernetes{
+			Node:      "Node 1",
+			Container: "Container 1",
+			Pod:       "Pod 1",
+		},
+		Runtime:    Runtime{Runtime: "Runtime 1"},
+		GadgetData: "Data 1",
+	},
+	{
+		Kubernetes: Kubernetes{
+			Node:      "Node 2",
+			Container: "Container 2",
+			Pod:       "Pod 2",
+		},
+		Runtime:    Runtime{Runtime: "Runtime 2"},
+		GadgetData: "Data 2",
+	},
+	{
+		Kubernetes: Kubernetes{
+			Node:      "Node 3",
+			Container: "Container 3",
+			Pod:       "Pod 3",
+		},
+		Runtime:    Runtime{Runtime: "Runtime 3"},
+		GadgetData: "Data 3",
+	},
+}
+
+// Defining the column helper here lets the program crash on start if there are
+// errors in the syntax
+var gadgetColumns = columns.MustCreateColumns[GadgetData]()
+
+func main() {
+	// Get columnMap
+	cmap := gadgetColumns.GetColumnMap()
+
+	// Get a new formatter and output all data
+	formatter := textcolumns.NewFormatter(cmap, textcolumns.WithAutoScale(false))
+	formatter.WriteTable(os.Stdout, GadgetOutput)
+
+	/*
+		NODE             CONTAINER        POD              RUNTIME          GADGETDATA
+		————————————————————————————————————————————————————————————————————————————————————
+		Node 1           Container 1      Pod 1            Runtime 1        Data 1
+		Node 2           Container 2      Pod 2            Runtime 2        Data 2
+		Node 3           Container 3      Pod 3            Runtime 3        Data 3
+	*/
+
+	fmt.Println()
+
+	// Leave out kubernetes info for this one, but include gadget data (not-embedded struct) and runtime information
+	formatter = textcolumns.NewFormatter(
+		gadgetColumns.GetColumnMap(columns.Or(columns.WithEmbedded(false), columns.WithTag("runtime"))),
+		textcolumns.WithAutoScale(false),
+	)
+	formatter.WriteTable(os.Stdout, GadgetOutput)
+
+	/*
+		RUNTIME          GADGETDATA
+		—————————————————————————————————
+		Runtime 1        Data 1
+		Runtime 2        Data 2
+		Runtime 3        Data 3
+	*/
+}

--- a/pkg/columns/filter.go
+++ b/pkg/columns/filter.go
@@ -1,0 +1,113 @@
+// Copyright 2022 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package columns
+
+import "strings"
+
+type ColumnFilter func(matcher ColumnMatcher) bool
+
+// Or combines several ColumnFilter and matches if one filter matches
+func Or(filters ...ColumnFilter) ColumnFilter {
+	return func(matcher ColumnMatcher) bool {
+		for _, f := range filters {
+			if f(matcher) {
+				return true
+			}
+		}
+		return false
+	}
+}
+
+// And combines several ColumnFilter and matches if all filters match
+func And(filters ...ColumnFilter) ColumnFilter {
+	return func(matcher ColumnMatcher) bool {
+		for _, f := range filters {
+			if !f(matcher) {
+				return false
+			}
+		}
+		return true
+	}
+}
+
+// WithEmbedded checks whether a column matches the embedded criteria
+func WithEmbedded(embedded bool) ColumnFilter {
+	return func(matcher ColumnMatcher) bool {
+		if matcher.IsEmbedded() == embedded {
+			return true
+		}
+		return false
+	}
+}
+
+// WithTags makes sure that all returned columns contain all the given tags
+func WithTags(tags []string) ColumnFilter {
+	for i := range tags {
+		tags[i] = strings.ToLower(tags[i])
+	}
+	numTags := len(tags)
+	return func(matcher ColumnMatcher) bool {
+		marked := make([]bool, numTags)
+		count := 0
+		for i, tag := range tags {
+			if !marked[i] && matcher.HasTag(tag) {
+				count++
+				marked[i] = true
+				if count == numTags {
+					return true
+				}
+			}
+		}
+		return false
+	}
+}
+
+// WithoutTags makes sure that all returned columns contain none of the given tags
+func WithoutTags(tags []string) ColumnFilter {
+	for i := range tags {
+		tags[i] = strings.ToLower(tags[i])
+	}
+	return func(matcher ColumnMatcher) bool {
+		for _, tag := range tags {
+			if matcher.HasTag(tag) {
+				return false
+			}
+		}
+		return true
+	}
+}
+
+// WithTag makes sure that all returned columns contain all the given tag
+func WithTag(tag string) ColumnFilter {
+	tag = strings.ToLower(tag)
+	return func(matcher ColumnMatcher) bool {
+		return matcher.HasTag(tag)
+	}
+}
+
+// WithoutTag makes sure that all returned columns contain none of the given tag
+func WithoutTag(tag string) ColumnFilter {
+	tag = strings.ToLower(tag)
+	return func(matcher ColumnMatcher) bool {
+		return !matcher.HasTag(tag)
+	}
+}
+
+// WithNoTags makes sure that all returned columns contain no tags
+func WithNoTags() ColumnFilter {
+	return func(matcher ColumnMatcher) bool {
+		return matcher.HasNoTags()
+	}
+}

--- a/pkg/columns/filter/doc.go
+++ b/pkg/columns/filter/doc.go
@@ -1,0 +1,54 @@
+// Copyright 2022 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*
+Package filter helps filtering an array of structs that were analyzed by the columns library.
+
+If you have an array of a struct you have a `Column` instance for, you can simply filter it by using a filter string
+like this:
+
+	filter.FilterEntries(columnMap, events, []string{"pid:55"})
+
+This will return an array only containing entries that have the pid column set to 55.
+
+A filter string always starts with the column name, followed by a colon and then the actual filter rule.
+
+If the filter rule starts with an exclamation mark ("!"), the filter will be negated and return only entries that don't
+match the rule. This indicator has always be the first character of the filter rule.
+
+	filter.FilterEntries(columnMap, events, "name:!Demo") // matches entries with column "name" not being "Demo"
+
+A tilde ("~") at the start of a filter rule indicates a regular expression. The actual regular expression has to be
+written using the re2 syntax used by Go (see [https://github.com/google/re2/wiki/Syntax]).
+
+Additional rule options for integers, floats and strings are `>`, `>=`, `<` and `<=`, e.g.:
+
+	filter.FilterEntries(columnMap, events, []string{"pid:>=55"})
+
+# Optimizing / Streaming
+
+If you have to filter a stream of incoming events, you can use
+
+	myFilter := filter.GetFilterFromString(columnMap, filter)
+
+to get a filter with a .Match(entry) function that you can use to match against entries.
+
+# Filter examples
+
+	"columnName:value" - matches, if the content of columnName equals exactly value
+	"columnName:!value" - matches, if the content of columnName does not equal exactly value
+	"columnName:>=value" - matches, if the content of columnName is greater or equal to the value
+	"columnName:~value" - matches, if the content of columnName matches the regular expression 'value'
+*/
+package filter

--- a/pkg/columns/filter/examples_test.go
+++ b/pkg/columns/filter/examples_test.go
@@ -1,0 +1,89 @@
+// Copyright 2022 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filter_test
+
+import (
+	"fmt"
+
+	"github.com/kinvolk/inspektor-gadget/pkg/columns"
+	"github.com/kinvolk/inspektor-gadget/pkg/columns/filter"
+)
+
+func ExampleFilterEntries() {
+	type Employee struct {
+		Name       string `column:"name" columnTags:"sensitive"`
+		Age        int    `column:"age" columnTags:"sensitive"`
+		Department string `column:"department"`
+	}
+
+	Employees := []*Employee{
+		{"Alice", 32, "Security"},
+		{"Bob", 26, "Security"},
+		{"Eve", 99, "Security also"},
+	}
+
+	employeeColumns := columns.MustCreateColumns[Employee]()
+
+	// Get columnMap
+	cmap := employeeColumns.GetColumnMap()
+
+	// Filter entries, searching for people younger than 50 and an "e" in the name (case insensitive)
+	result, err := filter.FilterEntries(cmap, Employees, []string{"age:<50", "name:~(?i)e"})
+	if err != nil {
+		panic(err)
+	}
+
+	for _, e := range result {
+		fmt.Println(*e)
+	}
+
+	// Output:
+	// {Alice 32 Security}
+}
+
+func ExampleGetFilterFromString() {
+	type Employee struct {
+		Name       string `column:"name" columnTags:"sensitive"`
+		Age        int    `column:"age" columnTags:"sensitive"`
+		Department string `column:"department"`
+	}
+
+	Employees := []*Employee{
+		{"Alice", 32, "Security"},
+		{"Bob", 26, "Security"},
+		{"Eve", 99, "Security also"},
+	}
+
+	employeeColumns := columns.MustCreateColumns[Employee]()
+
+	// Get columnMap
+	cmap := employeeColumns.GetColumnMap()
+
+	// Create a new filter that matches employees from the "Security" department
+	employeeFilter, err := filter.GetFilterFromString(cmap, "department:Security")
+	if err != nil {
+		panic(err)
+	}
+
+	for _, e := range Employees {
+		if employeeFilter.Match(e) {
+			fmt.Println(*e)
+		}
+	}
+
+	// Output:
+	// {Alice 32 Security}
+	// {Bob 26 Security}
+}

--- a/pkg/columns/filter/filter.go
+++ b/pkg/columns/filter/filter.go
@@ -1,0 +1,262 @@
+// Copyright 2022 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filter
+
+import (
+	"fmt"
+	"reflect"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/kinvolk/inspektor-gadget/pkg/columns"
+
+	"golang.org/x/exp/constraints"
+)
+
+type comparisonType int
+
+const (
+	comparisonTypeMatch comparisonType = iota
+	comparisonTypeRegex
+	comparisonTypeLt
+	comparisonTypeLte
+	comparisonTypeGt
+	comparisonTypeGte
+)
+
+type filterSpec[T any] struct {
+	value          string
+	refValue       interface{}
+	comparisonType comparisonType
+	negate         bool
+	regex          *regexp.Regexp
+	column         *columns.Column[T]
+	cols           columns.ColumnMap[T]
+}
+
+// GetFilterFromString prepares a filter that has a Match() function that can be called on
+// entries of type *T
+func GetFilterFromString[T any](cols columns.ColumnMap[T], filter string) (*filterSpec[T], error) {
+	filterInfo := strings.SplitN(filter, ":", 2)
+	if len(filterInfo) == 1 {
+		// special case: only a column means we match with an empty string
+		filterInfo = append(filterInfo, "")
+	}
+
+	// Get column to group
+	column, ok := cols.GetColumn(filterInfo[0])
+	if !ok {
+		return nil, fmt.Errorf("could not apply filter: column %q not found", filterInfo[0])
+	}
+
+	fs := &filterSpec[T]{
+		cols:   cols,
+		column: column,
+	}
+
+	filterRule := filterInfo[1]
+
+	fs.value = filterRule
+
+	if strings.HasPrefix(filterRule, "!") {
+		fs.negate = true
+		filterRule = filterRule[1:]
+		fs.value = filterRule
+	}
+
+	if strings.HasPrefix(filterRule, "~") {
+		fs.comparisonType = comparisonTypeRegex
+		filterRule = strings.TrimPrefix(filterRule, "~")
+		fs.value = filterRule
+		re, err := regexp.Compile(fs.value)
+		if err != nil {
+			return nil, fmt.Errorf("could not compile regular expression %q: %w", fs.value, err)
+		}
+		fs.regex = re
+	} else if strings.HasPrefix(filterRule, ">=") {
+		fs.comparisonType = comparisonTypeGte
+		filterRule = strings.TrimPrefix(filterRule, ">=")
+		fs.value = filterRule
+	} else if strings.HasPrefix(filterRule, ">") {
+		fs.comparisonType = comparisonTypeGt
+		filterRule = strings.TrimPrefix(filterRule, ">")
+		fs.value = filterRule
+	} else if strings.HasPrefix(filterRule, "<=") {
+		fs.comparisonType = comparisonTypeLte
+		filterRule = strings.TrimPrefix(filterRule, "<=")
+		fs.value = filterRule
+	} else if strings.HasPrefix(filterRule, "<") {
+		fs.comparisonType = comparisonTypeLt
+		filterRule = strings.TrimPrefix(filterRule, "<")
+		fs.value = filterRule
+	}
+
+	if fs.comparisonType == comparisonTypeRegex && column.Kind() != reflect.String {
+		return nil, fmt.Errorf("tried to apply regular expression on non-string column %q", fs.column.Name)
+	}
+
+	// We precalculate value to be of a comparable type to column.kind when comparisonType is comparisonTypeMatch
+	var value reflect.Value
+	switch fs.comparisonType {
+	case comparisonTypeMatch,
+		comparisonTypeGt,
+		comparisonTypeGte,
+		comparisonTypeLt,
+		comparisonTypeLte:
+		switch fs.column.Kind() {
+		case reflect.Int,
+			reflect.Int8,
+			reflect.Int16,
+			reflect.Int32,
+			reflect.Int64:
+			number, err := strconv.ParseInt(fs.value, 10, 64)
+			if err != nil {
+				return nil, fmt.Errorf("tried to compare %q to int column %q", fs.value, column.Name)
+			}
+			value = reflect.ValueOf(number).Convert(column.Type())
+		case reflect.Uint,
+			reflect.Uint8,
+			reflect.Uint16,
+			reflect.Uint32,
+			reflect.Uint64:
+			number, err := strconv.ParseUint(fs.value, 10, 64)
+			if err != nil {
+				return nil, fmt.Errorf("tried to compare %q to uint column %q", fs.value, column.Name)
+			}
+			value = reflect.ValueOf(number).Convert(column.Type())
+		case reflect.Float32,
+			reflect.Float64:
+			number, err := strconv.ParseFloat(fs.value, 64)
+			if err != nil {
+				return nil, fmt.Errorf("tried to compare %q to float column %q", fs.value, column.Name)
+			}
+			value = reflect.ValueOf(number).Convert(column.Type())
+		case reflect.String:
+			value = reflect.ValueOf(fs.value)
+		default:
+			return nil, fmt.Errorf("tried to match %q on unsupported column %q", fs.value, column.Name)
+		}
+	}
+
+	if value.IsValid() {
+		fs.refValue = value.Interface()
+	}
+
+	return fs, nil
+}
+
+func compare[T constraints.Ordered](a, b T, ct comparisonType, negate bool) bool {
+	switch ct {
+	case comparisonTypeMatch:
+		return a == b != negate
+	case comparisonTypeGt:
+		return a > b != negate
+	case comparisonTypeGte:
+		return a >= b != negate
+	case comparisonTypeLt:
+		return a < b != negate
+	case comparisonTypeLte:
+		return a <= b != negate
+	default:
+		return false
+	}
+}
+
+func (fs *filterSpec[T]) Match(entry *T) bool {
+	if entry == nil {
+		return fs.negate
+	}
+
+	field := fs.column.GetRef(reflect.ValueOf(entry))
+
+	matches := false
+	switch fs.comparisonType {
+	case
+		comparisonTypeMatch,
+		comparisonTypeGt,
+		comparisonTypeGte,
+		comparisonTypeLt,
+		comparisonTypeLte:
+		switch fs.column.Kind() {
+		case reflect.Int:
+			return compare(field.Interface().(int), fs.refValue.(int), fs.comparisonType, fs.negate)
+		case reflect.Int8:
+			return compare(field.Interface().(int8), fs.refValue.(int8), fs.comparisonType, fs.negate)
+		case reflect.Int16:
+			return compare(field.Interface().(int16), fs.refValue.(int16), fs.comparisonType, fs.negate)
+		case reflect.Int32:
+			return compare(field.Interface().(int32), fs.refValue.(int32), fs.comparisonType, fs.negate)
+		case reflect.Int64:
+			return compare(field.Interface().(int64), fs.refValue.(int64), fs.comparisonType, fs.negate)
+		case reflect.Uint:
+			return compare(field.Interface().(uint), fs.refValue.(uint), fs.comparisonType, fs.negate)
+		case reflect.Uint8:
+			return compare(field.Interface().(uint8), fs.refValue.(uint8), fs.comparisonType, fs.negate)
+		case reflect.Uint16:
+			return compare(field.Interface().(uint16), fs.refValue.(uint16), fs.comparisonType, fs.negate)
+		case reflect.Uint32:
+			return compare(field.Interface().(uint32), fs.refValue.(uint32), fs.comparisonType, fs.negate)
+		case reflect.Uint64:
+			return compare(field.Interface().(uint64), fs.refValue.(uint64), fs.comparisonType, fs.negate)
+		case reflect.Float32:
+			return compare(field.Interface().(float32), fs.refValue.(float32), fs.comparisonType, fs.negate)
+		case reflect.Float64:
+			return compare(field.Interface().(float64), fs.refValue.(float64), fs.comparisonType, fs.negate)
+		case reflect.String:
+			return compare(field.Interface().(string), fs.refValue.(string), fs.comparisonType, fs.negate)
+		}
+	case comparisonTypeRegex:
+		if fs.regex.MatchString(field.String()) {
+			matches = true
+		}
+	}
+
+	return matches != fs.negate
+}
+
+// FilterEntries will filter entries according to the given filters.
+func FilterEntries[T any](cols columns.ColumnMap[T], entries []*T, filters []string) ([]*T, error) {
+	if entries == nil {
+		return nil, nil
+	}
+
+	var outEntries []*T
+
+	for _, filter := range filters {
+		fs, err := GetFilterFromString(cols, filter)
+		if err != nil {
+			return nil, fmt.Errorf("could not apply filter %q: %w", filter, err)
+		}
+
+		outEntries = make([]*T, 0)
+
+		// Iterate over entries and push them to their corresponding map key
+		for _, entry := range entries {
+			if entry == nil {
+				// Skip nil entries
+				continue
+			}
+
+			if fs.Match(entry) {
+				outEntries = append(outEntries, entry)
+			}
+		}
+
+		entries = outEntries
+	}
+
+	return outEntries, nil
+}

--- a/pkg/columns/filter/filter_test.go
+++ b/pkg/columns/filter/filter_test.go
@@ -1,0 +1,286 @@
+// Copyright 2022 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filter
+
+import (
+	"testing"
+
+	"github.com/kinvolk/inspektor-gadget/pkg/columns"
+)
+
+func TestFilters(t *testing.T) {
+	type testData struct {
+		Int         int      `column:"int,align:right,width:6"`
+		Int8        int8     `column:"int8,align:right,width:6"`
+		Int16       int16    `column:"int16,align:right,width:6"`
+		Int32       int32    `column:"int32,align:right,width:6"`
+		Int64       int64    `column:"int64,align:right,width:6"`
+		Uint        uint     `column:"uint,align:right,width:6"`
+		Uint8       uint8    `column:"uint8,align:right,width:6"`
+		Uint16      uint16   `column:"uint16,align:right,width:6"`
+		Uint32      uint32   `column:"uint32,align:right,width:6"`
+		Uint64      uint64   `column:"uint64,align:right,width:6"`
+		String      string   `column:"string"`
+		Dummy       string   // This a dummy field that we can expose using a virtual field
+		Time        int64    `column:"time,align:right,width:24,group:sum"`
+		Float32     float32  `column:"float32"`
+		Float64     float64  `column:"float64"`
+		Unsupported struct{} `column:"unsupported"`
+	}
+
+	type filterTest struct {
+		filterString  string
+		expectedCount int
+		expectError   bool
+		description   string
+	}
+
+	filterEntries := []*testData{
+		{
+			String:  "",
+			Int:     7,
+			Int8:    7,
+			Int16:   7,
+			Int32:   7,
+			Int64:   7,
+			Uint:    7,
+			Uint8:   7,
+			Uint16:  7,
+			Uint32:  7,
+			Uint64:  7,
+			Float32: 7,
+			Float64: 7,
+		},
+		{
+			String:  "Demo 123",
+			Int:     1,
+			Int8:    1,
+			Int16:   1,
+			Int32:   1,
+			Int64:   1,
+			Uint:    1,
+			Uint8:   1,
+			Uint16:  1,
+			Uint32:  1,
+			Uint64:  1,
+			Float32: 1,
+			Float64: 1,
+		},
+		{
+			String:  "Demo 234",
+			Int:     2,
+			Int8:    2,
+			Int16:   2,
+			Int32:   2,
+			Int64:   2,
+			Uint:    2,
+			Uint8:   2,
+			Uint16:  2,
+			Uint32:  2,
+			Uint64:  2,
+			Float32: 2,
+			Float64: 2,
+		},
+		{
+			String:  "Demo 234",
+			Int:     3,
+			Int8:    3,
+			Int16:   3,
+			Int32:   3,
+			Int64:   3,
+			Uint:    3,
+			Uint8:   3,
+			Uint16:  3,
+			Uint32:  3,
+			Uint64:  3,
+			Float32: 3,
+			Float64: 3,
+		},
+		{
+			String:  "Foobar",
+			Int:     2,
+			Int8:    2,
+			Int16:   2,
+			Int32:   2,
+			Int64:   2,
+			Uint:    2,
+			Uint8:   2,
+			Uint16:  2,
+			Uint32:  2,
+			Uint64:  2,
+			Float32: 2,
+			Float64: 2,
+		},
+		nil,
+	}
+
+	filterTests := []filterTest{
+		{filterString: "", expectedCount: 0, expectError: true, description: "empty filter, error"},
+		{filterString: "string", expectedCount: 1, expectError: false, description: "empty value in column string"},
+		{filterString: "string:", expectedCount: 1, expectError: false, description: "same"},
+		{filterString: "string:Demo 123", expectedCount: 1, expectError: false, description: "exact match on string"},
+		{filterString: "string:>Demo", expectedCount: 4, expectError: false, description: "gt match on string"},
+		{filterString: "string:>=Demo", expectedCount: 4, expectError: false, description: "gte match on string"},
+		{filterString: "string:<Demo", expectedCount: 1, expectError: false, description: "lt match on string"},
+		{filterString: "string:<=Demo", expectedCount: 1, expectError: false, description: "lte match on string"},
+		{filterString: "string:demo 123", expectedCount: 0, expectError: false, description: "lowercase, not found"},
+		{filterString: "string:~Demo", expectedCount: 3, expectError: false, description: "regular expression search"},
+		{filterString: "string:~demo", expectedCount: 0, expectError: false, description: "case-sensitive regular expression search"},
+		{filterString: "string:~(?i)demo", expectedCount: 3, expectError: false, description: "case-insensitive regular expression search"},
+		{filterString: "string:!~(?i)demo", expectedCount: 2, expectError: false, description: "negated case-insensitive regular expression search"},
+		{filterString: "string:~(?i)??//{demo", expectedCount: 0, expectError: true, description: "garbage regular expression search"},
+
+		{filterString: "int:", expectedCount: 0, expectError: true, description: "match on int, empty string"},
+		{filterString: "int:1", expectedCount: 1, expectError: false, description: "match on int, exact match"},
+		{filterString: "int:~1", expectedCount: 0, expectError: true, description: "match on int, wrong comparison type"},
+		{filterString: "int:!1", expectedCount: 4, expectError: false, description: "match on int, negated"},
+		{filterString: "int:<2", expectedCount: 1, expectError: false, description: "match on int, lt"},
+		{filterString: "int:<=1", expectedCount: 1, expectError: false, description: "match on int, lte"},
+		{filterString: "int:>1", expectedCount: 4, expectError: false, description: "match on int, gt"},
+		{filterString: "int:>=1", expectedCount: 5, expectError: false, description: "match on int, gte"},
+		{filterString: "uint:", expectedCount: 0, expectError: true, description: "match on uint, empty string"},
+		{filterString: "uint:1", expectedCount: 1, expectError: false, description: "match on uint, empty string"},
+		{filterString: "uint:~1", expectedCount: 0, expectError: true, description: "match on uint, wrong comparison type"},
+		{filterString: "uint:!1", expectedCount: 4, expectError: false, description: "match on uint, negated"},
+		{filterString: "uint:<2", expectedCount: 1, expectError: false, description: "match on uint, lt"},
+		{filterString: "uint:<=1", expectedCount: 1, expectError: false, description: "match on uint, lte"},
+		{filterString: "uint:>1", expectedCount: 4, expectError: false, description: "match on uint, gt"},
+		{filterString: "uint:>=1", expectedCount: 5, expectError: false, description: "match on uint, gte"},
+
+		{filterString: "int8:", expectedCount: 0, expectError: true, description: "match on int8, empty string"},
+		{filterString: "int8:1", expectedCount: 1, expectError: false, description: "match on int8, exact match"},
+		{filterString: "int8:~1", expectedCount: 0, expectError: true, description: "match on int8, wrong comparison type"},
+		{filterString: "int8:!1", expectedCount: 4, expectError: false, description: "match on int8, negated"},
+		{filterString: "int8:<2", expectedCount: 1, expectError: false, description: "match on int8, lt"},
+		{filterString: "int8:<=1", expectedCount: 1, expectError: false, description: "match on int8, lte"},
+		{filterString: "int8:>1", expectedCount: 4, expectError: false, description: "match on int8, gt"},
+		{filterString: "int8:>=1", expectedCount: 5, expectError: false, description: "match on int8, gte"},
+		{filterString: "uint8:", expectedCount: 0, expectError: true, description: "match on uint8, empty string"},
+		{filterString: "uint8:1", expectedCount: 1, expectError: false, description: "match on uint8, empty string"},
+		{filterString: "uint8:~1", expectedCount: 0, expectError: true, description: "match on uint8, wrong comparison type"},
+		{filterString: "uint8:!1", expectedCount: 4, expectError: false, description: "match on uint8, negated"},
+		{filterString: "uint8:<2", expectedCount: 1, expectError: false, description: "match on uint8, lt"},
+		{filterString: "uint8:<=1", expectedCount: 1, expectError: false, description: "match on uint8, lte"},
+		{filterString: "uint8:>1", expectedCount: 4, expectError: false, description: "match on uint8, gt"},
+		{filterString: "uint8:>=1", expectedCount: 5, expectError: false, description: "match on uint8, gte"},
+
+		{filterString: "int16:", expectedCount: 0, expectError: true, description: "match on int16, empty string"},
+		{filterString: "int16:1", expectedCount: 1, expectError: false, description: "match on int16, exact match"},
+		{filterString: "int16:~1", expectedCount: 0, expectError: true, description: "match on int16, wrong comparison type"},
+		{filterString: "int16:!1", expectedCount: 4, expectError: false, description: "match on int16, negated"},
+		{filterString: "int16:<2", expectedCount: 1, expectError: false, description: "match on int16, lt"},
+		{filterString: "int16:<=1", expectedCount: 1, expectError: false, description: "match on int16, lte"},
+		{filterString: "int16:>1", expectedCount: 4, expectError: false, description: "match on int16, gt"},
+		{filterString: "int16:>=1", expectedCount: 5, expectError: false, description: "match on int16, gte"},
+		{filterString: "uint16:", expectedCount: 0, expectError: true, description: "match on uint16, empty string"},
+		{filterString: "uint16:1", expectedCount: 1, expectError: false, description: "match on uint16, empty string"},
+		{filterString: "uint16:~1", expectedCount: 0, expectError: true, description: "match on uint16, wrong comparison type"},
+		{filterString: "uint16:!1", expectedCount: 4, expectError: false, description: "match on uint16, negated"},
+		{filterString: "uint16:<2", expectedCount: 1, expectError: false, description: "match on uint16, lt"},
+		{filterString: "uint16:<=1", expectedCount: 1, expectError: false, description: "match on uint16, lte"},
+		{filterString: "uint16:>1", expectedCount: 4, expectError: false, description: "match on uint16, gt"},
+		{filterString: "uint16:>=1", expectedCount: 5, expectError: false, description: "match on uint16, gte"},
+
+		{filterString: "int32:", expectedCount: 0, expectError: true, description: "match on int32, empty string"},
+		{filterString: "int32:1", expectedCount: 1, expectError: false, description: "match on int32, exact match"},
+		{filterString: "int32:~1", expectedCount: 0, expectError: true, description: "match on int32, wrong comparison type"},
+		{filterString: "int32:!1", expectedCount: 4, expectError: false, description: "match on int32, negated"},
+		{filterString: "int32:<2", expectedCount: 1, expectError: false, description: "match on int32, lt"},
+		{filterString: "int32:<=1", expectedCount: 1, expectError: false, description: "match on int32, lte"},
+		{filterString: "int32:>1", expectedCount: 4, expectError: false, description: "match on int32, gt"},
+		{filterString: "int32:>=1", expectedCount: 5, expectError: false, description: "match on int32, gte"},
+		{filterString: "uint32:", expectedCount: 0, expectError: true, description: "match on uint32, empty string"},
+		{filterString: "uint32:1", expectedCount: 1, expectError: false, description: "match on uint32, empty string"},
+		{filterString: "uint32:~1", expectedCount: 0, expectError: true, description: "match on uint32, wrong comparison type"},
+		{filterString: "uint32:!1", expectedCount: 4, expectError: false, description: "match on uint32, negated"},
+		{filterString: "uint32:<2", expectedCount: 1, expectError: false, description: "match on uint32, lt"},
+		{filterString: "uint32:<=1", expectedCount: 1, expectError: false, description: "match on uint32, lte"},
+		{filterString: "uint32:>1", expectedCount: 4, expectError: false, description: "match on uint32, gt"},
+		{filterString: "uint32:>=1", expectedCount: 5, expectError: false, description: "match on uint32, gte"},
+
+		{filterString: "int64:", expectedCount: 0, expectError: true, description: "match on int64, empty string"},
+		{filterString: "int64:1", expectedCount: 1, expectError: false, description: "match on int64, exact match"},
+		{filterString: "int64:~1", expectedCount: 0, expectError: true, description: "match on int64, wrong comparison type"},
+		{filterString: "int64:!1", expectedCount: 4, expectError: false, description: "match on int64, negated"},
+		{filterString: "int64:<2", expectedCount: 1, expectError: false, description: "match on int64, lt"},
+		{filterString: "int64:<=1", expectedCount: 1, expectError: false, description: "match on int64, lte"},
+		{filterString: "int64:>1", expectedCount: 4, expectError: false, description: "match on int64, gt"},
+		{filterString: "int64:>=1", expectedCount: 5, expectError: false, description: "match on int64, gte"},
+		{filterString: "uint64:", expectedCount: 0, expectError: true, description: "match on uint64, empty string"},
+		{filterString: "uint64:1", expectedCount: 1, expectError: false, description: "match on uint64, empty string"},
+		{filterString: "uint64:~1", expectedCount: 0, expectError: true, description: "match on uint64, wrong comparison type"},
+		{filterString: "uint64:!1", expectedCount: 4, expectError: false, description: "match on uint64, negated"},
+		{filterString: "uint64:<2", expectedCount: 1, expectError: false, description: "match on uint64, lt"},
+		{filterString: "uint64:<=1", expectedCount: 1, expectError: false, description: "match on uint64, lte"},
+		{filterString: "uint64:>1", expectedCount: 4, expectError: false, description: "match on uint64, gt"},
+		{filterString: "uint64:>=1", expectedCount: 5, expectError: false, description: "match on uint64, gte"},
+
+		{filterString: "float32:", expectedCount: 0, expectError: true, description: "match on float32, empty string"},
+		{filterString: "float32:1", expectedCount: 1, expectError: false, description: "match on float32, exact match"},
+		{filterString: "float32:~1", expectedCount: 0, expectError: true, description: "match on float32, wrong comparison type"},
+		{filterString: "float32:!1", expectedCount: 4, expectError: false, description: "match on float32, negated"},
+		{filterString: "float32:<2", expectedCount: 1, expectError: false, description: "match on float32, lt"},
+		{filterString: "float32:<=1", expectedCount: 1, expectError: false, description: "match on float32, lte"},
+		{filterString: "float32:>1", expectedCount: 4, expectError: false, description: "match on float32, gt"},
+		{filterString: "float32:>=1", expectedCount: 5, expectError: false, description: "match on float32, gte"},
+		{filterString: "float64:", expectedCount: 0, expectError: true, description: "match on float64, empty string"},
+		{filterString: "float64:1", expectedCount: 1, expectError: false, description: "match on float64, empty string"},
+		{filterString: "float64:~1", expectedCount: 0, expectError: true, description: "match on float64, wrong comparison type"},
+		{filterString: "float64:!1", expectedCount: 4, expectError: false, description: "match on float64, negated"},
+		{filterString: "float64:<2", expectedCount: 1, expectError: false, description: "match on float64, lt"},
+		{filterString: "float64:<=1", expectedCount: 1, expectError: false, description: "match on float64, lte"},
+		{filterString: "float64:>1", expectedCount: 4, expectError: false, description: "match on float64, gt"},
+		{filterString: "float64:>=1", expectedCount: 5, expectError: false, description: "match on float64, gte"},
+
+		{filterString: "unsupported:1", expectedCount: 0, expectError: true, description: "unsupported field"},
+	}
+
+	cols, err := columns.NewColumns[testData]()
+	if err != nil {
+		t.Errorf("failed to initialize: %v", err)
+	}
+
+	cmap := cols.GetColumnMap()
+
+	t.Run("test empty input", func(t *testing.T) {
+		res, err := FilterEntries(cmap, nil, []string{""})
+		if err != nil || res != nil {
+			t.Errorf("expected returned entries and err to be nil")
+		}
+	})
+
+	for _, filterTest := range filterTests {
+		t.Run(filterTest.description, func(t *testing.T) {
+			out, err := FilterEntries(cmap, filterEntries, []string{filterTest.filterString})
+			if err != nil && !filterTest.expectError {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if err == nil && filterTest.expectError {
+				t.Errorf("expected error")
+			}
+			if len(out) != filterTest.expectedCount {
+				t.Errorf("expected %d entries, got %d", filterTest.expectedCount, len(out))
+			}
+		})
+	}
+
+	filter, err := GetFilterFromString(cmap, "int8:1")
+	if err != nil {
+		t.Errorf("failed to get filter: %v", err)
+	}
+	if filter.Match(nil) {
+		t.Errorf("matching nil on non-negated filter should result in false")
+	}
+}

--- a/pkg/columns/formatter/textcolumns/doc.go
+++ b/pkg/columns/formatter/textcolumns/doc.go
@@ -1,0 +1,71 @@
+// Copyright 2022 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*
+Package textcolumns helps to output structs (and events of structs) using metadata from a `Columns` instance in a
+tabular way suitable for consoles or other frontends using fixed-width characters / fonts.
+
+It can automatically size the output tables according to either screen size or content and provides some helpful tools
+to get a consistent output.
+
+# Initializing
+
+You can create a new formatter by calling
+
+	tc := textcolumns.NewFormatter(columnMap)
+
+You can specify options by adding one or more of the WithX() functions to the initializer.
+The [columns.ColumnMap] can be obtained by calling [columns.GetColumpMap] on your `Column` instance.
+
+# Output
+
+After you have initialized the formatter, you can use
+
+	tc.FormatHeader()
+
+to obtain the header line as string, which will look something like this:
+
+	NODE                PID COMM             NAME                                 TIME
+
+You can also pass a filled struct to
+
+	tc.FormatEntry(&event)
+
+to get a string like this:
+
+	Node1                 2 AAA                                                   12ns
+
+Even simpler, use
+
+	tc.WriteTable(os.Stdout, entries)
+
+to directly print the whole table:
+
+	NODE                PID COMM             NAME                                 TIME
+	----------------------------------------------------------------------------------
+	Node1                 2 AAA                                                   12ns
+	Node1                 1 AAA              Yay                           14.677772ms
+	Node1                 2 AnotherComm                                    24.645772ms
+	Node2                 4 BBB                                           3.462217772s
+	Node2                 3 BBB                                                  333ns
+
+# Custom Columns
+
+By default, Columns will show all fields that have a column tag without the `hide` attribute. Using
+
+	tc.SetShowColumns("node,time")
+
+you can adjust the output to contain exactly the specified columns.
+*/
+package textcolumns

--- a/pkg/columns/formatter/textcolumns/helpers.go
+++ b/pkg/columns/formatter/textcolumns/helpers.go
@@ -1,0 +1,34 @@
+// Copyright 2022 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package textcolumns
+
+import "strings"
+
+// buildFillString builds a string that has the length of the widest column; it is used to copy
+// whitespace from, instead of generating it character by character all the time
+func (tf *TextColumnsFormatter[T]) buildFillString() {
+	maxLength := 0
+	for _, column := range tf.showColumns {
+		if column.calculatedWidth > maxLength {
+			maxLength = column.calculatedWidth
+		}
+	}
+
+	var s strings.Builder
+	for i := 0; i < maxLength; i++ {
+		s.WriteString(" ")
+	}
+	tf.fillString = s.String()
+}

--- a/pkg/columns/formatter/textcolumns/options.go
+++ b/pkg/columns/formatter/textcolumns/options.go
@@ -1,0 +1,85 @@
+// Copyright 2022 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package textcolumns
+
+type HeaderStyle int
+
+const (
+	HeaderStyleNormal HeaderStyle = iota
+	HeaderStyleUppercase
+	HeaderStyleLowercase
+)
+
+const (
+	DividerSpace = " "
+	DividerTab   = "\t"
+	DividerDash  = "—"
+	DividerNone  = ""
+)
+
+type Option func(*Options)
+
+type Options struct {
+	AutoScale      bool        // if enabled, the screen size will be used to scale the widths
+	ColumnDivider  string      // defines the string that should be used as spacer in between columns (default " ")
+	DefaultColumns []string    // defines which columns to show by default; will be set to all visible columns if nil
+	HeaderStyle    HeaderStyle // defines how column headers are decorated (e.g. uppercase/lowercase)
+	RowDivider     string      // defines the (to be repeated) string that should be used below the header
+}
+
+func DefaultOptions() *Options {
+	return &Options{
+		AutoScale:      false,
+		ColumnDivider:  DividerSpace,
+		DefaultColumns: nil,
+		HeaderStyle:    HeaderStyleUppercase,
+		RowDivider:     DividerNone,
+	}
+}
+
+// WithAutoScale sets whether auto-scaling to screen width should be enabled
+func WithAutoScale(autosScale bool) Option {
+	return func(opts *Options) {
+		opts.AutoScale = autosScale
+	}
+}
+
+// WithColumnDivider sets the string that should be used as divider between columns
+func WithColumnDivider(divider string) Option {
+	return func(opts *Options) {
+		opts.ColumnDivider = divider
+	}
+}
+
+// WithDefaultColumns sets the columns that should be displayed by default
+func WithDefaultColumns(columns []string) Option {
+	return func(opts *Options) {
+		opts.DefaultColumns = columns
+	}
+}
+
+// WithHeaderStyle sets the style to be used for the table header
+func WithHeaderStyle(headerStyle HeaderStyle) Option {
+	return func(opts *Options) {
+		opts.HeaderStyle = headerStyle
+	}
+}
+
+// WithRowDivider sets the string that should be used (repeatedly) to build the divider between header and content
+func WithRowDivider(divider string) Option {
+	return func(opts *Options) {
+		opts.RowDivider = divider
+	}
+}

--- a/pkg/columns/formatter/textcolumns/options_test.go
+++ b/pkg/columns/formatter/textcolumns/options_test.go
@@ -1,0 +1,52 @@
+// Copyright 2022 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package textcolumns
+
+import "testing"
+
+func TestOptions(t *testing.T) {
+	opts := &Options{
+		AutoScale:      false,
+		ColumnDivider:  "",
+		DefaultColumns: nil,
+		HeaderStyle:    0,
+		RowDivider:     DividerNone,
+	}
+
+	WithAutoScale(true)(opts)
+	if !opts.AutoScale {
+		t.Errorf("expected AutoScale to be true")
+	}
+
+	WithColumnDivider("X")(opts)
+	if opts.ColumnDivider != "X" {
+		t.Errorf("expected ColumnDivider to be X")
+	}
+
+	WithDefaultColumns([]string{"abc"})(opts)
+	if len(opts.DefaultColumns) != 1 || opts.DefaultColumns[0] != "abc" {
+		t.Errorf("expected DefaultColumns to have exactly 'abc' as value")
+	}
+
+	WithHeaderStyle(HeaderStyleLowercase)(opts)
+	if opts.HeaderStyle != HeaderStyleLowercase {
+		t.Errorf("expected HeaderStyle to be HeaderStyleLowercase")
+	}
+
+	WithRowDivider("X")(opts)
+	if opts.RowDivider != "X" {
+		t.Errorf("expected RowDivider to be X")
+	}
+}

--- a/pkg/columns/formatter/textcolumns/output.go
+++ b/pkg/columns/formatter/textcolumns/output.go
@@ -1,0 +1,147 @@
+// Copyright 2022 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package textcolumns
+
+import (
+	"fmt"
+	"io"
+	"reflect"
+	"strconv"
+	"strings"
+
+	"github.com/kinvolk/inspektor-gadget/pkg/columns"
+
+	"github.com/kinvolk/inspektor-gadget/pkg/columns/ellipsis"
+)
+
+func (tf *TextColumnsFormatter[T]) setFormatter(column *Column[T]) {
+	switch column.col.Kind() {
+	case reflect.Int,
+		reflect.Int8,
+		reflect.Int16,
+		reflect.Int32,
+		reflect.Int64:
+		column.formatter = func(v interface{}) string {
+			return tf.buildFixedString(strconv.FormatInt(reflect.ValueOf(v).Int(), 10), column.calculatedWidth, column.col.EllipsisType, column.col.Alignment)
+		}
+	case reflect.Uint,
+		reflect.Uint8,
+		reflect.Uint16,
+		reflect.Uint32,
+		reflect.Uint64:
+		column.formatter = func(v interface{}) string {
+			return tf.buildFixedString(strconv.FormatUint(reflect.ValueOf(v).Uint(), 10), column.calculatedWidth, column.col.EllipsisType, column.col.Alignment)
+		}
+	case reflect.Float32,
+		reflect.Float64:
+		column.formatter = func(v interface{}) string {
+			return tf.buildFixedString(strconv.FormatFloat(reflect.ValueOf(v).Float(), 'f', column.col.Precision, 64), column.calculatedWidth, column.col.EllipsisType, column.col.Alignment)
+		}
+	case reflect.String:
+		column.formatter = func(v interface{}) string {
+			return tf.buildFixedString(v.(string), column.calculatedWidth, column.col.EllipsisType, column.col.Alignment)
+		}
+	default:
+		column.formatter = func(v interface{}) string {
+			return tf.buildFixedString(fmt.Sprintf("%v", v), column.calculatedWidth, column.col.EllipsisType, column.col.Alignment)
+		}
+	}
+}
+
+func (tf *TextColumnsFormatter[T]) buildFixedString(s string, length int, ellipsisType ellipsis.EllipsisType, alignment columns.Alignment) string {
+	rs := []rune(s)
+
+	shortened := ellipsis.Shorten(rs, length, ellipsisType)
+	if len(shortened) == length {
+		return string(shortened)
+	}
+	if alignment == columns.AlignLeft {
+		return string(shortened) + tf.fillString[0:length-len(shortened)]
+	}
+	return tf.fillString[0:length-len(shortened)] + string(shortened)
+}
+
+// FormatEntry returns an entry as a formatted string, respecting the given formatting settings
+func (tf *TextColumnsFormatter[T]) FormatEntry(entry *T) string {
+	if entry == nil {
+		return ""
+	}
+
+	entryValue := reflect.ValueOf(entry)
+
+	var row strings.Builder
+	for i, col := range tf.showColumns {
+		if i > 0 {
+			row.WriteString(tf.options.ColumnDivider)
+		}
+		field := col.col.GetRef(entryValue)
+		row.WriteString(col.formatter(field.Interface()))
+	}
+	return row.String()
+}
+
+// FormatHeader returns the formatted header line with all visible column names, separated by ColumnDivider
+func (tf *TextColumnsFormatter[T]) FormatHeader() string {
+	tf.AdjustWidthsToScreen()
+	var row strings.Builder
+	for i, column := range tf.showColumns {
+		if i > 0 {
+			row.WriteString(tf.options.ColumnDivider)
+		}
+		name := column.col.Name
+		switch tf.options.HeaderStyle {
+		case HeaderStyleUppercase:
+			name = strings.ToUpper(name)
+		case HeaderStyleLowercase:
+			name = strings.ToLower(name)
+		}
+		row.WriteString(tf.buildFixedString(name, column.calculatedWidth, ellipsis.End, column.col.Alignment))
+	}
+	return row.String()
+}
+
+// FormatRowDivider returns a string that repeats the defined RowDivider until the total length of a row is reached
+func (tf *TextColumnsFormatter[T]) FormatRowDivider() string {
+	if tf.options.RowDivider == DividerNone {
+		return ""
+	}
+	var row strings.Builder
+	rowDividerLen := 0
+	for i, col := range tf.showColumns {
+		if i > 0 {
+			rowDividerLen += len([]rune(tf.options.ColumnDivider))
+		}
+		rowDividerLen += col.calculatedWidth
+	}
+	for i := 0; i < rowDividerLen; i += len([]rune(tf.options.RowDivider)) {
+		row.WriteString(tf.options.RowDivider)
+	}
+	return string([]rune(row.String())[:rowDividerLen])
+}
+
+// WriteTable writes header, divider and body with the current settings, where the body consists of the entries given
+// to the writer
+func (tf *TextColumnsFormatter[T]) WriteTable(writer io.Writer, entries []*T) {
+	writer.Write([]byte(tf.FormatHeader()))
+	writer.Write([]byte("\n"))
+	if tf.options.RowDivider != DividerNone {
+		writer.Write([]byte(tf.FormatRowDivider()))
+		writer.Write([]byte("\n"))
+	}
+	for _, entry := range entries {
+		writer.Write([]byte(tf.FormatEntry(entry)))
+		writer.Write([]byte("\n"))
+	}
+}

--- a/pkg/columns/formatter/textcolumns/scaler.go
+++ b/pkg/columns/formatter/textcolumns/scaler.go
@@ -1,0 +1,222 @@
+// Copyright 2022 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package textcolumns
+
+import (
+	"fmt"
+	"math"
+	"os"
+	"reflect"
+	"strconv"
+
+	"golang.org/x/term"
+)
+
+// RecalculateWidths sets the screen width and automatically scales columns to fit (if enabled in options)
+// If force is true, fixed widths will also be adjusted.
+func (tf *TextColumnsFormatter[T]) RecalculateWidths(maxWidth int, force bool) {
+	if tf.currentMaxWidth == maxWidth {
+		// No need to recalculate
+		return
+	}
+
+	if len(tf.showColumns) == 0 {
+		return
+	}
+
+	// calculate the minimum required length - else we could get negative values on auto-scaling
+	requiredWidth := (len(tf.showColumns) - 1) * len([]rune(tf.options.ColumnDivider))
+	if force {
+		requiredWidth += len(tf.showColumns)
+	} else {
+		for _, column := range tf.showColumns {
+			if column.col.FixedWidth {
+				requiredWidth += column.col.Width
+				continue
+			}
+			requiredWidth++
+		}
+	}
+
+	// enforce the requiredWidth
+	if requiredWidth > maxWidth {
+		maxWidth = requiredWidth
+	}
+
+	tf.currentMaxWidth = maxWidth
+
+	// Get total width of all printed columns
+	totalWidth := 0
+	spaces := 0
+	for i, column := range tf.showColumns {
+		if i > 0 {
+			spaces += len([]rune(tf.options.ColumnDivider))
+		}
+		if column.col.FixedWidth && !force {
+			spaces += column.col.Width
+			continue
+		}
+		totalWidth += column.col.Width
+	}
+
+	// Keep count of occurrences (needed when redistributing leftover space)
+	occurrences := make(map[string]int)
+
+	// Adjust width
+	totalAdjustedWidth := 0
+	for _, column := range tf.showColumns {
+		if column.col.FixedWidth && !force {
+			column.calculatedWidth = column.col.Width
+			continue
+		}
+		occurrences[column.col.Name]++
+		column.calculatedWidth = int(math.Floor(float64(column.col.Width) / float64(totalWidth) * float64(maxWidth-spaces)))
+		totalAdjustedWidth += column.calculatedWidth
+	}
+
+	// Handle leftover space
+	leftover := maxWidth - (totalAdjustedWidth + spaces)
+	for {
+		if leftover == 0 {
+			break
+		}
+
+		spent := false
+
+		// distribute
+		for _, column := range tf.showColumns {
+			if column.col.FixedWidth && !force {
+				continue
+			}
+			if occurrences[column.col.Name] > 1 {
+				// cannot redistribute here, since it would be used more than just once
+				continue
+			}
+			column.calculatedWidth += 1
+			spent = true
+			leftover--
+			if leftover == 0 {
+				break
+			}
+		}
+		if !spent {
+			// in case there are no columns to be resized found
+			break
+		}
+	}
+
+	tf.buildFillString()
+}
+
+// AdjustWidthsToScreen will try to get the width of the screen buffer and call RecalculateWidths with that value
+func (tf *TextColumnsFormatter[T]) AdjustWidthsToScreen() {
+	if !tf.options.AutoScale {
+		return
+	}
+
+	if !term.IsTerminal(int(os.Stdout.Fd())) {
+		return
+	}
+	terminalWidth, _, err := term.GetSize(0)
+	if err != nil {
+		return
+	}
+
+	tf.RecalculateWidths(terminalWidth, false)
+}
+
+// AdjustWidthsToContent will calculate widths of columns by getting the maximum length found for each column
+// in the input array. If considerHeaders is true, header lengths will also be considered when calculating.
+// If maxWidth > 0, space will be reduced to accordingly to match the given width.
+// If force is true, fixed widths will be ignored and scaled as well in the case that maxWidths is exceeded.
+func (tf *TextColumnsFormatter[T]) AdjustWidthsToContent(entries []*T, considerHeaders bool, maxWidth int, force bool) {
+	columnWidths := make([]int, len(tf.showColumns))
+	for columnIndex, column := range tf.showColumns {
+		// Get info on fixed columns first
+		if column.col.FixedWidth {
+			columnWidths[columnIndex] = column.calculatedWidth
+		}
+	}
+	for _, entry := range entries {
+		if entry == nil {
+			continue
+		}
+		entryValue := reflect.ValueOf(entry)
+		for columnIndex, column := range tf.showColumns {
+			if column.col.FixedWidth {
+				continue
+			}
+
+			field := column.col.GetRef(entryValue)
+
+			flen := 0
+			switch column.col.Kind() {
+			case reflect.Int,
+				reflect.Int8,
+				reflect.Int16,
+				reflect.Int32,
+				reflect.Int64:
+				flen = len([]rune((strconv.FormatInt(field.Int(), 10))))
+			case reflect.Uint,
+				reflect.Uint8,
+				reflect.Uint16,
+				reflect.Uint32,
+				reflect.Uint64:
+				flen = len([]rune((strconv.FormatUint(field.Uint(), 10))))
+			case reflect.Float32,
+				reflect.Float64:
+				flen = len([]rune(strconv.FormatFloat(field.Float(), 'f', column.col.Precision, 64)))
+			case reflect.String:
+				flen = len([]rune(field.Interface().(string)))
+			default:
+				flen = len([]rune(fmt.Sprintf("%v", field.Interface())))
+			}
+
+			if columnWidths[columnIndex] < flen {
+				columnWidths[columnIndex] = flen
+			}
+		}
+	}
+
+	if considerHeaders {
+		for columnIndex, column := range tf.showColumns {
+			if column.col.FixedWidth {
+				continue
+			}
+			headerLen := len([]rune(column.col.Name))
+			if headerLen > columnWidths[columnIndex] {
+				columnWidths[columnIndex] = headerLen
+			}
+		}
+	}
+
+	// Now set calculated widths accordingly
+	totalWidth := 0
+	for columnIndex, column := range tf.showColumns {
+		column.calculatedWidth = columnWidths[columnIndex]
+		totalWidth += column.calculatedWidth
+	}
+
+	// Last but not least, add column dividers
+	totalWidth += len([]rune(tf.options.ColumnDivider)) * (len(tf.showColumns) - 1)
+
+	if maxWidth == 0 || totalWidth <= maxWidth {
+		// Yay, it fits! (or user doesn't care)
+		return
+	}
+
+	// We did our best, but let's resize to fit to maxWidth
+	tf.RecalculateWidths(maxWidth, force)
+}

--- a/pkg/columns/formatter/textcolumns/textcolumns.go
+++ b/pkg/columns/formatter/textcolumns/textcolumns.go
@@ -1,0 +1,114 @@
+// Copyright 2022 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package textcolumns
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/kinvolk/inspektor-gadget/pkg/columns"
+)
+
+type Column[T any] struct {
+	col             *columns.Column[T]
+	calculatedWidth int
+	formatter       ColumnFormatter
+}
+
+type TextColumnsFormatter[T any] struct {
+	options         *Options
+	columns         map[string]*Column[T]
+	currentMaxWidth int
+	showColumns     []*Column[T]
+	fillString      string
+}
+
+// NewFormatter returns a TextColumnsFormatter that will turn entries of type T into tables that can be shown
+// on terminals or other frontends using fixed-width characters
+func NewFormatter[T any](columns columns.ColumnMap[T], options ...Option) *TextColumnsFormatter[T] {
+	opts := DefaultOptions()
+	for _, o := range options {
+		o(opts)
+	}
+
+	formatterColumnMap := make(map[string]*Column[T])
+	for columnName, column := range columns {
+		formatterColumnMap[columnName] = &Column[T]{
+			col:             column,
+			calculatedWidth: column.Width,
+		}
+	}
+
+	tf := &TextColumnsFormatter[T]{
+		options: opts,
+		columns: formatterColumnMap,
+	}
+
+	for _, column := range tf.columns {
+		tf.setFormatter(column)
+	}
+
+	tf.SetShowColumns(opts.DefaultColumns)
+
+	return tf
+}
+
+// SetShowDefaultColumns resets the shown columns to those defined by default
+func (tf *TextColumnsFormatter[T]) SetShowDefaultColumns() {
+	if tf.options.DefaultColumns != nil {
+		tf.SetShowColumns(tf.options.DefaultColumns)
+		return
+	}
+	newColumns := make([]*Column[T], 0)
+	for _, c := range tf.columns {
+		if !c.col.Visible {
+			continue
+		}
+		newColumns = append(newColumns, c)
+	}
+
+	// Sort using the default sort order
+	sort.Slice(newColumns, func(i, j int) bool {
+		return newColumns[i].col.Order < newColumns[j].col.Order
+	})
+
+	tf.showColumns = newColumns
+
+	tf.rebuild()
+}
+
+// SetShowColumns takes a comma separated list of column names that will be displayed when using the output methods
+func (tf *TextColumnsFormatter[T]) SetShowColumns(columns []string) {
+	if columns == nil {
+		tf.SetShowDefaultColumns()
+		return
+	}
+
+	newColumns := make([]*Column[T], 0)
+	for _, c := range columns {
+		if column, ok := tf.columns[strings.ToLower(c)]; ok {
+			newColumns = append(newColumns, column)
+		}
+	}
+	tf.showColumns = newColumns
+
+	tf.rebuild()
+}
+
+func (tf *TextColumnsFormatter[T]) rebuild() {
+	tf.buildFillString()
+	tf.currentMaxWidth = -1 // force recalculation
+	tf.AdjustWidthsToScreen()
+}

--- a/pkg/columns/formatter/textcolumns/textcolumns_test.go
+++ b/pkg/columns/formatter/textcolumns/textcolumns_test.go
@@ -1,0 +1,176 @@
+// Copyright 2022 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package textcolumns
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/kinvolk/inspektor-gadget/pkg/columns"
+)
+
+type testStruct struct {
+	Name     string  `column:"name,width:10"`
+	Age      uint    `column:"age,width:4,align:right,fixed"`
+	Size     float32 `column:"size,width:6,precision:2,align:right"`
+	Balance  int     `column:"balance,width:8,align:right"`
+	CanDance bool    `column:"canDance,width:8"`
+}
+
+var testEntries = []*testStruct{
+	{"Alice", 32, 1.74, 1000, true},
+	{"Bob", 26, 1.73, -200, true},
+	{"Eve", 99, 5.12, 1000000, false},
+	nil,
+}
+
+var testColumns = columns.MustCreateColumns[testStruct]().GetColumnMap()
+
+func TestTextColumnsFormatter_FormatEntry(t *testing.T) {
+	expected := []string{
+		"Alice        32   1.74     1000 true    ",
+		"Bob          26   1.73     -200 true    ",
+		"Eve          99   5.12  1000000 false   ",
+		"",
+	}
+	formatter := NewFormatter(testColumns, WithRowDivider(DividerDash))
+	for i, entry := range testEntries {
+		if res := formatter.FormatEntry(entry); res != expected[i] {
+			t.Errorf("got %s, expected %s", res, expected[i])
+		}
+	}
+
+	b := bytes.NewBuffer(nil)
+	formatter.WriteTable(b, testEntries)
+	out := b.String()
+	if out != strings.Join(append([]string{"NAME        AGE   SIZE  BALANCE CANDANCE", "————————————————————————————————————————"}, expected...), "\n")+"\n" {
+		t.Errorf("got %s", out)
+	}
+}
+
+func TestTextColumnsFormatter_FormatHeader(t *testing.T) {
+	formatter := NewFormatter(testColumns)
+
+	expected := "NAME        AGE   SIZE  BALANCE CANDANCE"
+	if res := formatter.FormatHeader(); res != expected {
+		t.Errorf("got %s, expected %s", res, expected)
+	}
+
+	formatter.options.HeaderStyle = HeaderStyleLowercase
+	expected = "name        age   size  balance candance"
+	if res := formatter.FormatHeader(); res != expected {
+		t.Errorf("got %s, expected %s", res, expected)
+	}
+
+	formatter.options.HeaderStyle = HeaderStyleNormal
+	expected = "name        age   size  balance canDance"
+	if res := formatter.FormatHeader(); res != expected {
+		t.Errorf("got %s, expected %s", res, expected)
+	}
+}
+
+func TestTextColumnsFormatter_FormatRowDivider(t *testing.T) {
+	formatter := NewFormatter(testColumns, WithRowDivider(DividerDash))
+	expected := "————————————————————————————————————————"
+	if res := formatter.FormatRowDivider(); res != expected {
+		t.Errorf("got %s, expected %s", res, expected)
+	}
+}
+
+func TestTextColumnsFormatter_RecalculateWidths(t *testing.T) {
+	formatter := NewFormatter(testColumns, WithRowDivider(DividerDash))
+	maxWidth := 100
+	formatter.RecalculateWidths(maxWidth, true)
+	if clen := len([]rune(formatter.FormatHeader())); clen != 100 {
+		t.Errorf("expected header to have width of %d, got %d", maxWidth, clen)
+	}
+	if clen := len([]rune(formatter.FormatRowDivider())); clen != 100 {
+		t.Errorf("expected row divider to have width of %d, got %d", maxWidth, clen)
+	}
+	for _, e := range testEntries {
+		if e != nil {
+			if clen := len([]rune(formatter.FormatEntry(e))); clen != 100 {
+				t.Errorf("expected entry to have width of %d, got %d", maxWidth, clen)
+			}
+		}
+	}
+}
+
+func TestTextColumnsFormatter_AdjustWidthsToContent(t *testing.T) {
+	/*
+		Expected result (32 characters):
+		NAME   AGE SIZE BALANCE CANDANCE
+		————————————————————————————————
+		Alice   32 1.74    1000 true
+		Bob     26 1.73    -200 true
+		Eve     99 5.12 1000000 false
+	*/
+	formatter := NewFormatter(testColumns, WithRowDivider(DividerDash))
+	formatter.AdjustWidthsToContent(testEntries, true, 0, false)
+	if cstr := formatter.FormatHeader(); cstr != "NAME   AGE SIZE BALANCE CANDANCE" {
+		t.Errorf("expected header does not match, got %s", cstr)
+	}
+	if cstr := formatter.FormatRowDivider(); cstr != "————————————————————————————————" {
+		t.Errorf("expected row divider does not match, got %s", cstr)
+	}
+	if cstr := formatter.FormatEntry(testEntries[0]); cstr != "Alice   32 1.74    1000 true    " {
+		t.Errorf("expected entry does not match, got %s", cstr)
+	}
+}
+
+func TestTextColumnsFormatter_AdjustWidthsToContentNoHeaders(t *testing.T) {
+	/*
+		Expected result (29 characters):
+		NAME   AGE SIZE BALANCE CAND…
+		—————————————————————————————
+		Alice   32 1.74    1000 true
+		Bob     26 1.73    -200 true
+		Eve     99 5.12 1000000 false
+	*/
+	formatter := NewFormatter(testColumns, WithRowDivider(DividerDash))
+	formatter.AdjustWidthsToContent(testEntries, false, 0, false)
+	if cstr := formatter.FormatHeader(); cstr != "NAME   AGE SIZE BALANCE CAND…" {
+		t.Errorf("expected header does not match, got %s", cstr)
+	}
+	if cstr := formatter.FormatRowDivider(); cstr != "—————————————————————————————" {
+		t.Errorf("expected row divider does not match, got %s", cstr)
+	}
+	if cstr := formatter.FormatEntry(testEntries[0]); cstr != "Alice   32 1.74    1000 true " {
+		t.Errorf("expected entry does not match, got %s", cstr)
+	}
+}
+
+func TestTextColumnsFormatter_AdjustWidthsMaxWidth(t *testing.T) {
+	/*
+		Expected result (9 characters):
+		N… …  … …
+		—————————
+		A… …  … …
+		B… …  … …
+		E… …  … …
+	*/
+	formatter := NewFormatter(testColumns, WithRowDivider(DividerDash))
+	formatter.AdjustWidthsToContent(testEntries, false, 9, true)
+	if cstr := formatter.FormatHeader(); cstr != "N… …  … …" {
+		t.Errorf("expected header does not match, got %s", cstr)
+	}
+	if cstr := formatter.FormatRowDivider(); cstr != "—————————" {
+		t.Errorf("expected row divider does not match, got %s", cstr)
+	}
+	if cstr := formatter.FormatEntry(testEntries[0]); cstr != "A… …  … …" {
+		t.Errorf("expected entry does not match, got %s", cstr)
+	}
+}

--- a/pkg/columns/formatter/textcolumns/types.go
+++ b/pkg/columns/formatter/textcolumns/types.go
@@ -1,0 +1,17 @@
+// Copyright 2022 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package textcolumns
+
+type ColumnFormatter func(any) string

--- a/pkg/columns/group/doc.go
+++ b/pkg/columns/group/doc.go
@@ -1,0 +1,21 @@
+// Copyright 2022 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*
+Package group can group the entries of an array by one or more columns. This will reduce the number of entries to
+the number of distinct values for the columns you group by. By default, the values of the first entry belonging to a
+group will be used, however, you can specify the `group` attribute to add up the values of a given
+field.
+*/
+package group

--- a/pkg/columns/group/group.go
+++ b/pkg/columns/group/group.go
@@ -1,0 +1,138 @@
+// Copyright 2022 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package group
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/kinvolk/inspektor-gadget/pkg/columns"
+)
+
+// GroupEntries will group the given entries using the column names given in groupBy and return a new
+// array with the results
+func GroupEntries[T any](columns columns.ColumnMap[T], entries []*T, groupBy []string) ([]*T, error) {
+	if entries == nil {
+		return nil, nil
+	}
+
+	newEntries := entries
+
+	for _, groupName := range groupBy {
+		groupName = strings.ToLower(groupName)
+
+		entriesVal := reflect.ValueOf(newEntries)
+
+		// Special case: empty group
+		// This means we will reduce the output to one record
+		if groupName == "" {
+			groupMap := make(map[string][]reflect.Value)
+			allValues := make([]reflect.Value, 0, len(entries))
+			for i := 0; i < entriesVal.Len(); i++ {
+				if entriesVal.Index(i).IsNil() {
+					// Skip nil entries
+					continue
+				}
+				allValues = append(allValues, entriesVal.Index(i))
+			}
+			groupMap[""] = allValues
+
+			outEntries := make([]*T, 0, len(groupMap))
+			flattenValues(columns, &outEntries, groupMap)
+
+			// We may exit now, since grouping more fields makes no sense after this
+			return outEntries, nil
+		}
+
+		// Get column to group
+		column, ok := columns.GetColumn(groupName)
+		if !ok {
+			return nil, fmt.Errorf("could not group by %q: column not found", groupName)
+		}
+
+		// Create a new map with key matching the group key
+		groupMap := make(map[string][]reflect.Value)
+
+		// Iterate over entries and push them to their corresponding map key
+		for i := 0; i < entriesVal.Len(); i++ {
+			entry := entriesVal.Index(i)
+			if entry.IsNil() {
+				// Skip nil entries
+				continue
+			}
+
+			// Transform group key according to request
+			key := column.GetRef(entry.Elem()).String()
+
+			if _, ok := groupMap[key]; !ok {
+				groupMap[key] = make([]reflect.Value, 0)
+			}
+
+			groupMap[key] = append(groupMap[key], entriesVal.Index(i))
+		}
+
+		outEntries := make([]*T, 0, len(groupMap))
+		flattenValues(columns, &outEntries, groupMap)
+
+		newEntries = outEntries
+	}
+
+	return newEntries, nil
+}
+
+func flattenValues[T any](cols columns.ColumnMap[T], outEntries *[]*T, groupMap map[string][]reflect.Value) {
+	entriesVal := reflect.ValueOf(outEntries).Elem()
+
+	for _, v := range groupMap {
+		// Use first entry as base
+		entry := reflect.New(v[0].Elem().Type())
+		entry.Elem().Set(v[0].Elem())
+		for i := 1; i < len(v); i++ {
+			curEntry := v[i]
+			for _, column := range cols.GetColumnMap() {
+				switch column.GroupType {
+				case columns.GroupTypeNone:
+					continue
+				case columns.GroupTypeSum:
+					switch column.Kind() {
+					case reflect.Int,
+						reflect.Int8,
+						reflect.Int16,
+						reflect.Int32,
+						reflect.Int64:
+						cur := column.GetRef(entry).Int() + column.GetRef(curEntry).Int()
+						column.GetRef(entry).SetInt(cur)
+					case reflect.Uint,
+						reflect.Uint8,
+						reflect.Uint16,
+						reflect.Uint32,
+						reflect.Uint64:
+						cur := column.GetRef(entry).Uint() + column.GetRef(curEntry).Uint()
+						column.GetRef(entry).SetUint(cur)
+					case reflect.Float32,
+						reflect.Float64:
+						cur := column.GetRef(entry).Float() + column.GetRef(curEntry).Float()
+						column.GetRef(entry).SetFloat(cur)
+					}
+				}
+			}
+		}
+
+		entriesVal = reflect.Append(entriesVal, entry)
+	}
+
+	reflect.ValueOf(outEntries).Elem().Set(entriesVal)
+}

--- a/pkg/columns/group/group_test.go
+++ b/pkg/columns/group/group_test.go
@@ -1,0 +1,141 @@
+// Copyright 2022 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package group
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/kinvolk/inspektor-gadget/pkg/columns"
+
+	"github.com/kinvolk/inspektor-gadget/pkg/columns/sort"
+)
+
+func TestGroupSum(t *testing.T) {
+	type Embedded struct {
+		EmbeddedInt   int64   `column:"embeddedInt,group:sum"`
+		EmbeddedFloat float64 `column:"embeddedFloat,group:sum"`
+	}
+	type testStruct struct {
+		Name  string  `column:"name"`
+		Int   int64   `column:"int,group:sum"`
+		Uint  uint64  `column:"uint,group:sum"`
+		Float float64 `column:"float,group:sum"`
+		Embedded
+	}
+	type test struct {
+		Name           string
+		GroupBy        []string
+		Input          []*testStruct
+		ExpectedResult []*testStruct
+		ExpectError    bool
+	}
+
+	entries := []*testStruct{
+		{Name: "a", Int: 1, Float: 1, Uint: 1, Embedded: Embedded{EmbeddedInt: 1, EmbeddedFloat: 1}},
+		{Name: "a", Int: 1, Float: 1, Uint: 1, Embedded: Embedded{EmbeddedInt: 1, EmbeddedFloat: 1}},
+		{Name: "b", Int: 2, Float: 2, Uint: 2, Embedded: Embedded{EmbeddedInt: 2, EmbeddedFloat: 2}},
+		{Name: "b", Int: 2, Float: 2, Uint: 2, Embedded: Embedded{EmbeddedInt: 2, EmbeddedFloat: 2}},
+		nil,
+	}
+
+	tests := []test{
+		{
+			Name:    "GroupAll",
+			GroupBy: []string{""},
+			Input:   entries,
+			ExpectedResult: []*testStruct{
+				{
+					Name:  "a",
+					Int:   6,
+					Uint:  6,
+					Float: 6,
+					Embedded: Embedded{
+						EmbeddedInt:   6,
+						EmbeddedFloat: 6,
+					},
+				},
+			},
+		},
+		{
+			Name:    "GroupByColumn",
+			GroupBy: []string{"name"},
+			Input:   entries,
+			ExpectedResult: []*testStruct{
+				{
+					Name:  "a",
+					Int:   2,
+					Uint:  2,
+					Float: 2,
+					Embedded: Embedded{
+						EmbeddedInt:   2,
+						EmbeddedFloat: 2,
+					},
+				},
+				{
+					Name:  "b",
+					Int:   4,
+					Uint:  4,
+					Float: 4,
+					Embedded: Embedded{
+						EmbeddedInt:   4,
+						EmbeddedFloat: 4,
+					},
+				},
+			},
+		},
+		{
+			Name:           "InvalidColumn",
+			GroupBy:        []string{"foobar"},
+			Input:          entries,
+			ExpectedResult: nil,
+			ExpectError:    true,
+		},
+		{
+			Name:           "NilArray",
+			GroupBy:        []string{"name"},
+			Input:          nil,
+			ExpectedResult: nil,
+			ExpectError:    false,
+		},
+	}
+
+	cols, err := columns.NewColumns[testStruct]()
+	if err != nil {
+		t.Errorf("failed to initialize: %v", err)
+	}
+
+	cmap := cols.GetColumnMap()
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			result, err := GroupEntries(cmap, test.Input, test.GroupBy)
+
+			// We need to sort the result as the grouping result is not consistent due
+			// to internally using a map
+			sort.SortEntries(cmap, result, test.GroupBy)
+
+			if err != nil && !test.ExpectError {
+				t.Errorf("while grouping: %v", err)
+			}
+			if err == nil && test.ExpectError {
+				t.Errorf("expected error")
+			}
+			if !reflect.DeepEqual(result, test.ExpectedResult) {
+				t.Errorf("got %+v", result)
+			}
+		})
+	}
+}

--- a/pkg/columns/options.go
+++ b/pkg/columns/options.go
@@ -1,0 +1,63 @@
+// Copyright 2022 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package columns
+
+import "github.com/kinvolk/inspektor-gadget/pkg/columns/ellipsis"
+
+type Option func(*Options)
+
+type Options struct {
+	DefaultAlignment        Alignment             // default text alignment to use; default AlignLeft
+	DefaultEllipsis         ellipsis.EllipsisType // default type of ellipsis to use for overflowing text; default: ellipsis.End
+	DefaultWidth            int                   // width to be used when no width is specified for a column; default: 16
+	RequireColumnDefinition bool                  // if set to false, Columns will consider all struct members, regardless of the column tag (in backticks behind the struct field, like `column:"columnName"`) being present; default: true
+}
+
+func GetDefault() *Options {
+	return &Options{
+		DefaultAlignment:        AlignLeft,
+		DefaultEllipsis:         ellipsis.End,
+		DefaultWidth:            16,
+		RequireColumnDefinition: true,
+	}
+}
+
+// WithAlignment sets the default alignment
+func WithAlignment(a Alignment) Option {
+	return func(opts *Options) {
+		opts.DefaultAlignment = a
+	}
+}
+
+// WithEllipsis sets the default ellipsis type
+func WithEllipsis(e ellipsis.EllipsisType) Option {
+	return func(opts *Options) {
+		opts.DefaultEllipsis = e
+	}
+}
+
+// WithRequireColumnDefinition sets whether the library should handle struct members without a column tag
+func WithRequireColumnDefinition(require bool) Option {
+	return func(opts *Options) {
+		opts.RequireColumnDefinition = require
+	}
+}
+
+// WithWidth sets the default column width
+func WithWidth(w int) Option {
+	return func(opts *Options) {
+		opts.DefaultWidth = w
+	}
+}

--- a/pkg/columns/options_test.go
+++ b/pkg/columns/options_test.go
@@ -1,0 +1,40 @@
+// Copyright 2022 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package columns
+
+import (
+	"testing"
+
+	"github.com/kinvolk/inspektor-gadget/pkg/columns/ellipsis"
+)
+
+func TestOptions(t *testing.T) {
+	opts := GetDefault()
+
+	WithAlignment(AlignRight)(opts)
+	if opts.DefaultAlignment != AlignRight {
+		t.Errorf("expected default alignment to be AlignRight")
+	}
+
+	WithEllipsis(ellipsis.Middle)(opts)
+	if opts.DefaultEllipsis != ellipsis.Middle {
+		t.Errorf("expected ellipsis to be ellipsis.Middle")
+	}
+
+	WithWidth(2342)(opts)
+	if opts.DefaultWidth != 2342 {
+		t.Errorf("expected default width to be 2342")
+	}
+}

--- a/pkg/columns/sort/doc.go
+++ b/pkg/columns/sort/doc.go
@@ -1,0 +1,27 @@
+// Copyright 2022 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*
+Package sort can be used to sort an array by their columns in either ascending or descending order.
+
+Calling
+
+	sort.SortEntries(columnMap, entries, []string{"node", "-time"})
+
+for example sorts the array by the time column in descending order and afterwards by the node column.
+
+The "-" prefix means the sorter should use descending order. Sorting by multiple fields will be done from the last field
+to the first in a stable way - so the first column always gets the highest priority.
+*/
+package sort

--- a/pkg/columns/sort/sort.go
+++ b/pkg/columns/sort/sort.go
@@ -1,0 +1,147 @@
+// Copyright 2022 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sort
+
+import (
+	"reflect"
+	"sort"
+
+	"github.com/kinvolk/inspektor-gadget/pkg/columns"
+)
+
+type columnSorter[T any] struct {
+	array   []*T
+	column  *columns.Column[T]
+	swapper func(i, j int)
+	less    func(i, j int) bool
+}
+
+// SortEntries sorts entries by applying the sortBy rules from right to left (first rule has the highest
+// priority). The rules are strings containing the column names, optionally prefixed with "-" to switch to descending
+// sort order.
+func SortEntries[T any](cols columns.ColumnMap[T], entries []*T, sortBy []string) {
+	if entries == nil {
+		return
+	}
+
+	for i := len(sortBy) - 1; i >= 0; i-- {
+		sortField := sortBy[i]
+
+		if len(sortField) == 0 {
+			continue
+		}
+
+		// Handle ordering
+		order := columns.OrderAsc
+		if sortField[0] == '-' {
+			sortField = sortField[1:]
+			order = columns.OrderDesc
+		}
+
+		column, ok := cols.GetColumn(sortField)
+		if !ok {
+			continue
+		}
+
+		sorter := newColumnSorter(entries, column, order)
+		if sorter == nil {
+			continue
+		}
+		sort.Stable(sorter)
+	}
+}
+
+func newColumnSorter[T any](array []*T, column *columns.Column[T], order columns.Order) *columnSorter[T] {
+	cs := &columnSorter[T]{
+		array:   array,
+		column:  column,
+		swapper: reflect.Swapper(array),
+	}
+
+	switch column.Kind() {
+	case reflect.Int,
+		reflect.Int8,
+		reflect.Int16,
+		reflect.Int32,
+		reflect.Int64:
+		cs.less = func(i, j int) bool {
+			v1 := reflect.ValueOf(array[i])
+			v2 := reflect.ValueOf(array[j])
+			if v1.IsNil() {
+				return false
+			}
+			if v2.IsNil() {
+				return true
+			}
+			return !(column.GetRef(v1).Int() < column.GetRef(v2).Int()) != order
+		}
+	case reflect.Uint,
+		reflect.Uint8,
+		reflect.Uint16,
+		reflect.Uint32,
+		reflect.Uint64:
+		cs.less = func(i, j int) bool {
+			v1 := reflect.ValueOf(array[i])
+			v2 := reflect.ValueOf(array[j])
+			if v1.IsNil() {
+				return false
+			}
+			if v2.IsNil() {
+				return true
+			}
+			return !(column.GetRef(v1).Uint() < column.GetRef(v2).Uint()) != order
+		}
+	case reflect.Float32,
+		reflect.Float64:
+		cs.less = func(i, j int) bool {
+			v1 := reflect.ValueOf(array[i])
+			v2 := reflect.ValueOf(array[j])
+			if v1.IsNil() {
+				return false
+			}
+			if v2.IsNil() {
+				return true
+			}
+			return !(column.GetRef(v1).Float() < column.GetRef(v2).Float()) != order
+		}
+	case reflect.String:
+		cs.less = func(i, j int) bool {
+			v1 := reflect.ValueOf(array[i])
+			v2 := reflect.ValueOf(array[j])
+			if v1.IsNil() {
+				return false
+			}
+			if v2.IsNil() {
+				return true
+			}
+			return !(column.GetRef(v1).String() < column.GetRef(v2).String()) != order
+		}
+	default:
+		return nil
+	}
+	return cs
+}
+
+func (cs *columnSorter[T]) Len() int {
+	return len(cs.array)
+}
+
+func (cs *columnSorter[T]) Swap(i, j int) {
+	cs.swapper(i, j)
+}
+
+func (cs *columnSorter[T]) Less(i, j int) bool {
+	return cs.less(i, j)
+}

--- a/pkg/columns/sort/sort_test.go
+++ b/pkg/columns/sort/sort_test.go
@@ -1,0 +1,149 @@
+// Copyright 2022 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sort
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/kinvolk/inspektor-gadget/pkg/columns"
+)
+
+func TestSorter(t *testing.T) {
+	type testEmbedded struct {
+		EmbeddedInt int `column:"embeddedInt"`
+	}
+	type testData struct {
+		testEmbedded
+		Int     int     `column:"int"`
+		Uint    uint    `column:"uint"`
+		String  string  `column:"string"`
+		Float32 float32 `column:"float32"`
+		Float64 float64 `column:"float64"`
+		Bool    bool    `column:"bool"`
+		Group   string  `column:"group"`
+	}
+	testEntries := []*testData{
+		nil,
+		{Int: 1, Uint: 2, String: "c", Float32: 3, Float64: 4, Group: "b", testEmbedded: testEmbedded{EmbeddedInt: 7}},
+		nil,
+		{Int: 2, Uint: 3, String: "d", Float32: 4, Float64: 5, Group: "b", testEmbedded: testEmbedded{EmbeddedInt: 6}},
+		nil,
+		{Int: 3, Uint: 4, String: "e", Float32: 5, Float64: 1, Group: "a", testEmbedded: testEmbedded{EmbeddedInt: 5}},
+		nil,
+		{Int: 4, Uint: 5, String: "a", Float32: 1, Float64: 2, Group: "a", testEmbedded: testEmbedded{EmbeddedInt: 4}},
+		nil,
+		{Int: 5, Uint: 1, String: "b", Float32: 2, Float64: 3, Group: "c", testEmbedded: testEmbedded{EmbeddedInt: 3}},
+		nil,
+	}
+
+	// Using shuffle should cover all sorting paths
+	rand.Seed(0)
+
+	cols, err := columns.NewColumns[testData]()
+	if err != nil {
+		t.Errorf("failed to initialize: %v", err)
+	}
+
+	cmap := cols.GetColumnMap()
+
+	rand.Shuffle(len(testEntries), func(i, j int) { testEntries[i], testEntries[j] = testEntries[j], testEntries[i] })
+	SortEntries(cmap, testEntries, []string{"uint"})
+
+	if testEntries[0].Uint != 1 {
+		t.Errorf("expected value to be 1")
+	}
+
+	rand.Shuffle(len(testEntries), func(i, j int) { testEntries[i], testEntries[j] = testEntries[j], testEntries[i] })
+	SortEntries(cmap, testEntries, []string{"-uint"})
+	if testEntries[0].Uint != 5 {
+		t.Errorf("expected value to be 5")
+	}
+
+	rand.Shuffle(len(testEntries), func(i, j int) { testEntries[i], testEntries[j] = testEntries[j], testEntries[i] })
+	SortEntries(cmap, testEntries, []string{"int"})
+	if testEntries[0].Int != 1 {
+		t.Errorf("expected value to be 1")
+	}
+
+	rand.Shuffle(len(testEntries), func(i, j int) { testEntries[i], testEntries[j] = testEntries[j], testEntries[i] })
+	SortEntries(cmap, testEntries, []string{"-int"})
+	if testEntries[0].Int != 5 {
+		t.Errorf("expected value to be 5")
+	}
+
+	rand.Shuffle(len(testEntries), func(i, j int) { testEntries[i], testEntries[j] = testEntries[j], testEntries[i] })
+	SortEntries(cmap, testEntries, []string{"float32"})
+	if testEntries[0].Float32 != 1 {
+		t.Errorf("expected value to be 1")
+	}
+
+	rand.Shuffle(len(testEntries), func(i, j int) { testEntries[i], testEntries[j] = testEntries[j], testEntries[i] })
+	SortEntries(cmap, testEntries, []string{"-float32"})
+	if testEntries[0].Float32 != 5 {
+		t.Errorf("expected value to be 5")
+	}
+
+	rand.Shuffle(len(testEntries), func(i, j int) { testEntries[i], testEntries[j] = testEntries[j], testEntries[i] })
+	SortEntries(cmap, testEntries, []string{"float64"})
+	if testEntries[0].Float64 != 1 {
+		t.Errorf("expected value to be 1")
+	}
+
+	rand.Shuffle(len(testEntries), func(i, j int) { testEntries[i], testEntries[j] = testEntries[j], testEntries[i] })
+	SortEntries(cmap, testEntries, []string{"-float64"})
+	if testEntries[0].Float64 != 5 {
+		t.Errorf("expected value to be 5")
+	}
+
+	rand.Shuffle(len(testEntries), func(i, j int) { testEntries[i], testEntries[j] = testEntries[j], testEntries[i] })
+	SortEntries(cmap, testEntries, []string{"group", "string"})
+	if testEntries[0].Group != "a" || testEntries[0].String != "a" {
+		t.Errorf("expected value to be a (group) and a (string)")
+	}
+
+	rand.Shuffle(len(testEntries), func(i, j int) { testEntries[i], testEntries[j] = testEntries[j], testEntries[i] })
+	SortEntries(cmap, testEntries, []string{"embeddedInt"})
+	if testEntries[0].EmbeddedInt != 3 {
+		t.Errorf("expected embedded value to be a 3")
+	}
+
+	rand.Shuffle(len(testEntries), func(i, j int) { testEntries[i], testEntries[j] = testEntries[j], testEntries[i] })
+	SortEntries(cmap, testEntries, []string{"string"})
+	if testEntries[0].String != "a" {
+		t.Errorf("expected value to be a")
+	}
+
+	// Sort by unsupported column - should result in noop
+	SortEntries(cmap, testEntries, []string{"bool"})
+	if testEntries[0].String != "a" {
+		t.Errorf("expected value to be a")
+	}
+
+	// Sort by invalid column - should result in noop
+	SortEntries(cmap, testEntries, []string{"invalid"})
+	if testEntries[0].String != "a" {
+		t.Errorf("expected value to be a")
+	}
+
+	// Sort by empty column - should result in noop
+	SortEntries(cmap, testEntries, []string{""})
+	if testEntries[0].String != "a" {
+		t.Errorf("expected value to be a")
+	}
+
+	// Sort nil array - should result in noop
+	SortEntries(cmap, nil, []string{""})
+}

--- a/pkg/columns/types.go
+++ b/pkg/columns/types.go
@@ -1,0 +1,53 @@
+// Copyright 2022 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package columns
+
+// Alignment defines whether text should be aligned to the left or right inside a column
+type Alignment int
+
+const (
+	AlignLeft Alignment = iota
+	AlignRight
+)
+
+// GroupType defines how columns should be aggregated in case of grouping
+type GroupType int
+
+const (
+	GroupTypeNone GroupType = iota // GroupTypeNone uses the first occurrence of a value in a group to represent its group
+	GroupTypeSum                   // GroupTypeSum adds values of this column up for its group
+)
+
+// Order defines the sorting order of columns
+type Order bool
+
+const (
+	OrderAsc  Order = true  // OrderAsc sorts in ascending alphanumerical order
+	OrderDesc Order = false // OrderDesc sorts in descending alphanumerical order
+)
+
+type ColumnMatcher interface {
+	HasTag(string) bool
+	HasNoTags() bool
+	IsEmbedded() bool
+}
+
+// ColumnInterface is an interface that is valid for Columns and ColumnMap
+type ColumnInterface[T any] interface {
+	GetColumn(columnName string) (*Column[T], bool)
+	GetColumnMap(filters ...ColumnFilter) ColumnMap[T]
+	GetOrderedColumns(filters ...ColumnFilter) []*Column[T]
+	GetColumnNames(filters ...ColumnFilter) []string
+}


### PR DESCRIPTION
# Columns: Improve gadget data handling

This PR introduces a new library that can improve the way we handle our event/stats data in a couple of ways, described below.

More information about the functionality / features can be found here:
https://github.com/kinvolk/inspektor-gadget/blob/michael/tableformatter/pkg/columns/README.md

### Store metadata in the event/stats structs
Instead of having two or more places to define metadata like column widths, sorting parameters and so on, we can keep them right by the structs using tags. The library uses a combination of generics and reflection to achieve this. That way we can (in most cases) handle things like including/excluding columns, sorting, grouping automatically without writing additional code specific to the structs.

Special cases might need a bit of additional code, though.

### Optimize output for columns
The library is able to take into account column widths and other information from the tag metadata and will format the output accordingly. It supports
* shortening entries by either cutting at the width or indicating with an ellipsis ("...")
* adjust column widths automatically using the terminal width
* aligning values left or right

### Add helper functions
#### Sorting
Using the library one can simply sort the structs by one or more individual fields.

#### Grouping
Grouping by column content is also possible, so if you want for example group all entries from a specific node and return the sum of the values for another column (e.g. bpf programs' total runtime in top/ebpf on each node), you can simply do so without writing additional code.

#### Filtering
Different filter rules can be applied to sets of data, including: exact match, regular expression match, <, >, <=, >=.

### Metadata Export
All information gathered by the library from the structs can be exposed and used for other use cases. In case of command line handling via cobra it can return a list of all available columns without writing additional code. This could also be used for other frontends like web interfaces.

## Benchmarks
Depending on the use case, using reflection is usually slower than specific code. I did some basic benchmarks that show a x2-x5 decrease of performance for things like formatting a complete line, but as this is still happening in a couple of nanoseconds per row, it should be negligible for all our use cases.

## Todos
- [x] Extract example code for gadgets
- [x] Add unit tests

## Related Issues
#856, #851