### PR TITLE
container-collection: Lazily enrich ownerReferences

### DIFF
--- a/examples/kube-container-collection/main.go
+++ b/examples/kube-container-collection/main.go
@@ -84,12 +84,12 @@ func callback(notif containercollection.PubSubEvent) {
 		if notif.Container.OciConfig != nil {
 			config, err := json.Marshal(notif.Container.OciConfig)
 			if err != nil {
-				publishEvent(&notif.Container, "CannotMarshalContainerConfig", err.Error())
+				publishEvent(notif.Container, "CannotMarshalContainerConfig", err.Error())
 			} else {
-				publishEvent(&notif.Container, "NewContainerConfig", string(config))
+				publishEvent(notif.Container, "NewContainerConfig", string(config))
 			}
 		} else {
-			publishEvent(&notif.Container, "ContainerConfigNotFound", "")
+			publishEvent(notif.Container, "ContainerConfigNotFound", "")
 		}
 	case containercollection.EventTypeRemoveContainer:
 		fmt.Printf("Container removed: %v pid %d\n", notif.Container.ID, notif.Container.Pid)

--- a/pkg/container-collection/container-collection.go
+++ b/pkg/container-collection/container-collection.go
@@ -24,6 +24,8 @@ package containercollection
 import (
 	"sync"
 
+	log "github.com/sirupsen/logrus"
+
 	eventtypes "github.com/kinvolk/inspektor-gadget/pkg/types"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -230,10 +232,15 @@ func (cc *ContainerCollection) LookupPIDByPod(namespace, pod string) map[string]
 // container identified by the mount namespace, or nil if not found
 func (cc *ContainerCollection) LookupOwnerReferenceByMntns(mntns uint64) *metav1.OwnerReference {
 	var ownerRef *metav1.OwnerReference
+	var err error
 	cc.containers.Range(func(key, value interface{}) bool {
 		c := value.(*Container)
 		if mntns == c.Mntns {
-			ownerRef = c.OwnerReference
+			ownerRef, err = c.GetOwnerReference()
+			if err != nil {
+				log.Warnf("Failed to get owner reference of %s/%s/%s: %s",
+					c.Namespace, c.Podname, c.Name, err)
+			}
 			// container found, stop iterating
 			return false
 		}

--- a/pkg/container-collection/container-collection.go
+++ b/pkg/container-collection/container-collection.go
@@ -97,7 +97,7 @@ initialContainersLoop:
 
 		cc.containers.Store(container.ID, container)
 		if cc.pubsub != nil {
-			cc.pubsub.Publish(EventTypeAddContainer, *container)
+			cc.pubsub.Publish(EventTypeAddContainer, container)
 		}
 	}
 	cc.initialContainers = nil
@@ -125,7 +125,7 @@ func (cc *ContainerCollection) RemoveContainer(id string) {
 	}
 
 	if cc.pubsub != nil {
-		cc.pubsub.Publish(EventTypeRemoveContainer, *v.(*Container))
+		cc.pubsub.Publish(EventTypeRemoveContainer, v.(*Container))
 	}
 }
 
@@ -145,7 +145,7 @@ func (cc *ContainerCollection) AddContainer(container *Container) {
 		return
 	}
 	if cc.pubsub != nil {
-		cc.pubsub.Publish(EventTypeAddContainer, *container)
+		cc.pubsub.Publish(EventTypeAddContainer, container)
 	}
 }
 
@@ -312,7 +312,7 @@ func (cc *ContainerCollection) Subscribe(key interface{}, selector ContainerSele
 	}
 	ret := []*Container{}
 	cc.pubsub.Subscribe(key, func(event PubSubEvent) {
-		if ContainerSelectorMatches(&selector, &event.Container) {
+		if ContainerSelectorMatches(&selector, event.Container) {
 			f(event)
 		}
 	}, func() {

--- a/pkg/container-collection/match_test.go
+++ b/pkg/container-collection/match_test.go
@@ -155,7 +155,7 @@ func TestContainerResolver(t *testing.T) {
 			Pid:        uint32(100 + i),
 			CgroupPath: "/none",
 			CgroupID:   1,
-			OwnerReference: &metav1.OwnerReference{
+			ownerReference: &metav1.OwnerReference{
 				UID: types.UID(fmt.Sprintf("abcde%d", i)),
 			},
 		})

--- a/pkg/container-collection/pubsub.go
+++ b/pkg/container-collection/pubsub.go
@@ -29,7 +29,7 @@ const (
 
 type PubSubEvent struct {
 	Type      EventType
-	Container Container
+	Container *Container
 }
 
 // GadgetPubSub provides a synchronous publish subscribe mechanism for gadgets
@@ -71,7 +71,7 @@ func (g *GadgetPubSub) Unsubscribe(key interface{}) {
 	delete(g.subs, key)
 }
 
-func (g *GadgetPubSub) Publish(eventType EventType, container Container) {
+func (g *GadgetPubSub) Publish(eventType EventType, container *Container) {
 	// Make a copy so we don't keep the lock while actually publishing
 	g.mu.RLock()
 	copiedSubs := []FuncNotify{}

--- a/pkg/container-collection/pubsub_test.go
+++ b/pkg/container-collection/pubsub_test.go
@@ -36,7 +36,7 @@ func TestPubSub(t *testing.T) {
 
 	p.Subscribe(key, callback, nil)
 
-	p.Publish(EventTypeRemoveContainer, Container{ID: "container1"})
+	p.Publish(EventTypeRemoveContainer, &Container{ID: "container1"})
 	_, ok := <-done
 	if !ok {
 		t.Fatalf("Failed to receive event from callback")
@@ -50,8 +50,40 @@ func TestPubSub(t *testing.T) {
 	}
 
 	p.Unsubscribe(key)
-	p.Publish(EventTypeRemoveContainer, Container{ID: "container2"})
+	p.Publish(EventTypeRemoveContainer, &Container{ID: "container2"})
 	if counter != 1 {
 		t.Fatalf("Callback called too many times")
+	}
+}
+
+func TestPubSubVerifyPointerToContainer(t *testing.T) {
+	p := NewGadgetPubSub()
+	if p == nil {
+		t.Fatalf("Failed to create new pubsub")
+	}
+
+	c := &Container{ID: "container1"}
+
+	var receivedC *Container
+
+	key := "callback1"
+	done := make(chan struct{}, 1)
+	callback := func(e PubSubEvent) {
+		receivedC = e.Container
+		done <- struct{}{}
+	}
+
+	p.Subscribe(key, callback, nil)
+	p.Publish(EventTypeAddContainer, c)
+
+	_, ok := <-done
+	if !ok {
+		t.Fatalf("Failed to receive event from callback")
+	}
+
+	p.Unsubscribe(key)
+
+	if receivedC != c {
+		t.Fatalf("Pointer doesn't correspond to original object")
 	}
 }

--- a/pkg/gadget-collection/gadgets/trace/dns/gadget.go
+++ b/pkg/gadget-collection/gadgets/trace/dns/gadget.go
@@ -199,9 +199,9 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 	containerEventCallback := func(event containercollection.PubSubEvent) {
 		switch event.Type {
 		case containercollection.EventTypeAddContainer:
-			attachContainerFunc(&event.Container)
+			attachContainerFunc(event.Container)
 		case containercollection.EventTypeRemoveContainer:
-			detachContainerFunc(&event.Container)
+			detachContainerFunc(event.Container)
 		}
 	}
 

--- a/pkg/gadget-collection/gadgets/trace/network/gadget.go
+++ b/pkg/gadget-collection/gadgets/trace/network/gadget.go
@@ -204,9 +204,9 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 	containerEventCallback := func(event containercollection.PubSubEvent) {
 		switch event.Type {
 		case containercollection.EventTypeAddContainer:
-			attachContainerFunc(&event.Container)
+			attachContainerFunc(event.Container)
 		case containercollection.EventTypeRemoveContainer:
-			detachContainerFunc(&event.Container)
+			detachContainerFunc(event.Container)
 		}
 	}
 

--- a/pkg/gadget-collection/gadgets/trace/sni/gadget.go
+++ b/pkg/gadget-collection/gadgets/trace/sni/gadget.go
@@ -225,9 +225,9 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 	containerEventCallback := func(event containercollection.PubSubEvent) {
 		switch event.Type {
 		case containercollection.EventTypeAddContainer:
-			attachContainerFunc(&event.Container)
+			attachContainerFunc(event.Container)
 		case containercollection.EventTypeRemoveContainer:
-			detachContainerFunc(&event.Container)
+			detachContainerFunc(event.Container)
 		}
 	}
 

--- a/pkg/gadgettracermanager/containers-map/tracer.go
+++ b/pkg/gadgettracermanager/containers-map/tracer.go
@@ -135,10 +135,10 @@ func (cm *ContainersMap) ContainersMapUpdater() containercollection.FuncNotify {
 				return
 			}
 
-			cm.addContainerInMap(&event.Container)
+			cm.addContainerInMap(event.Container)
 
 		case containercollection.EventTypeRemoveContainer:
-			cm.deleteContainerFromMap(&event.Container)
+			cm.deleteContainerFromMap(event.Container)
 		}
 	}
 }

--- a/pkg/tracer-collection/tracer-collection.go
+++ b/pkg/tracer-collection/tracer-collection.go
@@ -76,7 +76,7 @@ func (tc *TracerCollection) TracerMapsUpdater() containercollection.FuncNotify {
 			}
 
 			for _, t := range tc.tracers {
-				if containercollection.ContainerSelectorMatches(&t.containerSelector, &event.Container) {
+				if containercollection.ContainerSelectorMatches(&t.containerSelector, event.Container) {
 					mntnsC := uint64(event.Container.Mntns)
 					one := uint32(1)
 					if mntnsC != 0 {
@@ -89,7 +89,7 @@ func (tc *TracerCollection) TracerMapsUpdater() containercollection.FuncNotify {
 
 		case containercollection.EventTypeRemoveContainer:
 			for _, t := range tc.tracers {
-				if containercollection.ContainerSelectorMatches(&t.containerSelector, &event.Container) {
+				if containercollection.ContainerSelectorMatches(&t.containerSelector, event.Container) {
 					mntnsC := uint64(event.Container.Mntns)
 					t.mntnsSetMap.Delete(mntnsC)
 				}


### PR DESCRIPTION
https://github.com/kinvolk/inspektor-gadget/pull/435 added the owner reference to the container structure. However, collecting that information makes the start up of the gadget tracer manager slow. This PR changes the logic to only collect that information when needed. 

I applied the following patch to measure the time it takes to enrich each container:
<details>
  <summary>Patch</summary>

```diff
diff --git pkg/container-collection/container-collection.go pkg/container-collection/container-collection.go
index fe4a0344..a3c0a0eb 100644
--- pkg/container-collection/container-collection.go
+++ pkg/container-collection/container-collection.go
@@ -23,8 +23,10 @@ package containercollection
 
 import (
        "sync"
+       "time"
 
        eventtypes "github.com/kinvolk/inspektor-gadget/pkg/types"
+       log "github.com/sirupsen/logrus"
        metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -87,6 +89,8 @@ func (cc *ContainerCollection) Initialize(options ...ContainerCollectionOption)
        // been called, so that cc.containerEnrichers is fully set up.
 initialContainersLoop:
        for _, container := range cc.initialContainers {
+               start := time.Now()
+
                for _, enricher := range cc.containerEnrichers {
                        ok := enricher(container)
                        if !ok {
@@ -99,6 +103,11 @@ initialContainersLoop:
                if cc.pubsub != nil {
                        cc.pubsub.Publish(EventTypeAddContainer, *container)
                }
+
+               end := time.Now()
+               diff := end.Sub(start)
+
+               log.Infof("processing %s took %s", container.Name, diff)
        }
        cc.initialContainers = nil
```

</details>

Running in a node with 77 pods 

```
$ kubectl get pods -A | wc -l
77
```
I got these results:

### with this patch 

```
Starting the Gadget Tracer Manager...
time="2022-09-16T18:50:02Z" level=info msg="GadgetTracerManager: hook mode: fanotify (auto)"
[...]
time="2022-09-16T18:50:02Z" level=info msg="processing mypod12 took 114.696µs"
time="2022-09-16T18:50:02Z" level=info msg="processing mypod13 took 148.771µs"
time="2022-09-16T18:50:02Z" level=info msg="processing mypod14 took 139.964µs"
time="2022-09-16T18:50:02Z" level=info msg="processing mypod15 took 126.929µs
[...]
time="2022-09-16T18:50:02Z" level=info msg="Starting trace controller manager"
```

It takes some microseconds to enrich each container and less than a second between the first and last log messages.

### on main 

```
Starting the Gadget Tracer Manager...
time="2022-09-16T19:03:29Z" level=info msg="GadgetTracerManager: hook mode: fanotify (auto)"
[...]
time="2022-09-16T19:03:30Z" level=info msg="processing container took 399.44445ms"
time="2022-09-16T19:03:30Z" level=warning msg="container default/mypod10/mypod10 wasn't detected by the main hook! The fallback pod informer will add it."
time="2022-09-16T19:03:31Z" level=info msg="processing mypod1 took 400.321877ms"
time="2022-09-16T19:03:31Z" level=warning msg="container default/mypod16/mypod16 wasn't detected by the main hook! The fallback pod informer will add it."
time="2022-09-16T19:03:31Z" level=info msg="processing mypod10 took 399.076149ms"
time="2022-09-16T19:03:31Z" level=warning msg="container default/mypod24/mypod24 wasn't detected by the main hook! The fallback pod informer will add it."
time="2022-09-16T19:03:31Z" level=info msg="processing mypod11 took 400.723095ms"
[...]
time="2022-09-16T19:04:01Z" level=info msg="Starting trace controller manager"
```

Around 400ms are needed for each container and it takes 32 seconds from first to last log message. 

Fixes https://github.com/kinvolk/inspektor-gadget/issues/940.
Ref https://github.com/kinvolk/inspektor-gadget/issues/712 & https://github.com/kinvolk/inspektor-gadget/issues/799