### PR TITLE
lint: Update to golangci-lint v1.49.0 and fix issues detected by it.

### DIFF
--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -56,7 +56,7 @@ jobs:
       uses: golangci/golangci-lint-action@v3.2.0
       with:
         # This version number must be kept in sync with Makefile lint one.
-        version: v1.46.2
+        version: v1.49.0
         working-directory: /home/runner/work/inspektor-gadget/inspektor-gadget
         # Workaround to display the output:
         # https://github.com/golangci/golangci-lint-action/issues/119#issuecomment-981090648

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,6 +16,9 @@ issues:
     - text: "ST1000: at least one file in a package should have a package comment"
       linters:
         - stylecheck
+    - text: 'SA1019: "io/ioutil" has been deprecated since Go 1.16'
+      linters:
+        - staticcheck
 
 linters:
   disable-all: true

--- a/Makefile
+++ b/Makefile
@@ -168,12 +168,15 @@ generate-documentation:
 	go run -tags docs cmd/gen-doc/gen-doc.go -repo $(shell pwd)
 
 lint:
-	# This version number must be kept in sync with CI workflow lint one.
-	# XDG_CACHE_HOME is necessary to avoid this type of errors:
-	# ERRO Running error: context loading failed: failed to load packages: failed to load with go/packages: err: exit status 1: stderr: failed to initialize build cache at /.cache/go-build: mkdir /.cache: permission denied
-	# Process 15167 has exited with status 3
-	# While GOLANGCI_LINT_CACHE is used to store golangci-lint cache.
-	docker run --rm --env XDG_CACHE_HOME=/tmp/xdg_home_cache --env GOLANGCI_LINT_CACHE=/tmp/golangci_lint_cache --user $(shell id -u):$(shell id -g) -v $(shell pwd):/app -w /app golangci/golangci-lint:v1.46.2 golangci-lint run --fix
+# This version number must be kept in sync with CI workflow lint one.
+# XDG_CACHE_HOME is necessary to avoid this type of errors:
+# ERRO Running error: context loading failed: failed to load packages: failed to load with go/packages: err: exit status 1: stderr: failed to initialize build cache at /.cache/go-build: mkdir /.cache: permission denied
+# Process 15167 has exited with status 3
+# While GOLANGCI_LINT_CACHE is used to store golangci-lint cache.
+	docker run --rm --env XDG_CACHE_HOME=/tmp/xdg_home_cache \
+		--env GOLANGCI_LINT_CACHE=/tmp/golangci_lint_cache \
+		--user $(shell id -u):$(shell id -g) -v $(shell pwd):/app -w /app \
+		golangci/golangci-lint:v1.49.0 golangci-lint run --fix
 
 # minikube
 LIVENESS_PROBE_INITIAL_DELAY_SECONDS ?= 60

--- a/pkg/apis/gadget/v1alpha1/groupversion_info.go
+++ b/pkg/apis/gadget/v1alpha1/groupversion_info.go
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 // Package v1alpha1 contains API Schema definitions for the gadget v1alpha1 API group
-//+kubebuilder:object:generate=true
-//+groupName=gadget.kinvolk.io
+// +kubebuilder:object:generate=true
+// +groupName=gadget.kinvolk.io
 package v1alpha1
 
 import (

--- a/pkg/gadgets/trace/network/tracer/tracer.go
+++ b/pkg/gadgets/trace/network/tracer/tracer.go
@@ -161,7 +161,7 @@ func (t *Tracer) Attach(key string, pid uint32) (err error) {
 func pktTypeString(pktType int) string {
 	// pkttype definitions:
 	// https://github.com/torvalds/linux/blob/v5.14-rc7/include/uapi/linux/if_packet.h#L26
-	var pktTypeNames = []string{
+	pktTypeNames := []string{
 		"HOST",
 		"BROADCAST",
 		"MULTICAST",

--- a/pkg/gadgets/trace/tcp/tracer/tracer.go
+++ b/pkg/gadgets/trace/tcp/tracer/tracer.go
@@ -93,7 +93,8 @@ type Tracer struct {
 }
 
 func NewTracer(config *Config, enricher gadgets.DataEnricher,
-	eventCallback func(types.Event)) (*Tracer, error) {
+	eventCallback func(types.Event),
+) (*Tracer, error) {
 	t := &Tracer{
 		config:        config,
 		enricher:      enricher,

--- a/pkg/gadgettracermanager/containers-map/tracer.go
+++ b/pkg/gadgettracermanager/containers-map/tracer.go
@@ -51,8 +51,8 @@ func copyToC(dest *[NameMaxLength]C.char, source string) {
 // This makes it possible for gadgets to access that information and
 // display it directly from the BPF code. Example of such code:
 //
-//     struct container *container_entry;
-//     container_entry = bpf_map_lookup_elem(&containers, &mntns_id);
+//	struct container *container_entry;
+//	container_entry = bpf_map_lookup_elem(&containers, &mntns_id);
 //
 // External tools such as tracee or bpftrace could also benefit from this just
 // by using this "containers" map (other interaction with Inspektor Gadget is


### PR DESCRIPTION
In https://github.com/kinvolk/inspektor-gadget/pull/821 I'm hitting https://github.com/golangci/golangci-lint/issues/2859, hence I need to update the version of golangci-lint to something that contains https://github.com/golangci/golangci-lint/pull/2976.

I decided to switch to the latest release (v1.49.0) to keep it as updated as possible. I have to add an exception for `SA1019: "io/ioutil" has been deprecated since Go 1.16`, we can fix it later on. 