### PR TITLE
probes: Don't set an internal timeout but rely on the probe's timeout

### DIFF
--- a/pkg/resources/manifests/deploy.yaml
+++ b/pkg/resources/manifests/deploy.yaml
@@ -121,6 +121,7 @@ spec:
                 - "/cleanup.sh"
         readinessProbe:
           periodSeconds: 5
+          timeoutSeconds: 2
           exec:
             command:
               - /bin/gadgettracermanager
@@ -128,6 +129,7 @@ spec:
         livenessProbe:
           initialDelaySeconds: 60
           periodSeconds: 5
+          timeoutSeconds: 2
           exec:
             command:
               - /bin/gadgettracermanager


### PR DESCRIPTION
# Don't set an internal timeout but rely on the probe's timeout

Currently, the probes will time out with the minimum value between `{livenessProbe|readinessProbe}.timeoutSeconds` and our internal `clientTimeout`. In fact, changing `timeoutSeconds` to any value larger than our 2 seconds doesn't have any effect, as 2 seconds is the internal timeout for the client that is performing the probe. The same happens in the oppose situation:

<details>
  <summary>Test 1 (clientTimeout < livenessProbe.timeoutSeconds) </summary>

**Condition**: `clientTimeout = 5` and `livenessProbe.timeoutSeconds = 10`
**Result**: The liveness probe failed after 5 seconds. 
**Pod events**:
```bash
Unhealthy          Liveness probe failed: Gadget Tracer Manager health RPC reached the timeout: 5s
```
**Kubelet logs**:
```bash
$ sudo journalctl -xeu kubelet  | grep -i <gadget-container-id>
# Empty
```

Note: For the sake of simplicity and clearness on logs, I disabled the readiness probe and set the livenessProbe.initialDelaySeconds = 10 and livenessProbe.periodSeconds = 7.

</details>

<details>
  <summary>Test 2 (clientTimeout > livenessProbe.timeoutSeconds) </summary>

**Condition**: `clientTimeout = 10` and `livenessProbe.timeoutSeconds = 3`
**Result**: The liveness probe failed after 3 seconds.
**Pod events**:
```bash
Unhealthy          Liveness probe failed:
```
**Kubelet logs**:
```bash
$ sudo journalctl -xeu kubelet  | grep -i <gadget-container-id>
Sep 14 08:09:59 master kubelet[678]: E0914 08:09:59.334825     678 remote_runtime.go:394] "ExecSync cmd from runtime service failed" err="rpc error: code = DeadlineExceeded desc = failed to exec in container: timeout 3s exceeded: context deadline exceeded" containerID="494f7c1ddaa76d5b3352de0aa25077334a532a32025a6d91d9678bba9e1fefb8" cmd=[/bin/gadgettracermanager -liveness]
```

Note: For the sake of simplicity and clearness on logs, I disabled the readiness probe and set the livenessProbe.initialDelaySeconds = 10 and livenessProbe.periodSeconds = 7.

</details>

With this commit, the idea is start relying on probe.timeoutSeconds, (which can be easily modified for testing) but keep using our internal client's timeout just as fallback, when the timeoutSeconds feature doesn't work, see https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes.

We discovered this problem while analysing https://github.com/kinvolk/inspektor-gadget/issues/940.

## How to use

This change doesn't impact the user as the timeout value continues to be 2 seconds.

## Testing done

