### PR TITLE
kubectl-gadget: Only support Linux nodes explicitly

### DIFF
--- a/cmd/kubectl-gadget/debug.go
+++ b/cmd/kubectl-gadget/debug.go
@@ -25,16 +25,18 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/yaml"
+
+	"github.com/kinvolk/inspektor-gadget/cmd/kubectl-gadget/utils"
 )
 
 func getGadgetPodsDebug(client *kubernetes.Clientset) string {
 	var sb strings.Builder
 
 	listOpts := metav1.ListOptions{
-		LabelSelector: "k8s-app=" + gadgetNamespace,
+		LabelSelector: "k8s-app=" + utils.GadgetNamespace,
 	}
 
-	pods, err := client.CoreV1().Pods(gadgetNamespace).List(context.TODO(), listOpts)
+	pods, err := client.CoreV1().Pods(utils.GadgetNamespace).List(context.TODO(), listOpts)
 	if err != nil {
 		return ""
 	}
@@ -59,7 +61,7 @@ func getGadgetPodsDebug(client *kubernetes.Clientset) string {
 
 func getPodLog(client *kubernetes.Clientset, podname string) string {
 	podLogOpts := corev1.PodLogOptions{}
-	req := client.CoreV1().Pods(gadgetNamespace).GetLogs(podname, &podLogOpts)
+	req := client.CoreV1().Pods(utils.GadgetNamespace).GetLogs(podname, &podLogOpts)
 	if req == nil {
 		return ""
 	}
@@ -95,7 +97,7 @@ func eventTime(event corev1.Event) time.Time {
 func getEvents(client *kubernetes.Clientset) string {
 	var sb strings.Builder
 
-	events, err := client.CoreV1().Events(gadgetNamespace).List(context.TODO(), metav1.ListOptions{})
+	events, err := client.CoreV1().Events(utils.GadgetNamespace).List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
 		return ""
 	}

--- a/cmd/kubectl-gadget/deploy.go
+++ b/cmd/kubectl-gadget/deploy.go
@@ -318,7 +318,7 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 			}
 
 			// Get gadget daemon set (if any) to check if it was modified
-			currentGadgetDS, _ = k8sClient.AppsV1().DaemonSets(gadgetNamespace).Get(
+			currentGadgetDS, _ = k8sClient.AppsV1().DaemonSets(utils.GadgetNamespace).Get(
 				context.TODO(), "gadget", metav1.GetOptions{},
 			)
 		}
@@ -365,7 +365,7 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 	// The below code (particularly how to use UntilWithSync) is highly
 	// inspired from kubectl wait source code:
 	// https://github.com/kubernetes/kubectl/blob/b5fe0f6e9c65ea95a2118746b7e04822255d76c2/pkg/cmd/wait/wait.go#L364
-	daemonSetInterface := k8sClient.AppsV1().DaemonSets(gadgetNamespace)
+	daemonSetInterface := k8sClient.AppsV1().DaemonSets(utils.GadgetNamespace)
 	lw := &cache.ListWatch{
 		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 			options.LabelSelector = "k8s-app=gadget"
@@ -385,7 +385,7 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 	_, err = watchtools.UntilWithSync(ctx, lw, &appsv1.DaemonSet{}, nil, func(event watch.Event) (bool, error) {
 		switch event.Type {
 		case watch.Deleted:
-			return false, fmt.Errorf("DaemonSet from namespace %s should not be deleted", gadgetNamespace)
+			return false, fmt.Errorf("DaemonSet from namespace %s should not be deleted", utils.GadgetNamespace)
 		case watch.Modified:
 			daemonSet, _ := event.Object.(*appsv1.DaemonSet)
 			status := daemonSet.Status

--- a/cmd/kubectl-gadget/undeploy.go
+++ b/cmd/kubectl-gadget/undeploy.go
@@ -97,7 +97,7 @@ func runUndeploy(cmd *cobra.Command, args []string) error {
 
 again:
 	fmt.Println("Removing traces...")
-	err = traceClient.GadgetV1alpha1().Traces(gadgetNamespace).DeleteCollection(
+	err = traceClient.GadgetV1alpha1().Traces(utils.GadgetNamespace).DeleteCollection(
 		context.TODO(), metav1.DeleteOptions{}, metav1.ListOptions{},
 	)
 	if err != nil && !errors.IsNotFound(err) {
@@ -106,7 +106,7 @@ again:
 
 	time.Sleep(time.Duration(delay) * time.Millisecond)
 
-	traces, err := traceClient.GadgetV1alpha1().Traces(gadgetNamespace).List(
+	traces, err := traceClient.GadgetV1alpha1().Traces(utils.GadgetNamespace).List(
 		context.TODO(), metav1.ListOptions{},
 	)
 	if err == nil && len(traces.Items) != 0 {
@@ -120,7 +120,7 @@ again:
 		// finalizers and let k8s remove them immediately.
 		for _, trace := range traces.Items {
 			data := []byte("{\"metadata\":{\"finalizers\":[]}}")
-			_, err := traceClient.GadgetV1alpha1().Traces(gadgetNamespace).Patch(
+			_, err := traceClient.GadgetV1alpha1().Traces(utils.GadgetNamespace).Patch(
 				context.TODO(), trace.Name, types.MergePatchType, data, metav1.PatchOptions{},
 			)
 			if err != nil {
@@ -190,11 +190,11 @@ again:
 	if undeployWait {
 		list, err = k8sClient.CoreV1().Namespaces().List(
 			context.TODO(), metav1.ListOptions{
-				FieldSelector: "metadata.name=" + gadgetNamespace,
+				FieldSelector: "metadata.name=" + utils.GadgetNamespace,
 			},
 		)
 		if err != nil {
-			errs = append(errs, fmt.Sprintf("failed to list %q namespace: %s", gadgetNamespace, err))
+			errs = append(errs, fmt.Sprintf("failed to list %q namespace: %s", utils.GadgetNamespace, err))
 			goto out
 		}
 
@@ -206,16 +206,16 @@ again:
 
 	fmt.Println("Removing namespace...")
 	err = k8sClient.CoreV1().Namespaces().Delete(
-		context.TODO(), gadgetNamespace, metav1.DeleteOptions{},
+		context.TODO(), utils.GadgetNamespace, metav1.DeleteOptions{},
 	)
 	if err != nil {
-		errs = append(errs, fmt.Sprintf("failed to remove %q namespace: %s", gadgetNamespace, err))
+		errs = append(errs, fmt.Sprintf("failed to remove %q namespace: %s", utils.GadgetNamespace, err))
 		goto out
 	}
 
 	if undeployWait {
 		watcher := cache.NewListWatchFromClient(
-			k8sClient.CoreV1().RESTClient(), "namespaces", "", fields.OneTermEqualSelector("metadata.name", gadgetNamespace),
+			k8sClient.CoreV1().RESTClient(), "namespaces", "", fields.OneTermEqualSelector("metadata.name", utils.GadgetNamespace),
 		)
 
 		conditionFunc := func(event watch.Event) (bool, error) {
@@ -235,7 +235,7 @@ again:
 		defer cancel()
 		_, err := watchtools.Until(ctx, list.ResourceVersion, watcher, conditionFunc)
 		if err != nil {
-			errs = append(errs, fmt.Sprintf("failed waiting for %q namespace to be removed: %s", gadgetNamespace, err))
+			errs = append(errs, fmt.Sprintf("failed waiting for %q namespace to be removed: %s", utils.GadgetNamespace, err))
 		}
 	}
 

--- a/cmd/kubectl-gadget/utils/consts.go
+++ b/cmd/kubectl-gadget/utils/consts.go
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package utils
 
 const (
-	gadgetNamespace string = "gadget"
+	GadgetNamespace string = "gadget"
 )

--- a/pkg/resources/manifests/deploy.yaml
+++ b/pkg/resources/manifests/deploy.yaml
@@ -106,6 +106,8 @@ spec:
       serviceAccount: gadget
       hostPID: true
       hostNetwork: true
+      nodeSelector:
+        kubernetes.io/os: "linux"
       containers:
       - name: gadget
         terminationMessagePolicy: FallbackToLogsOnError


### PR DESCRIPTION
Inspektor Gadget can only be used in Linux nodes for now. This commit:
- add a nodeSelector to the deployment to only schedule gadget pods in
Linux nodes.
- add logic in different places to only list Linux nodes.

## Testing done

Create an AKS cluster with a Linux and Windows pool (https://docs.microsoft.com/en-us/azure/aks/windows-faq?tabs=azure-cli). 

```
$ kubectl get nodes -o wide
NAME                                STATUS   ROLES   AGE   VERSION   INTERNAL-IP    EXTERNAL-IP   OS-IMAGE                         KERNEL-VERSION     CONTAINER-RUNTIME
aks-agentpool-23349554-vmss000000   Ready    agent   37m   v1.23.8   10.240.0.4     <none>        Ubuntu 18.04.6 LTS               5.4.0-1089-azure   containerd://1.5.11+azure-2
akswin000001                        Ready    agent   34m   v1.23.8   10.240.1.112   <none>        Windows Server 2019 Datacenter   10.0.17763.3287    containerd://1.6.6+azure
```

### Before this patch 

```
$ ./kubectl-gadget deploy 
Creating Namespace/gadget...
Creating ServiceAccount/gadget...
Creating Role/gadget-role...
Creating RoleBinding/gadget-role-binding...
Creating ClusterRole/gadget-cluster-role...
Creating ClusterRoleBinding/gadget-cluster-role-binding...
Creating DaemonSet/gadget...
Creating CustomResourceDefinition/traces.gadget.kinvolk.io...
Waiting for gadget pod(s) to be ready...
Error: timed out waiting for the condition
```

### After this patch 

```
$ ./kubectl-gadget deploy --image="ghcr.io/kinvolk/inspektor-gadget:latest"
Creating Namespace/gadget...
Creating ServiceAccount/gadget...
Creating Role/gadget-role...
Creating RoleBinding/gadget-role-binding...
Creating ClusterRole/gadget-cluster-role...
Creating ClusterRoleBinding/gadget-cluster-role-binding...
Creating DaemonSet/gadget...
Creating CustomResourceDefinition/traces.gadget.kinvolk.io...
Waiting for gadget pod(s) to be ready...
0/1 gadget pod(s) ready
1/1 gadget pod(s) ready
Inspektor Gadget successfully deployed

$ ./kubectl-gadget trace exec -A
NODE             NAMESPACE        POD                            CONTAINER        PID     PPID    PCOMM            RET  ARGS                     
aks-agentpool-23349554-vmss000000 kube-system      csi-azurefile-node-wcd28       node-driver-registrar 546     537     csi-node-driver  0    /csi-node-driver-registrar --kubelet-registration-path=/var/lib/kubelet/plugins/file.csi.azure.com/csi.sock --mode=kubelet-registration-probe  
[...]

$ ./kubectl-gadget trace exec -A --node aks-agentpool-23349554-vmss000000
NODE             NAMESPACE        POD                            CONTAINER        PID     PPID    PCOMM            RET  ARGS                     
aks-agentpool-23349554-vmss000000 gadget           gadget-l97tz                   gadget           934     925     sh               0    /bin/sh -c exec gadgettracermanager -call receive-stream -tracerid trace_gadget_execsnoop-llbqb  
[...]

$ ./kubectl-gadget trace exec -A --node akswin000000
Error: invalid argument '--node': there's not a gadget pod in node "akswin000000". Does the node exist?
```

Related to https://github.com/kinvolk/inspektor-gadget/issues/125. 



