### PR TITLE
Fix typo in ebpf-objects-outside-docker Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ phony_explicit:
 ebpf-objects:
 	docker run --rm --name ebpf-object-builder --user $(shell id -u):$(shell id -g) -v $(shell pwd):/work ghcr.io/kinvolk/inspektor-gadget-ebpf-builder
 
-epbf-objects-outside-docker:
+ebpf-objects-outside-docker:
 	TARGET=arm64 go generate ./...
 	TARGET=amd64 go generate ./...
 


### PR DESCRIPTION
# Fix typo in ebpf-objects-outside-docker Makefile target

Rename "**_epbf_**-objects-outside-docker" to "**_ebpf_**-objects-outside-docker".

## How to use

`make ebpf-objects-outside-docker`

## Testing done

* Ran `make ebpf-objects-outside-docker`
* Grep'd the codebase for references to the command with the typo, but didn't find any.