### PR TITLE
trace/capabilities: Use *bool for InsetID

### DIFF
--- a/pkg/gadgets/trace/capabilities/tracer/tracer.go
+++ b/pkg/gadgets/trace/capabilities/tracer/tracer.go
@@ -25,7 +25,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"strconv"
 	"unsafe"
 
 	"github.com/cilium/ebpf"
@@ -225,7 +224,9 @@ func (t *Tracer) run() {
 		capOpt := int(eventC.cap_opt)
 
 		var audit int
-		var insetID int
+		true_ := true
+		false_ := false
+		var insetID *bool
 
 		if t.runningKernelVersion >= kernelVersion(5, 1, 0) {
 			audit = 0
@@ -233,18 +234,12 @@ func (t *Tracer) run() {
 				audit = 1
 			}
 
-			insetID = 0
+			insetID = &false_
 			if (capOpt & 0b100) != 0 {
-				insetID = 1
+				insetID = &true_
 			}
 		} else {
 			audit = capOpt
-			insetID = -1
-		}
-
-		insetString := "N/A"
-		if insetID != -1 {
-			insetString = strconv.Itoa(insetID)
 		}
 
 		verdict := "Deny"
@@ -261,7 +256,7 @@ func (t *Tracer) run() {
 			Cap:       int(eventC.cap),
 			UID:       uint32(eventC.uid),
 			Audit:     audit,
-			InsetID:   insetString,
+			InsetID:   insetID,
 			Comm:      C.GoString(&eventC.task[0]),
 			CapName:   capabilityName,
 			Verdict:   verdict,

--- a/pkg/gadgets/trace/capabilities/types/types.go
+++ b/pkg/gadgets/trace/capabilities/types/types.go
@@ -36,7 +36,7 @@ type Event struct {
 	CapName   string `json:"capName,omitempty"`
 	Cap       int    `json:"cap,omitempty"`
 	Audit     int    `json:"audit,omitempty"`
-	InsetID   string `json:"insetid,omitempty"`
+	InsetID   *bool  `json:"insetid,omitempty"`
 	Verdict   string `json:"verdict,omitempty"`
 }
 


### PR DESCRIPTION
InsetID represents the INSETID used in cap_capable() for kernel >= 5.1. It's possible to represent it by using *bool instead of string. nil indicates that the running kernel is < 5.1.

