### PR TITLE
ci: Bump libbpf-dev version

### DIFF
--- a/.github/actions/install-debian-packages/action.yml
+++ b/.github/actions/install-debian-packages/action.yml
@@ -4,7 +4,7 @@ description: "Install debian packages needed by inspektor-gadget"
 inputs:
   libbpf-version:
     description: "Version of the libbpf to install."
-    default: "1:0.4.0-1ubuntu1"
+    default: "1:0.5.0-1~ubuntu20.04.1"
   libseccomp-version:
     description: "Version of the libseccomp to install."
     default: "2.5.1-1ubuntu1~20.04.2"


### PR DESCRIPTION
The current CI version for libbpf-dev is failing for me in a fork without caching. This PR bumps the version to avoid the issue.

## Testing done
- Failed CI [run](https://github.com/mqasimsarfraz/inspektor-gadget/actions/runs/3090182879/jobs/4998660751)

