### PR TITLE
Implement local-gadget version of tcpconnect

### DIFF
--- a/cmd/common/trace/tcpconnect.go
+++ b/cmd/common/trace/tcpconnect.go
@@ -59,6 +59,10 @@ func NewTcpconnectParserWithK8sInfo(outputConfig *commonutils.OutputConfig) Trac
 	return newTcpconnectParser(outputConfig, commonutils.GetKubernetesColumns())
 }
 
+func NewTcpconnectParserWithRuntimeInfo(outputConfig *commonutils.OutputConfig) TraceParser[tcpconnectTypes.Event] {
+	return newTcpconnectParser(outputConfig, commonutils.GetContainerRuntimeColumns())
+}
+
 func (p *TcpconnectParser) TransformEvent(event *tcpconnectTypes.Event) string {
 	return p.Transform(event, func(event *tcpconnectTypes.Event) string {
 		var sb strings.Builder

--- a/cmd/local-gadget/trace/tcpconnect.go
+++ b/cmd/local-gadget/trace/tcpconnect.go
@@ -1,0 +1,49 @@
+// Copyright 2022 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package trace
+
+import (
+	"github.com/cilium/ebpf"
+	"github.com/spf13/cobra"
+
+	commontrace "github.com/kinvolk/inspektor-gadget/cmd/common/trace"
+	"github.com/kinvolk/inspektor-gadget/cmd/local-gadget/utils"
+	"github.com/kinvolk/inspektor-gadget/pkg/gadget-collection/gadgets/trace"
+	"github.com/kinvolk/inspektor-gadget/pkg/gadgets"
+	tcpconnectTracer "github.com/kinvolk/inspektor-gadget/pkg/gadgets/trace/tcpconnect/tracer"
+	tcpconnectTypes "github.com/kinvolk/inspektor-gadget/pkg/gadgets/trace/tcpconnect/types"
+)
+
+func newTcpconnectCmd() *cobra.Command {
+	var commonFlags utils.CommonFlags
+
+	runCmd := func(*cobra.Command, []string) error {
+		tcpconnectGadget := &TraceGadget[tcpconnectTypes.Event]{
+			commonFlags: &commonFlags,
+			parser:      commontrace.NewTcpconnectParserWithRuntimeInfo(&commonFlags.OutputConfig),
+			createAndRunTracer: func(mountnsmap *ebpf.Map, enricher gadgets.DataEnricher, eventCallback func(tcpconnectTypes.Event)) (trace.Tracer, error) {
+				return tcpconnectTracer.NewTracer(&tcpconnectTracer.Config{MountnsMap: mountnsmap}, enricher, eventCallback)
+			},
+		}
+
+		return tcpconnectGadget.Run()
+	}
+
+	cmd := commontrace.NewTcpconnectCmd(runCmd)
+
+	utils.AddCommonFlags(cmd, &commonFlags)
+
+	return cmd
+}

--- a/cmd/local-gadget/trace/trace.go
+++ b/cmd/local-gadget/trace/trace.go
@@ -96,6 +96,7 @@ func NewTraceCmd() *cobra.Command {
 	traceCmd.AddCommand(newBindCmd())
 	traceCmd.AddCommand(newExecCmd())
 	traceCmd.AddCommand(newTCPCmd())
+	traceCmd.AddCommand(newTcpconnectCmd())
 
 	return traceCmd
 }

--- a/docs/local-gadget.md
+++ b/docs/local-gadget.md
@@ -246,6 +246,24 @@ CONTAINER        T  PID     COMM             IP  SADDR                  DADDR   
 test-container   C  11039   wget             4   172.17.0.2             188.114.96.7           57560   443
 ```
 
+### Trace/TcpConnect
+
+The tcpconnect trace gadget traces IPv4 and IPv6 TCP connections.
+
+```bash
+$ docker run -it --rm --name test-container busybox /bin/sh -c "wget http://www.example.com"
+Connecting to www.example.com (93.184.216.34:80)
+saving to 'index.html'
+index.html           100% |************************************************************************************************|  1256  0:00:00 ETA
+'index.html' saved
+```
+
+```bash
+$ sudo local-gadget trace tcpconnect --containername test-container
+CONTAINER        PID     COMM             IP  SADDR            DADDR            DPORT
+test-container   503650  wget             4   172.17.0.3       93.184.216.34    80
+```
+
 ## Interactive Mode
 
 The interactive mode allows us to create multiple traces at the same time.


### PR DESCRIPTION
# Implement local-gadget version of tcpconnect

Add tcpconnect trace to local-gadget.
Resolves: https://github.com/kinvolk/inspektor-gadget/issues/895

## How to use

1. `sudo local-gadget trace tcpconnect`
2. `docker run -it --rm --name test-container busybox /bin/sh -c "wget http://www.example.com"`

## Testing done

Tested locally:
<img width="625" alt="image" src="https://user-images.githubusercontent.com/2948394/191310539-e34cd6ff-e5da-4d2a-b4b5-5ce48cf9b819.png">
