### PR TITLE
cmd: Version skew warning

### DIFF
--- a/cmd/kubectl-gadget/utils/trace.go
+++ b/cmd/kubectl-gadget/utils/trace.go
@@ -216,10 +216,10 @@ func createTraces(trace *gadgetv1alpha1.Trace) error {
 
 		if !ready {
 			if traceNode != "" {
-				return fmt.Errorf("gadget pod on node %q is not ready", traceNode)
+				return fmt.Errorf("gadget pod on node %q is not ready", pod.Spec.NodeName)
 			}
 
-			fmt.Fprintf(os.Stderr, "gadget pod on node %q is not ready", traceNode)
+			fmt.Fprintf(os.Stderr, "gadget pod on node %q is not ready", pod.Spec.NodeName)
 			continue
 		}
 

--- a/cmd/kubectl-gadget/version.go
+++ b/cmd/kubectl-gadget/version.go
@@ -17,7 +17,10 @@ package main
 import (
 	"fmt"
 
+	"github.com/blang/semver"
 	"github.com/spf13/cobra"
+
+	"github.com/kinvolk/inspektor-gadget/cmd/kubectl-gadget/utils"
 )
 
 // This variable is used by the "version" command and is set during build.
@@ -25,6 +28,8 @@ var version = "undefined"
 
 func init() {
 	rootCmd.AddCommand(versionCmd)
+
+	utils.KubectlGadgetVersion, _ = semver.New(version[1:])
 }
 
 var versionCmd = &cobra.Command{

--- a/docs/install.md
+++ b/docs/install.md
@@ -16,6 +16,7 @@ description: >
   * [Hook Mode](#hook-mode)
   * [Specific Information for Different Platforms](#specific-information-for-different-platforms)
     + [Minikube](#minikube)
+  * [Version skew policy](#version-skew-policy)
 <!-- /toc -->
 
 Inspektor Gadget is composed of a `kubectl` plugin executed in the user's
@@ -150,3 +151,11 @@ Gadget from the cluster:
 ```
 $ kubectl gadget undeploy
 ```
+
+## Version skew policy
+
+Inspektor Gadget requires the kubectl-gadget plugin and the DaemonSet
+deployed on the cluster to be the exact same version. Even if this is
+possible that different versions work well together, we don't provide
+any guarantee in those cases. We'll visit this policy again once we
+approach to the v1.0 release.

--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,11 @@ require (
 	sigs.k8s.io/yaml v1.2.0
 )
 
-require github.com/moby/moby v20.10.17+incompatible
+require (
+	github.com/blang/semver v3.5.1+incompatible
+	github.com/google/go-cmp v0.5.8
+	github.com/moby/moby v20.10.17+incompatible
+)
 
 require (
 	cloud.google.com/go v0.81.0 // indirect
@@ -80,7 +84,6 @@ require (
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/btree v1.0.1 // indirect
-	github.com/google/go-cmp v0.5.8 // indirect
 	github.com/google/gofuzz v1.1.0 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
 	github.com/googleapis/gnostic v0.5.5 // indirect


### PR DESCRIPTION
While checking the stats of the krew plugin index and Github Container registry for Inspektor Gadget I found a discrepancy: the kubectl-gadget has more downloads than the container image for v0.8.0.

![Selection_133](https://user-images.githubusercontent.com/13031921/189436509-99ffa62f-4c4b-41a4-80f2-56a27a0d642c.png)

![Selection_134](https://user-images.githubusercontent.com/13031921/189436514-097f328a-c9b9-43db-aa88-3786b7f4afbf.png)

It doesn't make sense as normally clusters have multiple nodes, so one should expect the container image number of downloads to be much higher than the plugin downloads. 
One possibility is that users are updating the kubectl-gadget plugin but not the Inspektor Gadget deployed on the cluster. This PR adds a warning to tell users when there is a version skew between both components. 

## How to test 

```
# deploy a specific version of Inspektor Gadget
$ ./kubectl-gadget deploy --image ghcr.io/kinvolk/inspektor-gadget:v0.8.0

# fake the kubectl-gadget version in Makefile
$ git diff
diff --git Makefile Makefile
index 056b0c9a..9ecd66d0 100644
--- Makefile
+++ Makefile
@@ -22,6 +22,8 @@ else
        VERSION := $(TAG)-dirty
 endif
 
+VERSION="v0.9.0"
+
 pvpath := $(shell command -v pv 2>/dev/null || true)
 ifeq ($(pvpath),)
        PV :=

$ make kubectl-gadge

# run a tracer:
$ ./kubectl-gadget trace open 
NODE             NAMESPACE        POD                            CONTAINER        PID     COMM             FD  ERR PATH                     
WARNING: version skew detected (0.8.0 vs 0.9.0), use 'kubectl gadget deploy' to fix it.
^C
Terminating...
```
