### PR TITLE
integration-tests: Use the JSON mode to verify the gadgets' output

### DIFF
--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -2,6 +2,7 @@ name: Inspektor Gadget CI
 env:
   REGISTRY: ghcr.io
   CONTAINER_REPO: ${{ github.repository }}
+  GO_VERSION: 1.18.3
 concurrency:
   group: ${{ github.ref }}
   cancel-in-progress: true
@@ -29,7 +30,7 @@ jobs:
     - name: Setup go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.18.3
+        go-version: ${{ env.GO_VERSION }}
         cache: true
       id: go
     - name: Check if generated files are updated
@@ -46,7 +47,7 @@ jobs:
     - name: Setup go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.18.3
+        go-version: ${{ env.GO_VERSION }}
         cache: true
       id: go
     - name: Install debian packages
@@ -79,7 +80,7 @@ jobs:
     - name: Setup go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.18.3
+        go-version: ${{ env.GO_VERSION }}
         cache: true
       id: go
     - name: Install debian packages
@@ -136,7 +137,7 @@ jobs:
     - name: Setup go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.18.3
+        go-version: ${{ env.GO_VERSION }}
         cache: true
       id: go
     - name: Install debian packages
@@ -340,7 +341,7 @@ jobs:
     - name: Setup go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.18.3
+        go-version: ${{ env.GO_VERSION }}
         cache: true
     - name: Build example binaries
       run: |
@@ -357,7 +358,7 @@ jobs:
     - name: Setup go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.18.3
+        go-version: ${{ env.GO_VERSION }}
         cache: true
       id: go
     - name: Install debian packages
@@ -381,7 +382,7 @@ jobs:
     - name: Setup go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.18.3
+        go-version: ${{ env.GO_VERSION }}
         cache: true
       id: go
     - name: Install debian packages
@@ -474,7 +475,7 @@ jobs:
     - name: Setup go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.18.3
+        go-version: ${{ env.GO_VERSION }}
         cache: true
     - name: Authenticate and set ARO cluster context
       # NOTE: This action generates the Kubernetes config file in the current
@@ -514,7 +515,7 @@ jobs:
     - name: Setup go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.18.3
+        go-version: ${{ env.GO_VERSION }}
         cache: true
     - name: Setup Minikube
       uses: manusa/actions-setup-minikube@v2.4.3

--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -471,6 +471,11 @@ jobs:
       group: no-simultaneous-test-integration-aro
     steps:
     - uses: actions/checkout@v3
+    - name: Setup go
+      uses: actions/setup-go@v3
+      with:
+        go-version: 1.18.3
+        cache: true
     - name: Authenticate and set ARO cluster context
       # NOTE: This action generates the Kubernetes config file in the current
       # directory. Therefore, it must be run after checking out code otherwise
@@ -506,6 +511,11 @@ jobs:
         type: [default, core]
     steps:
     - uses: actions/checkout@v3
+    - name: Setup go
+      uses: actions/setup-go@v3
+      with:
+        go-version: 1.18.3
+        cache: true
     - name: Setup Minikube
       uses: manusa/actions-setup-minikube@v2.4.3
       with:

--- a/integration/command.go
+++ b/integration/command.go
@@ -56,6 +56,9 @@ type command struct {
 	// expectedRegexp contains a regex used to match against the command output.
 	expectedRegexp string
 
+	// expectedOutputFn is a function used to verify the output.
+	expectedOutputFn func(output string) error
+
 	// cleanup indicates this command is used to clean resource and should not be
 	// skipped even if previous commands failed.
 	cleanup bool
@@ -225,6 +228,13 @@ func (c *command) verifyOutput() error {
 	if c.expectedString != "" && output != c.expectedString {
 		return fmt.Errorf("output didn't match the expected string: %s\n%v\n%s",
 			c.expectedString, pretty.Diff(c.expectedString, output), getInspektorGadgetLogs())
+	}
+
+	if c.expectedOutputFn != nil {
+		if err := c.expectedOutputFn(output); err != nil {
+			return fmt.Errorf("verifying output with custom function: %w\n%s",
+				err, getInspektorGadgetLogs())
+		}
 	}
 
 	return nil

--- a/integration/helpers.go
+++ b/integration/helpers.go
@@ -1,0 +1,107 @@
+// Copyright 2022 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/google/go-cmp/cmp"
+
+	eventtypes "github.com/kinvolk/inspektor-gadget/pkg/types"
+)
+
+func parseOutput[T any](output string, normalize func(*T)) ([]*T, error) {
+	ret := []*T{}
+
+	scanner := bufio.NewScanner(strings.NewReader(output))
+	for scanner.Scan() {
+		var entry T
+
+		line := scanner.Text()
+		if err := json.Unmarshal([]byte(line), &entry); err != nil {
+			return nil, fmt.Errorf("unmarshaling line %q: %w", line, err)
+		}
+
+		// To be able to use reflect.DeepEqual and cmp.Diff, we need to
+		// "normalize" the output so that it only includes non-default values
+		// for the fields we are able to verify.
+		if normalize != nil {
+			normalize(&entry)
+		}
+
+		ret = append(ret, &entry)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("parsing output: %w", err)
+	}
+
+	return ret, nil
+}
+
+// expectAllToMatch verifies that the expectedEntry is matched by all the
+// entries in the output.
+func expectAllToMatch[T any](output string, normalize func(*T), expectedEntry *T) error {
+	entries, err := parseOutput(output, normalize)
+	if err != nil {
+		return err
+	}
+
+	for _, entry := range entries {
+		if !reflect.DeepEqual(expectedEntry, entry) {
+			return fmt.Errorf("unexpected output entry:\n%s",
+				cmp.Diff(expectedEntry, entry))
+		}
+	}
+
+	return nil
+}
+
+// expectEntriesToMatch verifies that all the entries in expectedEntries are
+// matched by at least one entry in the output.
+func expectEntriesToMatch[T any](output string, normalize func(*T), expectedEntries ...*T) error {
+	entries, err := parseOutput(output, normalize)
+	if err != nil {
+		return err
+	}
+
+out:
+	for _, expectedEntry := range expectedEntries {
+		for _, entry := range entries {
+			if reflect.DeepEqual(expectedEntry, entry) {
+				continue out
+			}
+		}
+		return fmt.Errorf("output doesn't contain the expected entry: %+v", expectedEntry)
+	}
+
+	return nil
+}
+
+func buildBaseEvent(namespace string) eventtypes.Event {
+	return eventtypes.Event{
+		Type: eventtypes.NORMAL,
+		CommonData: eventtypes.CommonData{
+			Namespace: namespace,
+			// Pod and Container name are defined by busyboxPodCommand.
+			Pod:       "test-pod",
+			Container: "test-pod",
+			// TODO: Include the Node
+		},
+	}
+}


### PR DESCRIPTION
# Use the JSON output mode in integration-tests

This PR starts using JSON instead of columns output mode in the integration-tests. It starts by implementing just some gadgets:
- Trace/Bind
- Trace/Exec
- Trace/Signal
- Trace/Tcp

Notice I had to upgrade the Go version for the integration-tests jobs because the helper functions created to verify the JSON output use generics, which was introduced in v1.18.

Fixes https://github.com/kinvolk/inspektor-gadget/issues/719.
