### PR TITLE
Makefile: fix target dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,10 +70,10 @@ list-local-gadget-targets:
 	@echo $(LOCAL_GADGET_TARGETS)
 
 .PHONY: local-gadget-all
-local-gadget-all: $(LOCAL_GADGET_TARGETS)
+local-gadget-all: $(LOCAL_GADGET_TARGETS) local-gadget
 
 local-gadget: local-gadget-$(GOHOSTOS)-$(GOHOSTARCH)
-	mv local-gadget-$(GOHOSTOS)-$(GOHOSTARCH) local-gadget
+	cp local-gadget-$(GOHOSTOS)-$(GOHOSTARCH) local-gadget
 
 local-gadget-%: phony_explicit
 	echo Building local-gadget-$* && \
@@ -95,10 +95,10 @@ list-kubectl-gadget-targets:
 	@echo $(KUBECTL_GADGET_TARGETS)
 
 .PHONY: kubectl-gadget-all
-kubectl-gadget-all: $(KUBECTL_GADGET_TARGETS)
+kubectl-gadget-all: $(KUBECTL_GADGET_TARGETS) kubectl-gadget
 
 kubectl-gadget: kubectl-gadget-$(GOHOSTOS)-$(GOHOSTARCH)
-	mv kubectl-gadget-$(GOHOSTOS)-$(GOHOSTARCH) kubectl-gadget
+	cp kubectl-gadget-$(GOHOSTOS)-$(GOHOSTARCH) kubectl-gadget
 
 kubectl-gadget-%: phony_explicit
 	export GO111MODULE=on CGO_ENABLED=0 && \


### PR DESCRIPTION
Currently, the following commands fail:
```
$ make build install/kubectl-gadget
```

Because the first target produces 'kubectl-gadget' but then requires 'kubectl-gadget-linux-amd64'.

In general, a Makefile target should not remove the output of a previous target, unless it is something like the 'clean' target.