To verify the behaviour, I used a "fake" implementation of the [`HealthServer` interface](https://pkg.go.dev/google.golang.org/grpc/health/grpc_health_v1#HealthServer) that never responds to the probe check so that we can trigger the timeout:

<details>
  <summary>Patch to test timeout</summary>

```golang
diff --git a/gadget-container/gadgettracermanager/main.go b/gadget-container/gadgettracermanager/main.go
index 3578d63a3a18..f05a041474d7 100644
--- a/gadget-container/gadgettracermanager/main.go
+++ b/gadget-container/gadgettracermanager/main.go
@@ -31,7 +31,6 @@ import (
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/health"
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/status"
 
@@ -82,6 +81,23 @@ func init() {
 	flag.BoolVar(&fallbackPodInformer, "fallback-podinformer", true, "Use pod informer as a fallback for main hook")
 }
 
+// FakeServer implements `service Health`.
+type FakeServer struct{}
+
+// Check implements `service Health`.
+func (s *FakeServer) Check(ctx context.Context, in *healthpb.HealthCheckRequest) (*healthpb.HealthCheckResponse, error) {
+	for {
+		log.Println("Stay busy")
+	}
+}
+
+// Watch implements `service Health`.
+func (s *FakeServer) Watch(in *healthpb.HealthCheckRequest, stream healthpb.Health_WatchServer) error {
+	for {
+		log.Println("Stay busy")
+	}
+}
+
 func main() {
 	flag.Parse()
 
@@ -240,7 +256,7 @@ func main() {
 
 		pb.RegisterGadgetTracerManagerServer(grpcServer, tracerManager)
 
-		healthserver := health.NewServer()
+		healthserver := &FakeServer{}
 		healthpb.RegisterHealthServer(grpcServer, healthserver)
 
 		log.Printf("Serving on gRPC socket %s", socketfile)
diff --git a/pkg/resources/manifests/deploy.yaml b/pkg/resources/manifests/deploy.yaml
index e55c8d6b450e..0c81bc05d79a 100644
--- a/pkg/resources/manifests/deploy.yaml
+++ b/pkg/resources/manifests/deploy.yaml
@@ -119,13 +119,13 @@ spec:
             exec:
               command:
                 - "/cleanup.sh"
-        readinessProbe:
-          periodSeconds: 5
-          timeoutSeconds: 2
-          exec:
-            command:
-              - /bin/gadgettracermanager
-              - -liveness
+        # readinessProbe:
+        #   periodSeconds: 5
+        #   timeoutSeconds: 2
+        #   exec:
+        #     command:
+        #       - /bin/gadgettracermanager
+        #       - -liveness
         livenessProbe:
           initialDelaySeconds: 60
           periodSeconds: 5
```
  
</details>

### Test timeoutSeconds

I measured the timing manually by monitoring when the liveness probe was actually called. I did that using the `local-gadget` in the node:
```bash
$ sudo /inspektor-gadget/local-gadget trace exec --containername gadget -o custom-columns=time,comm,args
TIME                    COMM                    ARGS
[...]
2022-09-15T09:33:05Z    gadgettracerman         /bin/gadgettracermanager -serve -hook-mode=auto -controller -fallback…
2022-09-15T09:33:19Z    gadgettracerman         /bin/gadgettracermanager -liveness
2022-09-15T09:33:24Z    gadgettracerman         /bin/gadgettracermanager -liveness
2022-09-15T09:33:29Z    gadgettracerman         /bin/gadgettracermanager -liveness
[...]

$ sudo /inspektor-gadget/local-gadget list-containers --no-trunc --containername gadget
RUNTIME       ID                                                                  NAME
containerd    b8e94b0e5297cb6d3f8a86b01c4fd8221628cadd9156036ca81e72accd95d01d    gadget
```

And check how much time passes from the entry on `local-gadget` until the `Unhealthy` event appears in pod events (2 secs, as expected):
```bash
$ kubectl get events --watch -n gadget -o custom-columns=TIME:.lastTimestamp,REASON:.reason,MSG:.message
TIME                   REASON             MSG
2022-09-15T09:33:04Z   SuccessfulCreate   Created pod: gadget-j5zht
[...]
2022-09-15T09:33:21Z   Unhealthy          Liveness probe failed:
2022-09-15T09:33:26Z   Unhealthy          Liveness probe failed:
2022-09-15T09:33:31Z   Unhealthy          Liveness probe failed:
2022-09-15T09:33:31Z   Killing            Container gadget failed liveness probe, will be restarted
[...]
```

Then, I confirmed the reason for the failure on the Kubelet logs:
```bash
$  sudo journalctl -xeu kubelet  | grep -i b8e94b0e5297cb6d3f8a86b01c4fd8221628cadd9156036ca81e72accd95d01d
Sep 15 09:33:21 master kubelet[678]: E0915 09:33:21.668307     678 remote_runtime.go:394] "ExecSync cmd from runtime service failed" err="rpc error: code = DeadlineExceeded desc = failed to exec in container: timeout 2s exceeded: context deadline exceeded" containerID="b8e94b0e5297cb6d3f8a86b01c4fd8221628cadd9156036ca81e72accd95d01d" cmd=[/bin/gadgettracermanager -liveness]
Sep 15 09:33:26 master kubelet[678]: E0915 09:33:26.643517     678 remote_runtime.go:394] "ExecSync cmd from runtime service failed" err="rpc error: code = DeadlineExceeded desc = failed to exec in container: timeout 2s exceeded: context deadline exceeded" containerID="b8e94b0e5297cb6d3f8a86b01c4fd8221628cadd9156036ca81e72accd95d01d" cmd=[/bin/gadgettracermanager -liveness]
Sep 15 09:33:31 master kubelet[678]: E0915 09:33:31.753226     678 remote_runtime.go:394] "ExecSync cmd from runtime service failed" err="rpc error: code = DeadlineExceeded desc = failed to exec in container: timeout 2s exceeded: context deadline exceeded" containerID="b8e94b0e5297cb6d3f8a86b01c4fd8221628cadd9156036ca81e72accd95d01d" cmd=[/bin/gadgettracermanager -liveness]
```

### Test internal timer (fallback)

To test this, I set a `livenessProbe.timeoutSeconds = 65` (any value larger than the internal timer we set to 1 min) and repeated the previous test:

```bash
$ kubectl get events --watch -n gadget -o custom-columns=TIME:.lastTimestamp,REASON:.reason,MSG:.message
[...]
2022-09-15T09:36:30Z   Unhealthy          Liveness probe failed: Gadget Tracer Manager health RPC reached the timeout: 1m0s
2022-09-15T09:37:30Z   Unhealthy          Liveness probe failed: Gadget Tracer Manager health RPC reached the timeout: 1m0s
2022-09-15T09:38:30Z   Unhealthy          Liveness probe failed: Gadget Tracer Manager health RPC reached the timeout: 1m0s
2022-09-15T09:38:30Z   Killing            Container gadget failed liveness probe, will be restarted
[...]
```
