### PR TITLE
local-gadget: Add tcp trace gadget

### DIFF
--- a/cmd/common/trace/tcp.go
+++ b/cmd/common/trace/tcp.go
@@ -1,0 +1,150 @@
+// Copyright 2022 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package trace
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	commonutils "github.com/kinvolk/inspektor-gadget/cmd/common/utils"
+	tcpTypes "github.com/kinvolk/inspektor-gadget/pkg/gadgets/trace/tcp/types"
+)
+
+type TCPParser struct {
+	commonutils.BaseParser[tcpTypes.Event]
+}
+
+func newTCPParser(outputConfig *commonutils.OutputConfig, prependColumns []string) TraceParser[tcpTypes.Event] {
+	columnsWidth := map[string]int{
+		// TODO: Move Kubernetes metadata columns to common/utils.
+		"node":      -16,
+		"namespace": -16,
+		"pod":       -30,
+		"container": -16,
+		"t":         -2,
+		"pid":       -7,
+		"comm":      -16,
+		"ip":        -3,
+		"saddr":     -22,
+		"daddr":     -22,
+		"sport":     -7,
+		"dport":     -7,
+	}
+
+	if len(outputConfig.CustomColumns) == 0 {
+		outputConfig.CustomColumns = GetTCPDefaultColumns()
+		if len(prependColumns) != 0 {
+			outputConfig.CustomColumns = append(prependColumns, outputConfig.CustomColumns...)
+		}
+	}
+
+	return &TCPParser{
+		BaseParser: commonutils.NewBaseWidthParser[tcpTypes.Event](columnsWidth, outputConfig),
+	}
+}
+
+func NewTCPParserWithK8sInfo(outputConfig *commonutils.OutputConfig) TraceParser[tcpTypes.Event] {
+	return newTCPParser(outputConfig, commonutils.GetKubernetesColumns())
+}
+
+func NewTCPParserWithRuntimeInfo(outputConfig *commonutils.OutputConfig) TraceParser[tcpTypes.Event] {
+	return newTCPParser(outputConfig, commonutils.GetContainerRuntimeColumns())
+}
+
+func NewTCPParser(outputConfig *commonutils.OutputConfig) TraceParser[tcpTypes.Event] {
+	return newTCPParser(outputConfig, nil)
+}
+
+func getOperationShort(operation string) string {
+	operations := map[string]string{
+		"accept":  "A",
+		"connect": "C",
+		"close":   "X",
+		"unknown": "U",
+	}
+
+	if op, ok := operations[operation]; ok {
+		return op
+	}
+
+	return "U"
+}
+
+func (p *TCPParser) TransformEvent(event *tcpTypes.Event) string {
+	return p.Transform(event, func(event *tcpTypes.Event) string {
+		var sb strings.Builder
+
+		for _, col := range p.OutputConfig.CustomColumns {
+			switch col {
+			case "node":
+				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Node))
+			case "namespace":
+				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Namespace))
+			case "pod":
+				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Pod))
+			case "container":
+				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Container))
+			case "t":
+				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], getOperationShort(event.Operation)))
+			case "pid":
+				sb.WriteString(fmt.Sprintf("%*d", p.ColumnsWidth[col], event.Pid))
+			case "comm":
+				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Comm))
+			case "ip":
+				sb.WriteString(fmt.Sprintf("%*d", p.ColumnsWidth[col], event.IPVersion))
+			case "saddr":
+				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Saddr))
+			case "daddr":
+				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Daddr))
+			case "sport":
+				sb.WriteString(fmt.Sprintf("%*d", p.ColumnsWidth[col], event.Sport))
+			case "dport":
+				sb.WriteString(fmt.Sprintf("%*d", p.ColumnsWidth[col], event.Dport))
+			default:
+				continue
+			}
+
+			// Needed when field is larger than the predefined columnsWidth.
+			sb.WriteRune(' ')
+		}
+
+		return sb.String()
+	})
+}
+
+func GetTCPDefaultColumns() []string {
+	// The columns that will be used in case the user does not specify which
+	// specific columns they want to print through OutputConfig.
+	return []string{
+		"t",
+		"pid",
+		"comm",
+		"ip",
+		"saddr",
+		"daddr",
+		"sport",
+		"dport",
+	}
+}
+
+func NewTCPCmd(runCmd func(*cobra.Command, []string) error) *cobra.Command {
+	return &cobra.Command{
+		Use:   "tcp",
+		Short: "Trace tcp connect, accept and close",
+		RunE:  runCmd,
+	}
+}

--- a/cmd/local-gadget/trace/tcp.go
+++ b/cmd/local-gadget/trace/tcp.go
@@ -1,0 +1,49 @@
+// Copyright 2022 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package trace
+
+import (
+	"github.com/cilium/ebpf"
+	"github.com/spf13/cobra"
+
+	commontrace "github.com/kinvolk/inspektor-gadget/cmd/common/trace"
+	"github.com/kinvolk/inspektor-gadget/cmd/local-gadget/utils"
+	"github.com/kinvolk/inspektor-gadget/pkg/gadget-collection/gadgets/trace"
+	"github.com/kinvolk/inspektor-gadget/pkg/gadgets"
+	tcpTracer "github.com/kinvolk/inspektor-gadget/pkg/gadgets/trace/tcp/tracer"
+	tcpTypes "github.com/kinvolk/inspektor-gadget/pkg/gadgets/trace/tcp/types"
+)
+
+func newTCPCmd() *cobra.Command {
+	var commonFlags utils.CommonFlags
+
+	runCmd := func(*cobra.Command, []string) error {
+		tcpGadget := &TraceGadget[tcpTypes.Event]{
+			commonFlags: &commonFlags,
+			parser:      commontrace.NewTCPParserWithRuntimeInfo(&commonFlags.OutputConfig),
+			createAndRunTracer: func(mountnsmap *ebpf.Map, enricher gadgets.DataEnricher, eventCallback func(tcpTypes.Event)) (trace.Tracer, error) {
+				return tcpTracer.NewTracer(&tcpTracer.Config{MountnsMap: mountnsmap}, enricher, eventCallback)
+			},
+		}
+
+		return tcpGadget.Run()
+	}
+
+	cmd := commontrace.NewTCPCmd(runCmd)
+
+	utils.AddCommonFlags(cmd, &commonFlags)
+
+	return cmd
+}

