### PR TITLE
trace/bind: Use empty string for iface as default instead of "0"

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -361,7 +361,7 @@ func TestBindsnoop(t *testing.T) {
 				Addr:      "::",
 				Port:      9090,
 				Options:   ".R...",
-				Interface: "0",
+				Interface: "",
 			}
 
 			normalize := func(e *bindTypes.Event) {

--- a/pkg/gadgets/trace/bind/tracer/tracer.go
+++ b/pkg/gadgets/trace/bind/tracer/tracer.go
@@ -272,7 +272,7 @@ func (t *Tracer) run() {
 		addr := C.ip_to_string(eventC)
 		defer C.free(unsafe.Pointer(addr))
 
-		interfaceString := "0"
+		interfaceString := ""
 		interfaceNum := int(eventC.bound_dev_if)
 		if interfaceNum != 0 {
 			// It does exist a net link which index is 0.


### PR DESCRIPTION
The Interface field is the name of the interface that the socket is bound to. If the socket is not bound to any interface we can have an empty string as default.


