### PR TITLE
cmd/version: Additionally show server version

### DIFF
--- a/cmd/kubectl-gadget/version.go
+++ b/cmd/kubectl-gadget/version.go
@@ -15,12 +15,17 @@
 package main
 
 import (
+	"context"
 	"fmt"
+	"strings"
 
 	"github.com/blang/semver"
 	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	commonutils "github.com/kinvolk/inspektor-gadget/cmd/common/utils"
 	"github.com/kinvolk/inspektor-gadget/cmd/kubectl-gadget/utils"
+	"github.com/kinvolk/inspektor-gadget/pkg/k8sutil"
 )
 
 // This variable is used by the "version" command and is set during build.
@@ -35,7 +40,47 @@ func init() {
 var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Show version",
-	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println(version)
+	RunE: func(cmd *cobra.Command, args []string) error {
+		fmt.Println("Client version:", version)
+
+		client, err := k8sutil.NewClientsetFromConfigFlags(utils.KubernetesConfigFlags)
+		if err != nil {
+			return commonutils.WrapInErrSetupK8sClient(err)
+		}
+
+		opts := metav1.ListOptions{LabelSelector: "k8s-app=gadget"}
+		pods, err := client.CoreV1().Pods("gadget").List(context.TODO(), opts)
+		if err != nil {
+			return commonutils.WrapInErrListNodes(err)
+		}
+
+		serverVersions := make(map[string]struct{})
+		for _, pod := range pods.Items {
+			image := pod.Spec.Containers[0].Image
+
+			// Get the image tag
+			parts := strings.Split(image, ":")
+			if len(parts) < 2 {
+				continue
+			}
+
+			versionStr := parts[len(parts)-1]
+			if _, ok := serverVersions[versionStr]; !ok {
+				serverVersions[versionStr] = struct{}{}
+			}
+		}
+
+		if len(serverVersions) == 0 {
+			fmt.Println("Server version:", "not installed")
+		} else {
+			if len(serverVersions) > 1 {
+				fmt.Println("Warning: Multiple deployed versions detected")
+			}
+			for version := range serverVersions {
+				fmt.Println("Server version:", version)
+			}
+		}
+
+		return nil
 	},
 }


### PR DESCRIPTION
# `version` command outputs server version next to the client version

The `version` command now additionally outputs the deployed Inspektor Gadget version.
The information is from the deployed image-tag of the pods.
Solves https://github.com/kinvolk/inspektor-gadget/issues/902

## Testing done

_Versions are commit hashes, since these commits are not tagged._

```
➭ ./kubectl-gadget version
Client version: af1512e
Server version: v0.8.0
```

## Further possibilities
1. Additional message prompting the user to take action. For Example: `Please update Inspektor Gadget on the pods using kubectl gadget deploy`, ....