### PR TITLE
kubectl-gadget/utils: Handle KUBECONFIG with several paths

### DIFF
--- a/cmd/kubectl-gadget/utils/kube-config.go
+++ b/cmd/kubectl-gadget/utils/kube-config.go
@@ -15,8 +15,6 @@
 package utils
 
 import (
-	"github.com/spf13/viper"
-
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 
@@ -26,8 +24,8 @@ import (
 func kubeRestConfig() (*restclient.Config, error) {
 	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
 	loadingRules.DefaultClientConfig = &clientcmd.DefaultClientConfig
-	if viper.GetString("kubeconfig") != "" {
-		loadingRules.ExplicitPath = viper.GetString("kubeconfig")
+	if KubernetesConfigFlags.KubeConfig != nil {
+		loadingRules.ExplicitPath = *KubernetesConfigFlags.KubeConfig
 	}
 	overrides := &clientcmd.ConfigOverrides{ClusterDefaults: clientcmd.ClusterDefaults}
 	clientConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, overrides)


### PR DESCRIPTION
The PR fixes couple of things:
- `clientcmd.NewDefaultClientConfigLoadingRules` already handles multipath in KUBECONFIG so no need to do it explicitly.
- `loadingRules.ExplicitPath` should be using the value specified via --kubeconfig flag to respect kubernetes/cli-runtime flags. Also `loadingRules.ExplicitPath` should be a path and not a list of paths. It is fine to use it with --kubeconfig flag since it is always expected to be a path like with `kubectl` as well:

```
$ kubectl get pods --kubeconfig ~/.kube/config:~/.kube/config
error: stat /home/qasim/.kube/config:~/.kube/config: no such file or **directory**
```

Fixes #880 

## Testing done

### Before the fix
```
$ mv ~/.kube/config ~/.kube/test
$ KUBECONFIG=~/.kube/test:~/.kube/test go run ./cmd/kubectl-gadget/ trace exec -A
NODE             NAMESPACE        POD                            CONTAINER        PID     PPID    PCOMM            RET  ARGS                     
Error: failed to receive stream on node "minikube": stat /home/qasim/.kube/test:/home/qasim/.kube/test: no such file or directory
```
```
$ mv ~/.kube/config ~/.kube/test
$ go run ./cmd/kubectl-gadget/ --kubeconfig ~/.kube/test  trace exec -A
NODE             NAMESPACE        POD                            CONTAINER        PID     PPID    PCOMM            RET  ARGS                     
Error: failed to receive stream on node "minikube": error sending request: Post "http://localhost:8080/api/v1/namespaces/gadget/pods/gadget-vrj5n/exec?command=%2Fbin%2Fsh&command=-c&command=exec+gadgettracermanager+-call+receive-stream+-tracerid+trace_gadget_execsnoop-5swx5&container=gadget&container=gadget&stderr=true&stdout=true&tty=true": dial tcp 127.0.0.1:8080: connect: connection refused

```
### After the fix
```
$ mv ~/.kube/config ~/.kube/test
$ KUBECONFIG=~/.kube/test:~/.kube/test go run ./cmd/kubectl-gadget/ trace exec -A
NODE             NAMESPACE        POD                            CONTAINER        PID     PPID    PCOMM            RET  ARGS                     
minikube         gadget           gadget-vrj5n                   gadget           1774013 1774003 sh               0    /bin/sh -c exec gadgettracermanager -call receive-stream -tracerid trace_gadget_execsnoop-fj6sc  
minikube         gadget           gadget-vrj5n                   gadget           1774013 1774003 gadgettracerman  0    /usr/bin/gadgettracermanager -call receive-stream -tracerid trace_gadget_execsnoop-fj6sc  
```
```
$ mv ~/.kube/config ~/.kube/test
$ go run ./cmd/kubectl-gadget/ --kubeconfig ~/.kube/test  trace exec -A
NODE             NAMESPACE        POD                            CONTAINER        PID     PPID    PCOMM            RET  ARGS                     
minikube         gadget           gadget-vrj5n                   gadget           1775075 1775066 sh               0    /bin/sh -c exec gadgettracermanager -call receive-stream -tracerid trace_gadget_execsnoop-jcsbm  
minikube         gadget           gadget-vrj5n                   gadget           1775075 1593726 gadgettracerman  0    /usr/bin/gadgettracermanager -call receive-stream -tracerid trace_gadget_execsnoop-jcsbm  

