### PR TITLE
integration-tests: Delete all seccompprofiles before deleting SPO

### DIFF
--- a/integration/command.go
+++ b/integration/command.go
@@ -157,7 +157,7 @@ var cleanupInspektorGadget *command = &command{
 var cleanupSPO *command = &command{
 	name: "RemoveSecurityProfilesOperator",
 	cmd: `
-	kubectl delete seccompprofile -n security-profiles-operator --all
+	kubectl delete seccompprofile --all --all-namespaces
 	kubectl delete -f https://raw.githubusercontent.com/kubernetes-sigs/security-profiles-operator/v0.4.3/deploy/operator.yaml
 	kubectl delete -f https://github.com/jetstack/cert-manager/releases/download/v1.8.0/cert-manager.yaml
 	`,


### PR DESCRIPTION
Currently, if SPO is deleted before all the seccompprofiles are removed we can run into situations where a profile will have a dangling finalizer. This PR makes sure we remove all the profiles first and then remove the SPO, avoiding a profile to be stuck on termination.

Fixes #724 

## Solution:
We saw all the integration-test runs on ARO [stuck](https://github.com/kinvolk/inspektor-gadget/actions/runs/3094483604/jobs/5008045840) forever and upon investigation we realized that the cluster had a `seccompprofile` stuck on termination. The root cause was a test creating a `seccompprofile` and if the SPO was deleted before test clean up we end up having the dangling profile because of unremoved finalizer. The clean up approach is taken from [here](https://github.com/kubernetes-sigs/security-profiles-operator/blob/main/installation-usage.md#uninstalling) as:

To uninstall, remove the profiles before removing the rest of the operator:

```sh
$ kubectl delete seccompprofiles --all --all-namespaces
$ kubectl delete -f https://raw.githubusercontent.com/kubernetes-sigs/security-profiles-operator/main/deploy/operator.yaml
```

## Testing done
### Before
- Run integration test:
```INTEGRATION_TESTS_PARAMS="-run TestAuditSeccomp -v" make IMAGE_TAG=latest integration-tests```
- Kill the test process as soon as we start running `TestAuditSeccomp`:
```kill -2 (pidof integration.test)```
- Test run will not cancel since local cluster has dangling profile.
### After
Cancellation and clean up are successful.