### PR TITLE
probe: Set initial delay to 5 min using the startupProbe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -183,7 +183,6 @@ lint:
 		golangci/golangci-lint:v1.49.0 golangci-lint run --fix
 
 # minikube
-LIVENESS_PROBE_INITIAL_DELAY_SECONDS ?= 60
 LIVENESS_PROBE ?= true
 .PHONY: minikube-install
 minikube-install: gadget-default-container kubectl-gadget
@@ -205,7 +204,6 @@ minikube-install: gadget-default-container kubectl-gadget
 	# Remove all resources created by Inspektor Gadget.
 	./kubectl-gadget undeploy || true
 	./kubectl-gadget deploy --liveness-probe=$(LIVENESS_PROBE) \
-		--liveness-probe-initial-delay=$(LIVENESS_PROBE_INITIAL_DELAY_SECONDS) \
 		--image-pull-policy=Never
 	kubectl rollout status daemonset -n gadget gadget --timeout 30s
 	@echo "Image used by the gadget pod:"

--- a/cmd/kubectl-gadget/deploy.go
+++ b/cmd/kubectl-gadget/deploy.go
@@ -64,17 +64,16 @@ var deployCmd = &cobra.Command{
 var gadgetimage = "undefined"
 
 var (
-	image                     string
-	imagePullPolicy           string
-	hookMode                  string
-	livenessProbe             bool
-	livenessProbeInitialDelay int32
-	deployTimeout             time.Duration
-	fallbackPodInformer       bool
-	printOnly                 bool
-	quiet                     bool
-	debug                     bool
-	wait                      bool
+	image               string
+	imagePullPolicy     string
+	hookMode            string
+	livenessProbe       bool
+	deployTimeout       time.Duration
+	fallbackPodInformer bool
+	printOnly           bool
+	quiet               bool
+	debug               bool
+	wait                bool
 )
 
 func init() {
@@ -98,11 +97,6 @@ func init() {
 		"liveness-probe", "",
 		true,
 		"enable liveness probes")
-	deployCmd.PersistentFlags().Int32VarP(
-		&livenessProbeInitialDelay,
-		"liveness-probe-initial-delay", "",
-		60,
-		"liveness probes initial delay")
 	deployCmd.PersistentFlags().BoolVarP(
 		&fallbackPodInformer,
 		"fallback-podinformer", "",
@@ -314,8 +308,6 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 
 			if !livenessProbe {
 				gadgetContainer.LivenessProbe = nil
-			} else {
-				gadgetContainer.LivenessProbe.InitialDelaySeconds = livenessProbeInitialDelay
 			}
 
 			for i := range gadgetContainer.Env {

--- a/pkg/resources/manifests/deploy.yaml
+++ b/pkg/resources/manifests/deploy.yaml
@@ -127,9 +127,18 @@ spec:
               - /bin/gadgettracermanager
               - -liveness
         livenessProbe:
-          initialDelaySeconds: 60
           periodSeconds: 5
           timeoutSeconds: 2
+          exec:
+            command:
+              - /bin/gadgettracermanager
+              - -liveness
+        startupProbe:
+          periodSeconds: 5
+          timeoutSeconds: 2
+          # TODO: Decrease this long worse case startup time after fixing
+          # https://github.com/kinvolk/inspektor-gadget/issues/799.
+          failureThreshold: 60
           exec:
             command:
               - /bin/gadgettracermanager


### PR DESCRIPTION
# probe: Set initial delay to 5 min using the `startupProbe`

The current worse case startup time (77 sec) is not actually covering the worse case (3 minutes was reported in [#940](https://github.com/kinvolk/inspektor-gadget/issues/940)). Of course, we must investigate why the gadget pod takes so much time during the initialization ([#799](https://github.com/kinvolk/inspektor-gadget/issues/799)). But, in the meanwhile, to prevent users from completely disabling the liveness probe, this PR increases such time to 5 minutes using the `startupProbe`. I propose using the `startupProbe` instead of `livenessProbe.initialDelaySeconds`  because it allows us to avoid compromising the fast response to deadlocks that motivated us to introduce the liveness probe, as suggested [here](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-startup-probes).

## Testing done

Using the following patch, I verified that after 3 minutes (simulation of a very slow startup, as in [#940](https://github.com/kinvolk/inspektor-gadget/issues/940)), the gadget pod became ready, and Kubelet didn't restart it due to the `livenessProbe`.

```golang
diff --git a/gadget-container/gadgettracermanager/main.go b/gadget-container/gadgettracermanager/main.go
index 3578d63a3a18..bccb0e5b338b 100644
--- a/gadget-container/gadgettracermanager/main.go
+++ b/gadget-container/gadgettracermanager/main.go
@@ -213,6 +213,8 @@ func main() {
 	}
 
 	if serve {
+		time.Sleep(3 * time.Minute)
+
 		node := os.Getenv("NODE_NAME")
 		if node == "" {
 			log.Fatalf("Environment variable NODE_NAME not set")
```

## Impact (To be discussed)

Given that liveness and readiness probes are disabled until the `startupProbe` succeeds, this change also impacts the time the gadget pod requires to become ready. I made some tests, and the time increased by around 2/3 seconds. **Is it acceptable?**

<details>
  <summary>Current implementation without startupProbe (3 secs) </summary>

```bash
$ kubectl get pods -n gadget -o custom-columns=READY:.status.containerStatuses[*].ready --watch | ts '[%Y-%m-%d %H:%M:%S]'
[2022-09-14 16:33:27] READY
[2022-09-14 16:33:27] <none>
[2022-09-14 16:33:27] <none>
[2022-09-14 16:33:27] false
[2022-09-14 16:33:28] false
[2022-09-14 16:33:30] true
```
```bash
$ time ./kubectl-gadget deploy --image 192.168.1.105:5000/gadget:latest --image-pull-policy=Always
Creating Namespace/gadget...
[...]
Waiting for gadget pod(s) to be ready...
0/1 gadget pod(s) ready
1/1 gadget pod(s) ready
Inspektor Gadget successfully deployed

real    0m3,389s
user    0m0,103s
sys     0m0,007s
```

</details>

<details>
  <summary>After this PR, using the startupProbe (6 secs) </summary>

```bash
$ kubectl get pods -n gadget -o custom-columns=READY:.status.containerStatuses[*].ready --watch | ts '[%Y-%m-%d %H:%M:%S]'
[2022-09-14 16:31:05] READY
[2022-09-14 16:31:05] <none>
[2022-09-14 16:31:05] <none>
[2022-09-14 16:31:05] false
[2022-09-14 16:31:06] false
[2022-09-14 16:31:10] false
[2022-09-14 16:31:11] true
```

```bash
$ time ./kubectl-gadget deploy
Creating Namespace/gadget...
[...]
Waiting for gadget pod(s) to be ready...
0/1 gadget pod(s) ready
0/1 gadget pod(s) ready
1/1 gadget pod(s) ready
Inspektor Gadget successfully deployed

real    0m6,179s
user    0m0,071s
sys     0m0,029s
```

</details>