--- a/cmd/local-gadget/trace/trace.go
+++ b/cmd/local-gadget/trace/trace.go
@@ -95,6 +95,7 @@ func NewTraceCmd() *cobra.Command {
 
 	traceCmd.AddCommand(newBindCmd())
 	traceCmd.AddCommand(newExecCmd())
+	traceCmd.AddCommand(newTCPCmd())
 
 	return traceCmd
 }

--- a/docs/local-gadget.md
+++ b/docs/local-gadget.md
@@ -226,6 +226,26 @@ calico-node      421056  sv
 gadget           421066  gadgettracerman
 ```
 
+### Trace/Tcp
+
+We can also monitor the TCP connections using the tcp trace gadget. For
+instance, with the following container we can see that the gadget shows that a
+TCP connection was established:
+
+```bash
+$ docker run -it --rm --name test-container busybox /bin/sh -c "wget https://www.example.com"
+Connecting to www.kinvolk.io (188.114.96.7:443)
+saving to 'index.html'
+index.html           100% |index.html           100% |**********************************| 36362  0:00:00 ETA
+'index.html' saved
+```
+
+```bash
+$ sudo local-gadget trace tcp
+CONTAINER        T  PID     COMM             IP  SADDR                  DADDR                  SPORT   DPORT
+test-container   C  11039   wget             4   172.17.0.2             188.114.96.7           57560   443
+```
+
 ## Interactive Mode
 
 The interactive mode allows us to create multiple traces at the same time.


### PR DESCRIPTION
# Add `tcp` trace gadget to local-gadget

This PR first moved the code that will be shared between `kubectl-gadget` and `local-gadget` to the `common` folder and updated `kubectl-gadget` properly. Then, it added the `tcp` trace gadget to the `local-gadget`, reusing such code. And finally, this PR updates the documentation in [docs/local-gadget.md](https://github.com/kinvolk/inspektor-gadget/blob/jose/use-tracers-for-tcp/docs/local-gadget.md#tracetcp).

This PR fixes https://github.com/kinvolk/inspektor-gadget/issues/894. 

## How to use

Run `local-gadget trace tcp`.

## Testing done

- [x] Verify there are no regressions on `kubectl-gadget trace tcp`.

```bash
$ ./kubectl-gadget trace tcp -A
NODE             NAMESPACE        POD                            CONTAINER        T  PID     COMM             IP  SADDR                  DADDR                  SPORT   DPORT
master           kube-system      kube-apiserver-master          kube-apiserver   A  1633    kube-apiserver   6   ::ffff:172.28.128.4    ::ffff:172.28.128.1    6443    56834
master           kube-system      kube-apiserver-master          kube-apiserver   A  1633    kube-apiserver   6   ::ffff:172.28.128.4    ::ffff:172.28.128.1    6443    56836
master           kube-system      kube-apiserver-master          kube-apiserver   C  1633    kube-apiserver   4   172.28.128.4           172.28.128.4           45138   10250
master           kube-system      kube-apiserver-master          kube-apiserver   C  1633    kube-apiserver   4   172.28.128.4           172.28.128.5           49652   10250
master           kube-system      kube-apiserver-master          kube-apiserver   A  1633    kube-apiserver   6   ::ffff:172.28.128.4    ::ffff:172.28.128.4    6443    46936
master           kube-system      kube-apiserver-master          kube-apiserver   X  1633    kube-apiserver   6   ::ffff:172.28.128.4    ::ffff:172.28.128.4    6443    46936
master           kube-system      coredns-78fcd69978-x47zw       coredns          A  5270    coredns          6   ::ffff:192.168.0.3     ::ffff:10.0.2.15       8080    39476
master           kube-system      coredns-78fcd69978-x47zw       coredns          X  5270    coredns          6   ::ffff:192.168.0.3     ::ffff:10.0.2.15       8080    39476
master           kube-system      coredns-78fcd69978-x47zw       coredns          C  5270    coredns          4   127.0.0.1              127.0.0.1              35634   8080
```
- [x] Check new `local-gadget trace tcp` is working properly and it is displaying all types of connections:

```bash
$ sudo /inspektor-gadget/local-gadget trace tcp
WARN[0000] Runtime enricher (cri-o): couldn't get current containers
CONTAINER        T  PID     COMM             IP  SADDR                  DADDR                  SPORT   DPORT
kube-apiserver   A  1633    kube-apiserver   6   ::ffff:172.28.128.4    ::ffff:172.28.128.4    6443    45914
kube-apiserver   X  1633    kube-apiserver   6   ::ffff:172.28.128.4    ::ffff:172.28.128.4    6443    45914
coredns          A  5270    coredns          6   ::ffff:192.168.0.3     ::ffff:10.0.2.15       8080    39390
coredns          X  5270    coredns          6   ::ffff:192.168.0.3     ::ffff:10.0.2.15       8080    39390

```
