### PR TITLE
pkg/columns: add support for minWidth/maxWidth to help with auto-scaling

### DIFF
--- a/pkg/columns/columninfo_test.go
+++ b/pkg/columns/columninfo_test.go
@@ -244,45 +244,140 @@ func TestColumnsPrecision(t *testing.T) {
 
 func TestColumnsWidth(t *testing.T) {
 	type testSuccess1 struct {
-		FieldWidth int64 `column:"int,width:4"`
-	}
-	type testFail1 struct {
-		Field int64 `column:"fail,width"` // no param
-	}
-	type testFail2 struct {
-		Field int64 `column:"fail,width:"` // empty param
-	}
-	type testFail3 struct {
-		Field int64 `column:"fail,width:foo"` // invalid param
-	}
-	type testFail4 struct {
-		Field int64 `column:"fail,width:sum:bar"` // double param
+		FieldWidth     int64 `column:"int,width:4"`
+		FieldWidthType int64 `column:"intType,width:type"`
 	}
 
-	cols, err := NewColumns[testSuccess1]()
-	if err != nil {
-		t.Fatalf("failed to initialize: %v", err)
-	}
-	if col, ok := cols.GetColumn("int"); !ok || col.Width != 4 {
-		t.Errorf("expected column %q to have Width set to %d", "int", 4)
+	cols := expectColumnsSuccess[testSuccess1](t)
+	expectColumnValue(t, expectColumn(t, cols, "int"), "Width", 4)
+	expectColumnValue(t, expectColumn(t, cols, "intType"), "Width", MaxCharsInt64)
+
+	expectColumnsFail[struct {
+		Field int64 `column:"fail,width"`
+	}](t, "missing parameter")
+	expectColumnsFail[struct {
+		Field int64 `column:"fail,width:"`
+	}](t, "empty parameter")
+	expectColumnsFail[struct {
+		Field int64 `column:"fail,width:foo"`
+	}](t, "invalid parameter")
+	expectColumnsFail[struct {
+		Field int64 `column:"fail,width:sum:bar"`
+	}](t, "double parameter")
+}
+
+func TestColumnsMaxWidth(t *testing.T) {
+	type testSuccess1 struct {
+		FieldMaxWidth     int64 `column:"int,maxWidth:4"`
+		FieldMaxWidthType int64 `column:"intType,maxWidth:type"`
 	}
 
-	_, err = NewColumns[testFail1]()
-	if err == nil {
-		t.Errorf("succeeded to initialize but expected error")
+	cols := expectColumnsSuccess[testSuccess1](t)
+
+	expectColumnValue(t, expectColumn(t, cols, "int"), "MaxWidth", 4)
+	expectColumnValue(t, expectColumn(t, cols, "intType"), "MaxWidth", MaxCharsInt64)
+
+	expectColumnsFail[struct {
+		Field int64 `column:"fail,maxWidth"`
+	}](t, "missing parameter")
+	expectColumnsFail[struct {
+		Field int64 `column:"fail,maxWidth:"`
+	}](t, "empty parameter")
+	expectColumnsFail[struct {
+		Field int64 `column:"fail,maxWidth:foo"`
+	}](t, "invalid parameter")
+	expectColumnsFail[struct {
+		Field int64 `column:"fail,maxWidth:sum:bar"`
+	}](t, "double parameter")
+}
+
+func TestColumnsMinWidth(t *testing.T) {
+	type testSuccess1 struct {
+		FieldMinWidth     int64 `column:"int,minWidth:4"`
+		FieldMaxWidthType int64 `column:"intType,minWidth:type"`
 	}
-	_, err = NewColumns[testFail2]()
-	if err == nil {
-		t.Errorf("succeeded to initialize but expected error")
+
+	cols := expectColumnsSuccess[testSuccess1](t)
+	expectColumnValue(t, expectColumn(t, cols, "int"), "MinWidth", 4)
+	expectColumnValue(t, expectColumn(t, cols, "intType"), "MinWidth", MaxCharsInt64)
+
+	expectColumnsFail[struct {
+		Field int64 `column:"fail,minWidth"`
+	}](t, "missing parameter")
+	expectColumnsFail[struct {
+		Field int64 `column:"fail,minWidth:"`
+	}](t, "empty parameter")
+	expectColumnsFail[struct {
+		Field int64 `column:"fail,minWidth:foo"`
+	}](t, "invalid parameter")
+	expectColumnsFail[struct {
+		Field int64 `column:"fail,minWidth:sum:bar"`
+	}](t, "double parameter")
+}
+
+func TestColumnsWidthFromType(t *testing.T) {
+	type testSuccess1 struct {
+		Int8   int8   `column:",minWidth:type,maxWidth:type,width:type"`
+		Int16  int16  `column:",minWidth:type,maxWidth:type,width:type"`
+		Int32  int32  `column:",minWidth:type,maxWidth:type,width:type"`
+		Int64  int64  `column:",minWidth:type,maxWidth:type,width:type"`
+		Uint8  uint8  `column:",minWidth:type,maxWidth:type,width:type"`
+		Uint16 uint16 `column:",minWidth:type,maxWidth:type,width:type"`
+		Uint32 uint32 `column:",minWidth:type,maxWidth:type,width:type"`
+		Uint64 uint64 `column:",minWidth:type,maxWidth:type,width:type"`
+		Bool   bool   `column:",minWidth:type,maxWidth:type,width:type"`
 	}
-	_, err = NewColumns[testFail3]()
-	if err == nil {
-		t.Errorf("succeeded to initialize but expected error")
-	}
-	_, err = NewColumns[testFail4]()
-	if err == nil {
-		t.Errorf("succeeded to initialize but expected error")
-	}
+
+	cols := expectColumnsSuccess[testSuccess1](t)
+
+	col := expectColumn(t, cols, "int8")
+	expectColumnValue(t, col, "Width", MaxCharsInt8)
+	expectColumnValue(t, col, "MinWidth", MaxCharsInt8)
+	expectColumnValue(t, col, "MaxWidth", MaxCharsInt8)
+
+	col = expectColumn(t, cols, "int16")
+	expectColumnValue(t, col, "Width", MaxCharsInt16)
+	expectColumnValue(t, col, "MinWidth", MaxCharsInt16)
+	expectColumnValue(t, col, "MaxWidth", MaxCharsInt16)
+
+	col = expectColumn(t, cols, "int32")
+	expectColumnValue(t, col, "Width", MaxCharsInt32)
+	expectColumnValue(t, col, "MinWidth", MaxCharsInt32)
+	expectColumnValue(t, col, "MaxWidth", MaxCharsInt32)
+
+	col = expectColumn(t, cols, "int64")
+	expectColumnValue(t, col, "Width", MaxCharsInt64)
+	expectColumnValue(t, col, "MinWidth", MaxCharsInt64)
+	expectColumnValue(t, col, "MaxWidth", MaxCharsInt64)
+
+	col = expectColumn(t, cols, "uint8")
+	expectColumnValue(t, col, "Width", MaxCharsUint8)
+	expectColumnValue(t, col, "MinWidth", MaxCharsUint8)
+	expectColumnValue(t, col, "MaxWidth", MaxCharsUint8)
+
+	col = expectColumn(t, cols, "uint16")
+	expectColumnValue(t, col, "Width", MaxCharsUint16)
+	expectColumnValue(t, col, "MinWidth", MaxCharsUint16)
+	expectColumnValue(t, col, "MaxWidth", MaxCharsUint16)
+
+	col = expectColumn(t, cols, "uint32")
+	expectColumnValue(t, col, "Width", MaxCharsUint32)
+	expectColumnValue(t, col, "MinWidth", MaxCharsUint32)
+	expectColumnValue(t, col, "MaxWidth", MaxCharsUint32)
+
+	col = expectColumn(t, cols, "uint64")
+	expectColumnValue(t, col, "Width", MaxCharsUint64)
+	expectColumnValue(t, col, "MinWidth", MaxCharsUint64)
+	expectColumnValue(t, col, "MaxWidth", MaxCharsUint64)
+
+	col = expectColumn(t, cols, "bool")
+	expectColumnValue(t, col, "Width", MaxCharsBool)
+	expectColumnValue(t, col, "MinWidth", MaxCharsBool)
+	expectColumnValue(t, col, "MaxWidth", MaxCharsBool)
+
+	expectColumnsFail[struct {
+		String string `column:",minWidth:type,maxWidth:type,width:type"`
+	}](t, "invalid field type")
 }
 
 func TestWithoutColumnTag(t *testing.T) {

--- a/pkg/columns/columns_test.go
+++ b/pkg/columns/columns_test.go
@@ -24,16 +24,13 @@ func TestColumnMap(t *testing.T) {
 		StringField string `column:"stringField"`
 		IntField    int    `column:"intField"`
 	}
-	cols, err := NewColumns[testStruct]()
-	if err != nil {
-		t.Fatalf("could not initialize: %v", err)
-	}
+	cols := expectColumnsSuccess[testStruct](t)
 	columnMap := cols.GetColumnMap()
 	if _, ok := columnMap["stringfield"]; !ok {
-		t.Errorf("expected stringfield in column map")
+		t.Errorf("Expected stringfield in column map")
 	}
 	if _, ok := columnMap["intfield"]; !ok {
-		t.Errorf("expected stringfield in column map")
+		t.Errorf("Expected stringfield in column map")
 	}
 }
 
@@ -42,13 +39,10 @@ func TestEmptyStruct(t *testing.T) {
 		StringField string
 		IntField    int
 	}
-	cols, err := NewColumns[testStruct]()
-	if err != nil {
-		t.Fatalf("could not initialize: %v", err)
-	}
+	cols := expectColumnsSuccess[testStruct](t)
 	columnMap := cols.GetColumnMap()
 	if len(columnMap) != 0 {
-		t.Errorf("expected empty column map")
+		t.Errorf("Expected empty column map")
 	}
 }
 
@@ -57,19 +51,15 @@ func TestGetColumnNames(t *testing.T) {
 		StringField string `column:"stringField,order:500"`
 		IntField    int    `column:"intField,order:200"`
 	}
-	cols, err := NewColumns[testStruct]()
-	if err != nil {
-		t.Fatalf("could not initialize: %v", err)
-	}
-	ocols := cols.GetColumnNames()
+	ocols := expectColumnsSuccess[testStruct](t).GetColumnNames()
 	if len(ocols) != 2 {
-		t.Fatalf("expected two columns")
+		t.Fatalf("Expected two columns")
 	}
 	if ocols[0] != "intField" {
-		t.Errorf("expected first entry to be intField")
+		t.Errorf("Expected first entry to be intField")
 	}
 	if ocols[1] != "stringField" {
-		t.Errorf("expected second entry to be stringField")
+		t.Errorf("Expected second entry to be stringField")
 	}
 }
 
@@ -78,19 +68,15 @@ func TestGetSortedColumns(t *testing.T) {
 		StringField string `column:"stringField,order:500"`
 		IntField    int    `column:"intField,order:200"`
 	}
-	cols, err := NewColumns[testStruct]()
-	if err != nil {
-		t.Fatalf("could not initialize: %v", err)
-	}
-	ocols := cols.GetOrderedColumns()
+	ocols := expectColumnsSuccess[testStruct](t).GetOrderedColumns()
 	if len(ocols) != 2 {
-		t.Fatalf("expected two columns")
+		t.Fatalf("Expected two columns")
 	}
 	if ocols[0].Name != "intField" {
-		t.Errorf("expected first entry to be intField")
+		t.Errorf("Expected first entry to be intField")
 	}
 	if ocols[1].Name != "stringField" {
-		t.Errorf("expected second entry to be stringField")
+		t.Errorf("Expected second entry to be stringField")
 	}
 }
 
@@ -103,93 +89,78 @@ func TestGetters(t *testing.T) {
 		StringField string `column:"stringField"`
 		IntField    int    `column:"intField"`
 	}
-	cols, err := NewColumns[testStruct]()
-	if err != nil {
-		t.Fatalf("could not initialize: %v", err)
-	}
+	cols := expectColumnsSuccess[testStruct](t)
 
 	// String tests
-	col, ok := cols.GetColumn("StRiNgFiElD")
-	if !ok {
-		t.Errorf("expected to get valid column")
-	}
+	col := expectColumn(t, cols, "StRiNgFiElD")
 	if col.Kind() != reflect.String {
-		t.Errorf("expected Kind() to be reflect.String")
+		t.Errorf("Expected Kind() to be reflect.String")
 	}
 
-	_, ok = col.Get(nil).Interface().(string)
+	_, ok := col.Get(nil).Interface().(string)
 	if !ok {
-		t.Errorf("expected returned value to be of type string")
+		t.Errorf("Expected returned value to be of type string")
 	}
 	str, ok := col.Get(&testStruct{StringField: "demo"}).Interface().(string)
 	if !ok {
-		t.Errorf("expected returned value to be of type string")
+		t.Errorf("Expected returned value to be of type string")
 	}
 	if str != "demo" {
-		t.Errorf("expected returned value to be string 'demo'")
+		t.Errorf("Expected returned value to be string 'demo'")
 	}
 	// Raw access should return the same
 	str, ok = col.GetRaw(&testStruct{StringField: "demo"}).Interface().(string)
 	if !ok {
-		t.Errorf("expected returned value to be of type string")
+		t.Errorf("Expected returned value to be of type string")
 	}
 	if str != "demo" {
-		t.Errorf("expected returned value to be string 'demo'")
+		t.Errorf("Expected returned value to be string 'demo'")
 	}
 
 	// Int tests
-	col, ok = cols.GetColumn("InTfIeLd")
-	if !ok {
-		t.Errorf("expected to get valid column")
-	}
+	col = expectColumn(t, cols, "InTfIeLd")
 
 	i, ok := col.Get(&testStruct{IntField: 5}).Interface().(int)
 	if !ok {
-		t.Errorf("expected returned value to be of type int")
+		t.Errorf("Expected returned value to be of type int")
 	}
 	if i != 5 {
-		t.Errorf("expected returned value to be int with value 5")
+		t.Errorf("Expected returned value to be int with value 5")
 	}
 
 	_, ok = cols.GetColumn("uNkNoWn")
 	if ok {
-		t.Errorf("expected no column")
+		t.Errorf("Expected no column")
 	}
 
 	// Embedded string tests
-	col, ok = cols.GetColumn("embeddedstring")
-	if !ok {
-		t.Errorf("expected to get valid column")
-	}
+	col = expectColumn(t, cols, "embeddedstring")
 
 	_, ok = col.Get(nil).Interface().(string)
 	if !ok {
-		t.Errorf("expected returned value to be of type string")
+		t.Errorf("Expected returned value to be of type string")
 	}
 	str, ok = col.Get(&testStruct{embeddedStruct: embeddedStruct{EmbeddedString: "demo"}}).Interface().(string)
 	if !ok {
-		t.Errorf("expected returned value to be of type string")
+		t.Errorf("Expected returned value to be of type string")
 	}
 	if str != "demo" {
-		t.Errorf("expected returned value to be string 'demo'")
+		t.Errorf("Expected returned value to be string 'demo'")
 	}
 
 	// Reflection access
 	refStruct := reflect.ValueOf(&testStruct{embeddedStruct: embeddedStruct{EmbeddedString: "demo"}})
 	str, ok = col.GetRef(refStruct).Interface().(string)
 	if !ok {
-		t.Errorf("expected returned value to be of type string")
+		t.Errorf("Expected returned value to be of type string")
 	}
 	if str != "demo" {
-		t.Errorf("expected returned value to be string 'demo'")
+		t.Errorf("Expected returned value to be string 'demo'")
 	}
 }
 
 func TestInvalidType(t *testing.T) {
-	_, err := NewColumns[int]()
-	if err == nil {
-		t.Errorf("expected error trying to initialize on non-struct")
-	}
+	expectColumnsFail[int](t, "non-struct type int")
 }
 
 func TestMustCreateHelper(t *testing.T) {
@@ -200,7 +171,7 @@ func TestMustCreateHelper(t *testing.T) {
 
 	defer func() {
 		if err := recover(); err == nil {
-			t.Errorf("expected panic")
+			t.Errorf("Expected panic")
 		}
 	}()
 	MustCreateColumns[int]()
@@ -210,12 +181,9 @@ func TestExtractor(t *testing.T) {
 	type testStruct struct {
 		StringField string `column:"stringField"`
 	}
-	cols, err := NewColumns[testStruct]()
-	if err != nil {
-		t.Fatalf("could not initialize: %v", err)
-	}
+	cols := expectColumnsSuccess[testStruct](t)
 
-	err = cols.SetExtractor("sTrInGfIeLd", func(t *testStruct) string {
+	err := cols.SetExtractor("sTrInGfIeLd", func(t *testStruct) string {
 		return "empty"
 	})
 	if err != nil {
@@ -226,12 +194,12 @@ func TestExtractor(t *testing.T) {
 		return "empty"
 	})
 	if err == nil {
-		t.Errorf("expected error when setting extractor on non-existing field")
+		t.Errorf("Expected error when setting extractor on non-existing field")
 	}
 
 	err = cols.SetExtractor("sTrInGfIeLd", nil)
 	if err == nil {
-		t.Errorf("expected error when setting nil-extractor")
+		t.Errorf("Expected error when setting nil-extractor")
 	}
 }
 
@@ -240,16 +208,13 @@ func TestVirtualColumns(t *testing.T) {
 		StringField string `column:"stringField"`
 	}
 
-	cols, err := NewColumns[testStruct]()
-	if err != nil {
-		t.Fatalf("could not initialize: %v", err)
-	}
+	cols := expectColumnsSuccess[testStruct](t)
 
-	err = cols.AddColumn(Column[testStruct]{
+	err := cols.AddColumn(Column[testStruct]{
 		Name: "vcol",
 	})
 	if err == nil {
-		t.Errorf("expected error when adding column without extractor func")
+		t.Errorf("Expected error when adding column without extractor func")
 	}
 
 	err = cols.AddColumn(Column[testStruct]{
@@ -258,7 +223,7 @@ func TestVirtualColumns(t *testing.T) {
 		},
 	})
 	if err == nil {
-		t.Errorf("expected error when adding column without name")
+		t.Errorf("Expected error when adding column without name")
 	}
 
 	err = cols.AddColumn(Column[testStruct]{
@@ -268,7 +233,7 @@ func TestVirtualColumns(t *testing.T) {
 		},
 	})
 	if err == nil {
-		t.Errorf("expected error when adding column with already existing name")
+		t.Errorf("Expected error when adding column with already existing name")
 	}
 
 	err = cols.AddColumn(Column[testStruct]{
@@ -281,38 +246,35 @@ func TestVirtualColumns(t *testing.T) {
 		t.Errorf("could not add virtual column")
 	}
 
-	col, ok := cols.GetColumn("foobar")
+	col := expectColumn(t, cols, "foobar")
+	_, ok := col.Get(nil).Interface().(string)
 	if !ok {
-		t.Errorf("expected to get the virtual column")
-	}
-	_, ok = col.Get(nil).Interface().(string)
-	if !ok {
-		t.Errorf("expected returned value to be of type string")
+		t.Errorf("Expected returned value to be of type string")
 	}
 	str, ok := col.Get(&testStruct{}).Interface().(string)
 	if !ok {
-		t.Errorf("expected returned value to be of type string")
+		t.Errorf("Expected returned value to be of type string")
 	}
 	if str != "FooBar" {
-		t.Errorf("expected returned value to be string 'FooBar'")
+		t.Errorf("Expected returned value to be string 'FooBar'")
 	}
 
 	// Test GetRef also
 	str, ok = col.GetRef(reflect.ValueOf(&testStruct{})).Interface().(string)
 	if !ok {
-		t.Errorf("expected returned value to be of type string")
+		t.Errorf("Expected returned value to be of type string")
 	}
 	if str != "FooBar" {
-		t.Errorf("expected returned value to be string 'FooBar'")
+		t.Errorf("Expected returned value to be string 'FooBar'")
 	}
 
 	// Raw access should return an empty string
 	str, ok = col.GetRaw(&testStruct{}).Interface().(string)
 	if !ok {
-		t.Errorf("expected returned value to be of type string")
+		t.Errorf("Expected returned value to be of type string")
 	}
 	if str != "" {
-		t.Errorf("expected empty string when calling GetRaw() on a virtual column")
+		t.Errorf("Expected empty string when calling GetRaw() on a virtual column")
 	}
 }
 
@@ -322,16 +284,13 @@ func TestVerifyColumnNames(t *testing.T) {
 		IntField    string `column:"intField"`
 	}
 
-	cols, err := NewColumns[testStruct]()
-	if err != nil {
-		t.Fatalf("could not initialize: %v", err)
-	}
+	cols := expectColumnsSuccess[testStruct](t)
 
 	valid, invalid := cols.VerifyColumnNames([]string{"-stringField", "intField", "notExistingField", "notExistingField2"})
 	if len(valid) != 2 {
-		t.Errorf("expected VerifyColumnNames to return 2 valid entries")
+		t.Errorf("Expected VerifyColumnNames to return 2 valid entries")
 	}
 	if len(invalid) != 2 {
-		t.Errorf("expected VerifyColumnNames to return 2 invalid entries")
+		t.Errorf("Expected VerifyColumnNames to return 2 invalid entries")
 	}
 }

--- a/pkg/columns/filter.go
+++ b/pkg/columns/filter.go
@@ -54,31 +54,20 @@ func WithEmbedded(embedded bool) ColumnFilter {
 
 // WithTags makes sure that all returned columns contain all the given tags
 func WithTags(tags []string) ColumnFilter {
-	for i := range tags {
-		tags[i] = strings.ToLower(tags[i])
-	}
-	numTags := len(tags)
+	tags = ToLowerStrings(tags)
 	return func(matcher ColumnMatcher) bool {
-		marked := make([]bool, numTags)
-		count := 0
-		for i, tag := range tags {
-			if !marked[i] && matcher.HasTag(tag) {
-				count++
-				marked[i] = true
-				if count == numTags {
-					return true
-				}
+		for _, tag := range tags {
+			if !matcher.HasTag(tag) {
+				return false
 			}
 		}
-		return false
+		return true
 	}
 }
 
 // WithoutTags makes sure that all returned columns contain none of the given tags
 func WithoutTags(tags []string) ColumnFilter {
-	for i := range tags {
-		tags[i] = strings.ToLower(tags[i])
-	}
+	tags = ToLowerStrings(tags)
 	return func(matcher ColumnMatcher) bool {
 		for _, tag := range tags {
 			if matcher.HasTag(tag) {

--- a/pkg/columns/filter/filter_test.go
+++ b/pkg/columns/filter/filter_test.go
@@ -249,7 +249,7 @@ func TestFilters(t *testing.T) {
 
 	cols, err := columns.NewColumns[testData]()
 	if err != nil {
-		t.Errorf("failed to initialize: %v", err)
+		t.Errorf("Failed to initialize: %v", err)
 	}
 
 	cmap := cols.GetColumnMap()
@@ -257,7 +257,7 @@ func TestFilters(t *testing.T) {
 	t.Run("test empty input", func(t *testing.T) {
 		res, err := FilterEntries(cmap, nil, []string{""})
 		if err != nil || res != nil {
-			t.Errorf("expected returned entries and err to be nil")
+			t.Errorf("Expected returned entries and err to be nil")
 		}
 	})
 
@@ -265,13 +265,13 @@ func TestFilters(t *testing.T) {
 		t.Run(filterTest.description, func(t *testing.T) {
 			out, err := FilterEntries(cmap, filterEntries, []string{filterTest.filterString})
 			if err != nil && !filterTest.expectError {
-				t.Errorf("unexpected error: %v", err)
+				t.Errorf("Unexpected error: %v", err)
 			}
 			if err == nil && filterTest.expectError {
-				t.Errorf("expected error")
+				t.Errorf("Expected error")
 			}
 			if len(out) != filterTest.expectedCount {
-				t.Errorf("expected %d entries, got %d", filterTest.expectedCount, len(out))
+				t.Errorf("Expected %d entries, got %d", filterTest.expectedCount, len(out))
 			}
 		})
 	}
@@ -281,6 +281,19 @@ func TestFilters(t *testing.T) {
 		t.Errorf("failed to get filter: %v", err)
 	}
 	if filter.Match(nil) {
-		t.Errorf("matching nil on non-negated filter should result in false")
+		t.Errorf("Matching nil on non-negated filter should result in false")
 	}
+
+	t.Run("multiple filters", func(t *testing.T) {
+		out, err := FilterEntries(cmap, filterEntries, []string{"int:1", "int8:1", "string:Demo 123"})
+		if err != nil {
+			t.Errorf("Unexpected error: %v", err)
+		}
+		if len(out) != 1 {
+			t.Fatalf("Expected %d entries, got %d", 1, len(out))
+		}
+		if out[0].Int != 1 {
+			t.Errorf("Expected another entry")
+		}
+	})
 }

--- a/pkg/columns/formatter/textcolumns/options_test.go
+++ b/pkg/columns/formatter/textcolumns/options_test.go
@@ -27,26 +27,26 @@ func TestOptions(t *testing.T) {
 
 	WithAutoScale(true)(opts)
 	if !opts.AutoScale {
-		t.Errorf("expected AutoScale to be true")
+		t.Errorf("Expected AutoScale to be true")
 	}
 
 	WithColumnDivider("X")(opts)
 	if opts.ColumnDivider != "X" {
-		t.Errorf("expected ColumnDivider to be X")
+		t.Errorf("Expected ColumnDivider to be X")
 	}
 
 	WithDefaultColumns([]string{"abc"})(opts)
 	if len(opts.DefaultColumns) != 1 || opts.DefaultColumns[0] != "abc" {
-		t.Errorf("expected DefaultColumns to have exactly 'abc' as value")
+		t.Errorf("Expected DefaultColumns to have exactly 'abc' as value")
 	}
 
 	WithHeaderStyle(HeaderStyleLowercase)(opts)
 	if opts.HeaderStyle != HeaderStyleLowercase {
-		t.Errorf("expected HeaderStyle to be HeaderStyleLowercase")
+		t.Errorf("Expected HeaderStyle to be HeaderStyleLowercase")
 	}
 
 	WithRowDivider("X")(opts)
 	if opts.RowDivider != "X" {
-		t.Errorf("expected RowDivider to be X")
+		t.Errorf("Expected RowDivider to be X")
 	}
 }

--- a/pkg/columns/formatter/textcolumns/output.go
+++ b/pkg/columns/formatter/textcolumns/output.go
@@ -61,6 +61,9 @@ func (tf *TextColumnsFormatter[T]) setFormatter(column *Column[T]) {
 }
 
 func (tf *TextColumnsFormatter[T]) buildFixedString(s string, length int, ellipsisType ellipsis.EllipsisType, alignment columns.Alignment) string {
+	if length <= 0 {
+		return ""
+	}
 	rs := []rune(s)
 
 	shortened := ellipsis.Shorten(rs, length, ellipsisType)
@@ -133,15 +136,34 @@ func (tf *TextColumnsFormatter[T]) FormatRowDivider() string {
 
 // WriteTable writes header, divider and body with the current settings, where the body consists of the entries given
 // to the writer
-func (tf *TextColumnsFormatter[T]) WriteTable(writer io.Writer, entries []*T) {
-	writer.Write([]byte(tf.FormatHeader()))
-	writer.Write([]byte("\n"))
+func (tf *TextColumnsFormatter[T]) WriteTable(writer io.Writer, entries []*T) error {
+	_, err := writer.Write([]byte(tf.FormatHeader()))
+	if err != nil {
+		return err
+	}
+	_, err = writer.Write([]byte("\n"))
+	if err != nil {
+		return err
+	}
 	if tf.options.RowDivider != DividerNone {
-		writer.Write([]byte(tf.FormatRowDivider()))
-		writer.Write([]byte("\n"))
+		_, err = writer.Write([]byte(tf.FormatRowDivider()))
+		if err != nil {
+			return err
+		}
+		_, err = writer.Write([]byte("\n"))
+		if err != nil {
+			return err
+		}
 	}
 	for _, entry := range entries {
-		writer.Write([]byte(tf.FormatEntry(entry)))
-		writer.Write([]byte("\n"))
+		_, err = writer.Write([]byte(tf.FormatEntry(entry)))
+		if err != nil {
+			return err
+		}
+		_, err = writer.Write([]byte("\n"))
+		if err != nil {
+			return err
+		}
 	}
+	return nil
 }

--- a/pkg/columns/formatter/textcolumns/scaler.go
+++ b/pkg/columns/formatter/textcolumns/scaler.go
@@ -32,83 +32,161 @@ func (tf *TextColumnsFormatter[T]) RecalculateWidths(maxWidth int, force bool) {
 		return
 	}
 
-	if len(tf.showColumns) == 0 {
-		return
-	}
-
-	// calculate the minimum required length - else we could get negative values on auto-scaling
-	requiredWidth := (len(tf.showColumns) - 1) * len([]rune(tf.options.ColumnDivider))
-	if force {
-		requiredWidth += len(tf.showColumns)
-	} else {
-		for _, column := range tf.showColumns {
-			if column.col.FixedWidth {
-				requiredWidth += column.col.Width
-				continue
-			}
-			requiredWidth++
-		}
-	}
-
-	// enforce the requiredWidth
-	if requiredWidth > maxWidth {
-		maxWidth = requiredWidth
-	}
-
+	// set for caching (to avoid recalculation)
 	tf.currentMaxWidth = maxWidth
 
-	// Get total width of all printed columns
-	totalWidth := 0
-	spaces := 0
-	for i, column := range tf.showColumns {
-		if i > 0 {
-			spaces += len([]rune(tf.options.ColumnDivider))
-		}
-		if column.col.FixedWidth && !force {
-			spaces += column.col.Width
-			continue
-		}
-		totalWidth += column.col.Width
+	if len(tf.showColumns) == 0 {
+		return
 	}
 
 	// Keep count of occurrences (needed when redistributing leftover space)
 	occurrences := make(map[string]int)
 
-	// Adjust width
-	totalAdjustedWidth := 0
+	// width of all dividers between the columns
+	dividerWidth := (len(tf.showColumns) - 1) * len([]rune(tf.options.ColumnDivider))
+
+	// calculate the minimum required length (that is: length of dividers plus width (in case it's fixed or MinWidth is
+	// set) or one character (if no width was specified)) - else we could get negative values on auto-scaling
+	requiredWidth := dividerWidth
+
+	// totalWidthNotFixed will contain all columns that haven't been set to "fixed"
+	totalWidthNotFixed := 0
+
+	// totalWidthFixed will contain dividers and all columns that have either been set to "fixed" (or in a later pass
+	// have minWidth or maxWidth constraints)
+	totalWidthFixed := dividerWidth
+
 	for _, column := range tf.showColumns {
+		// Reset temporary values
+		column.treatAsFixed = false
+
+		occurrences[column.col.Name]++
+
 		if column.col.FixedWidth && !force {
-			column.calculatedWidth = column.col.Width
+			requiredWidth += column.col.Width
+			totalWidthFixed += column.col.Width
 			continue
 		}
-		occurrences[column.col.Name]++
-		column.calculatedWidth = int(math.Floor(float64(column.col.Width) / float64(totalWidth) * float64(maxWidth-spaces)))
-		totalAdjustedWidth += column.calculatedWidth
-	}
 
-	// Handle leftover space
-	leftover := maxWidth - (totalAdjustedWidth + spaces)
-	for {
-		if leftover == 0 {
-			break
+		totalWidthNotFixed += column.col.Width
+
+		if column.col.MinWidth > 0 && !force {
+			requiredWidth += column.col.MinWidth
+			continue
 		}
 
-		spent := false
+		// at least account one character per column
+		requiredWidth++
+	}
 
-		// distribute
+	// if force is set, we only account one character per column plus dividers
+	if force {
+		requiredWidth = dividerWidth + len(tf.showColumns)
+	}
+
+	// enforce at least having requiredWidth (we need to ignore maxWidth in this case)
+	if requiredWidth > maxWidth {
+		maxWidth = requiredWidth
+	}
+
+	// totalAdjustedWidthNotFixed stores the combined widths of all fields that have been scaled
+	var totalAdjustedWidthNotFixed int
+
+	// we might need to do several passes to satisfy the constraints
+	for {
+		satisfied := true
+
+		// collect deltas when moving columns from nonFixed to fixed because of exceeding their constraints
+		addToFixed := 0
+		removeFromNotFixed := 0
+
+		totalAdjustedWidthNotFixed = 0
 		for _, column := range tf.showColumns {
-			if column.col.FixedWidth && !force {
+			if (column.col.FixedWidth || column.treatAsFixed) && !force {
+				if column.col.FixedWidth {
+					column.calculatedWidth = column.col.Width
+				}
 				continue
 			}
-			if occurrences[column.col.Name] > 1 {
+
+			// set calculatedWidth based on the "weight" (relative width to other columns) of this column
+			column.calculatedWidth = int(math.Floor(float64(column.col.Width) / float64(totalWidthNotFixed) * float64(maxWidth-totalWidthFixed)))
+
+			// honor min/max widths; they'll now be treated as fixed width, afterwards we'll need another pass
+			if !force {
+				if column.col.MaxWidth > 0 && column.calculatedWidth > column.col.MaxWidth {
+					column.calculatedWidth = column.col.MaxWidth
+					column.treatAsFixed = true
+					satisfied = false
+
+					addToFixed += column.calculatedWidth
+					removeFromNotFixed += column.col.Width
+					continue
+				}
+				if column.col.MinWidth > 0 && column.calculatedWidth < column.col.MinWidth {
+					column.calculatedWidth = column.col.MinWidth
+					column.treatAsFixed = true
+					satisfied = false
+
+					addToFixed += column.calculatedWidth
+					removeFromNotFixed += column.col.Width
+					continue
+				}
+			}
+			totalAdjustedWidthNotFixed += column.calculatedWidth
+		}
+
+		if satisfied {
+			break
+		}
+		totalWidthFixed += addToFixed
+		totalWidthNotFixed -= removeFromNotFixed
+	}
+
+	// Handle leftover space (gets distributed amongst non-fixed columns)
+	leftover := maxWidth - (totalAdjustedWidthNotFixed + totalWidthFixed)
+
+distributeLeftover:
+	for leftover > 0 {
+		// keep track whether we actually got to distribute space (e.g. can't do that if all columns are fixed)
+		spent := false
+
+		alreadySpent := make(map[string]struct{})
+
+		// distribute one to each remaining candidate
+		for _, column := range tf.showColumns {
+			if (column.col.FixedWidth || column.treatAsFixed) && !force {
+				continue
+			}
+
+			// we can only distribute to columns that are used more than once if we have leftover space for all
+			// occurrences
+			if occ := occurrences[column.col.Name]; occ > 1 {
+				if _, ok := alreadySpent[column.col.Name]; ok {
+					// we already distributed to this column in this pass (on another occurrence)
+					continue
+				}
+				if occ <= leftover {
+					column.calculatedWidth += 1
+					leftover -= occ
+					spent = true
+
+					if leftover == 0 {
+						break distributeLeftover
+					}
+
+					alreadySpent[column.col.Name] = struct{}{}
+					continue
+				}
 				// cannot redistribute here, since it would be used more than just once
 				continue
 			}
+
 			column.calculatedWidth += 1
-			spent = true
 			leftover--
+			spent = true
 			if leftover == 0 {
-				break
+				break distributeLeftover
 			}
 		}
 		if !spent {

--- a/pkg/columns/formatter/textcolumns/textcolumns.go
+++ b/pkg/columns/formatter/textcolumns/textcolumns.go
@@ -24,6 +24,7 @@ import (
 type Column[T any] struct {
 	col             *columns.Column[T]
 	calculatedWidth int
+	treatAsFixed    bool
 	formatter       ColumnFormatter
 }
 

--- a/pkg/columns/formatter/textcolumns/textcolumns_test.go
+++ b/pkg/columns/formatter/textcolumns/textcolumns_test.go
@@ -177,3 +177,31 @@ func TestTextColumnsFormatter_AdjustWidthsMaxWidth(t *testing.T) {
 		t.Errorf("expected entry does not match, got %s", cstr)
 	}
 }
+
+func TestWidthRestrictions(t *testing.T) {
+	type testStruct struct {
+		Name        string `column:"name,width:5,minWidth:2,maxWidth:10"`
+		SecondField string `column:"second"`
+	}
+	entries := []*testStruct{
+		{"123456789012", "123456789012"},
+		{"234567890123", "234567890123"},
+	}
+	cols, err := columns.NewColumns[testStruct]()
+	if err != nil {
+		t.Fatalf("error initializing")
+	}
+	formatter := NewFormatter(cols.GetColumnMap(), WithRowDivider(DividerDash), WithAutoScale(true))
+	t.Run("maxWidth", func(t *testing.T) {
+		formatter.RecalculateWidths(40, false)
+		if cstr := strings.TrimSpace(formatter.FormatEntry(entries[0])); cstr != "123456789… 123456789012" {
+			t.Errorf("expected entry does not match, got %s", cstr)
+		}
+	})
+	t.Run("minWidth", func(t *testing.T) {
+		formatter.RecalculateWidths(1, false)
+		if cstr := strings.TrimSpace(formatter.FormatEntry(entries[0])); cstr != "1… …" {
+			t.Errorf("expected entry does not match, got %s", cstr)
+		}
+	})
+}

--- a/pkg/columns/formatter/textcolumns/textcolumns_test.go
+++ b/pkg/columns/formatter/textcolumns/textcolumns_test.go
@@ -54,7 +54,10 @@ func TestTextColumnsFormatter_FormatEntry(t *testing.T) {
 	}
 
 	b := bytes.NewBuffer(nil)
-	formatter.WriteTable(b, testEntries)
+	err := formatter.WriteTable(b, testEntries)
+	if err != nil {
+		t.Errorf("unexpected write error: %v", err)
+	}
 	out := b.String()
 	if out != strings.Join(append([]string{"NAME        AGE   SIZE  BALANCE CANDANCE", "————————————————————————————————————————"}, expected...), "\n")+"\n" {
 		t.Errorf("got %s", out)

--- a/pkg/columns/group/group_test.go
+++ b/pkg/columns/group/group_test.go
@@ -19,8 +19,6 @@ import (
 	"testing"
 
 	"github.com/kinvolk/inspektor-gadget/pkg/columns"
-
-	"github.com/kinvolk/inspektor-gadget/pkg/columns/sort"
 )
 
 func TestGroupSum(t *testing.T) {
@@ -29,10 +27,11 @@ func TestGroupSum(t *testing.T) {
 		EmbeddedFloat float64 `column:"embeddedFloat,group:sum"`
 	}
 	type testStruct struct {
-		Name  string  `column:"name"`
-		Int   int64   `column:"int,group:sum"`
-		Uint  uint64  `column:"uint,group:sum"`
-		Float float64 `column:"float,group:sum"`
+		Name      string  `column:"name"`
+		Int       int64   `column:"int,group:sum"`
+		Uint      uint64  `column:"uint,group:sum"`
+		Float     float64 `column:"float,group:sum"`
+		Secondary int     `column:"secondary"`
 		Embedded
 	}
 	type test struct {
@@ -44,10 +43,10 @@ func TestGroupSum(t *testing.T) {
 	}
 
 	entries := []*testStruct{
-		{Name: "a", Int: 1, Float: 1, Uint: 1, Embedded: Embedded{EmbeddedInt: 1, EmbeddedFloat: 1}},
-		{Name: "a", Int: 1, Float: 1, Uint: 1, Embedded: Embedded{EmbeddedInt: 1, EmbeddedFloat: 1}},
-		{Name: "b", Int: 2, Float: 2, Uint: 2, Embedded: Embedded{EmbeddedInt: 2, EmbeddedFloat: 2}},
-		{Name: "b", Int: 2, Float: 2, Uint: 2, Embedded: Embedded{EmbeddedInt: 2, EmbeddedFloat: 2}},
+		{Name: "a", Int: 1, Float: 1, Uint: 1, Secondary: 1, Embedded: Embedded{EmbeddedInt: 1, EmbeddedFloat: 1}},
+		{Name: "a", Int: 1, Float: 1, Uint: 1, Secondary: 2, Embedded: Embedded{EmbeddedInt: 1, EmbeddedFloat: 1}},
+		{Name: "b", Int: 2, Float: 2, Uint: 2, Secondary: 2, Embedded: Embedded{EmbeddedInt: 2, EmbeddedFloat: 2}},
+		{Name: "b", Int: 2, Float: 2, Uint: 2, Secondary: 3, Embedded: Embedded{EmbeddedInt: 2, EmbeddedFloat: 2}},
 		nil,
 	}
 
@@ -58,10 +57,11 @@ func TestGroupSum(t *testing.T) {
 			Input:   entries,
 			ExpectedResult: []*testStruct{
 				{
-					Name:  "a",
-					Int:   6,
-					Uint:  6,
-					Float: 6,
+					Name:      "a",
+					Int:       6,
+					Uint:      6,
+					Float:     6,
+					Secondary: 1,
 					Embedded: Embedded{
 						EmbeddedInt:   6,
 						EmbeddedFloat: 6,
@@ -75,23 +75,54 @@ func TestGroupSum(t *testing.T) {
 			Input:   entries,
 			ExpectedResult: []*testStruct{
 				{
-					Name:  "a",
-					Int:   2,
-					Uint:  2,
-					Float: 2,
+					Name:      "a",
+					Int:       2,
+					Uint:      2,
+					Float:     2,
+					Secondary: 1,
 					Embedded: Embedded{
 						EmbeddedInt:   2,
 						EmbeddedFloat: 2,
 					},
 				},
 				{
-					Name:  "b",
-					Int:   4,
-					Uint:  4,
-					Float: 4,
+					Name:      "b",
+					Int:       4,
+					Uint:      4,
+					Float:     4,
+					Secondary: 2,
 					Embedded: Embedded{
 						EmbeddedInt:   4,
 						EmbeddedFloat: 4,
+					},
+				},
+			},
+		},
+		{
+			Name:    "GroupByMultipleColumn",
+			GroupBy: []string{"secondary", "name"},
+			Input:   entries,
+			ExpectedResult: []*testStruct{
+				{
+					Name:      "a",
+					Int:       4,
+					Uint:      4,
+					Float:     4,
+					Secondary: 1,
+					Embedded: Embedded{
+						EmbeddedInt:   4,
+						EmbeddedFloat: 4,
+					},
+				},
+				{
+					Name:      "b",
+					Int:       2,
+					Uint:      2,
+					Float:     2,
+					Secondary: 3,
+					Embedded: Embedded{
+						EmbeddedInt:   2,
+						EmbeddedFloat: 2,
 					},
 				},
 			},
@@ -123,18 +154,17 @@ func TestGroupSum(t *testing.T) {
 		t.Run(test.Name, func(t *testing.T) {
 			result, err := GroupEntries(cmap, test.Input, test.GroupBy)
 
-			// We need to sort the result as the grouping result is not consistent due
-			// to internally using a map
-			sort.SortEntries(cmap, result, test.GroupBy)
-
 			if err != nil && !test.ExpectError {
-				t.Errorf("while grouping: %v", err)
+				t.Errorf("While grouping: %v", err)
 			}
 			if err == nil && test.ExpectError {
-				t.Errorf("expected error")
+				t.Errorf("Expected error")
 			}
 			if !reflect.DeepEqual(result, test.ExpectedResult) {
-				t.Errorf("got %+v", result)
+				for _, entry := range result {
+					t.Logf("%+v", entry)
+				}
+				t.Errorf("Unexpected result")
 			}
 		})
 	}

--- a/pkg/columns/helpers.go
+++ b/pkg/columns/helpers.go
@@ -14,27 +14,12 @@
 
 package columns
 
-import (
-	"testing"
+import "strings"
 
-	"github.com/kinvolk/inspektor-gadget/pkg/columns/ellipsis"
-)
-
-func TestOptions(t *testing.T) {
-	opts := GetDefault()
-
-	WithAlignment(AlignRight)(opts)
-	if opts.DefaultAlignment != AlignRight {
-		t.Errorf("Expected default alignment to be AlignRight")
+// ToLowerStrings transforms the elements of an array of strings into lowercase.
+func ToLowerStrings(in []string) []string {
+	for i := range in {
+		in[i] = strings.ToLower(in[i])
 	}
-
-	WithEllipsis(ellipsis.Middle)(opts)
-	if opts.DefaultEllipsis != ellipsis.Middle {
-		t.Errorf("Expected ellipsis to be ellipsis.Middle")
-	}
-
-	WithWidth(2342)(opts)
-	if opts.DefaultWidth != 2342 {
-		t.Errorf("Expected default width to be 2342")
-	}
+	return in
 }

--- a/pkg/columns/sort/sort_test.go
+++ b/pkg/columns/sort/sort_test.go
@@ -59,68 +59,71 @@ func TestSorter(t *testing.T) {
 
 	cmap := cols.GetColumnMap()
 
-	rand.Shuffle(len(testEntries), func(i, j int) { testEntries[i], testEntries[j] = testEntries[j], testEntries[i] })
-	SortEntries(cmap, testEntries, []string{"uint"})
+	shuffle := func() {
+		rand.Shuffle(len(testEntries), func(i, j int) { testEntries[i], testEntries[j] = testEntries[j], testEntries[i] })
+	}
 
+	shuffle()
+	SortEntries(cmap, testEntries, []string{"uint"})
 	if testEntries[0].Uint != 1 {
 		t.Errorf("expected value to be 1")
 	}
 
-	rand.Shuffle(len(testEntries), func(i, j int) { testEntries[i], testEntries[j] = testEntries[j], testEntries[i] })
+	shuffle()
 	SortEntries(cmap, testEntries, []string{"-uint"})
 	if testEntries[0].Uint != 5 {
 		t.Errorf("expected value to be 5")
 	}
 
-	rand.Shuffle(len(testEntries), func(i, j int) { testEntries[i], testEntries[j] = testEntries[j], testEntries[i] })
+	shuffle()
 	SortEntries(cmap, testEntries, []string{"int"})
 	if testEntries[0].Int != 1 {
 		t.Errorf("expected value to be 1")
 	}
 
-	rand.Shuffle(len(testEntries), func(i, j int) { testEntries[i], testEntries[j] = testEntries[j], testEntries[i] })
+	shuffle()
 	SortEntries(cmap, testEntries, []string{"-int"})
 	if testEntries[0].Int != 5 {
 		t.Errorf("expected value to be 5")
 	}
 
-	rand.Shuffle(len(testEntries), func(i, j int) { testEntries[i], testEntries[j] = testEntries[j], testEntries[i] })
+	shuffle()
 	SortEntries(cmap, testEntries, []string{"float32"})
 	if testEntries[0].Float32 != 1 {
 		t.Errorf("expected value to be 1")
 	}
 
-	rand.Shuffle(len(testEntries), func(i, j int) { testEntries[i], testEntries[j] = testEntries[j], testEntries[i] })
+	shuffle()
 	SortEntries(cmap, testEntries, []string{"-float32"})
 	if testEntries[0].Float32 != 5 {
 		t.Errorf("expected value to be 5")
 	}
 
-	rand.Shuffle(len(testEntries), func(i, j int) { testEntries[i], testEntries[j] = testEntries[j], testEntries[i] })
+	shuffle()
 	SortEntries(cmap, testEntries, []string{"float64"})
 	if testEntries[0].Float64 != 1 {
 		t.Errorf("expected value to be 1")
 	}
 
-	rand.Shuffle(len(testEntries), func(i, j int) { testEntries[i], testEntries[j] = testEntries[j], testEntries[i] })
+	shuffle()
 	SortEntries(cmap, testEntries, []string{"-float64"})
 	if testEntries[0].Float64 != 5 {
 		t.Errorf("expected value to be 5")
 	}
 
-	rand.Shuffle(len(testEntries), func(i, j int) { testEntries[i], testEntries[j] = testEntries[j], testEntries[i] })
+	shuffle()
 	SortEntries(cmap, testEntries, []string{"group", "string"})
 	if testEntries[0].Group != "a" || testEntries[0].String != "a" {
 		t.Errorf("expected value to be a (group) and a (string)")
 	}
 
-	rand.Shuffle(len(testEntries), func(i, j int) { testEntries[i], testEntries[j] = testEntries[j], testEntries[i] })
+	shuffle()
 	SortEntries(cmap, testEntries, []string{"embeddedInt"})
 	if testEntries[0].EmbeddedInt != 3 {
 		t.Errorf("expected embedded value to be a 3")
 	}
 
-	rand.Shuffle(len(testEntries), func(i, j int) { testEntries[i], testEntries[j] = testEntries[j], testEntries[i] })
+	shuffle()
 	SortEntries(cmap, testEntries, []string{"string"})
 	if testEntries[0].String != "a" {
 		t.Errorf("expected value to be a")

--- a/pkg/gadgets/trace/bind/types/types.go
+++ b/pkg/gadgets/trace/bind/types/types.go
@@ -22,11 +22,11 @@ import (
 type Event struct {
 	eventtypes.Event
 
-	Pid       uint32 `json:"pid,omitempty" column:"pid,width:7,fixed"`
-	Comm      string `json:"comm,omitempty" column:"comm,width:16,fixed"`
+	Pid       uint32 `json:"pid,omitempty" column:"pid,minWidth:7"`
+	Comm      string `json:"comm,omitempty" column:"comm,maxWidth:16"`
 	Protocol  string `json:"proto,omitempty" column:"proto,width:5,fixed"`
 	Addr      string `json:"addr,omitempty" column:"addr,width:16"`
-	Port      uint16 `json:"port,omitempty" column:"port,width:5,fixed"`
+	Port      uint16 `json:"port,omitempty" column:"port,minWidth:type"`
 	Options   string `json:"opts,omitempty" column:"opts,width:5,fixed"`
 	Interface string `json:"if,omitempty" column:"if,width:12"`
 	MountNsID uint64 `json:"mountnsid,omitempty" column:"mntns,width:12,hide"`

--- a/pkg/gadgets/trace/exec/types/types.go
+++ b/pkg/gadgets/trace/exec/types/types.go
@@ -24,12 +24,12 @@ import (
 type Event struct {
 	eventtypes.Event
 
-	Pid       uint32   `json:"pid,omitempty" column:"pid,width:7,fixed"`
-	Ppid      uint32   `json:"ppid,omitempty" column:"ppid,width:7,fixed"`
-	Comm      string   `json:"pcomm,omitempty" column:"comm,width:16,fixed"`
+	Pid       uint32   `json:"pid,omitempty" column:"pid,minWidth:7"`
+	Ppid      uint32   `json:"ppid,omitempty" column:"ppid,minWidth:7"`
+	Comm      string   `json:"pcomm,omitempty" column:"comm,maxWidth:16"`
 	Retval    int      `json:"ret,omitempty" column:"ret,width:3,fixed"`
 	Args      []string `json:"args,omitempty" column:"args,width:40"`
-	UID       uint32   `json:"uid,omitempty" column:"uid,width:10,fixed,hide"`
+	UID       uint32   `json:"uid,omitempty" column:"uid,minWidth:10,hide"`
 	MountNsID uint64   `json:"mountnsid,omitempty" column:"mntns,width:12,hide"`
 }
 


### PR DESCRIPTION
This PR introduces two new parameters to columns, `minWidth` and `maxWidth`. Whenever the auto-scaler is in use, it will prevent columns from shrinking to less than minWidth or expanding to more than maxWidth. This is helpful when you know beforehand that a field will not cross those boundaries and instead give the remaining space to other columns.

This PR also introduces a new special value for `width`, `minWidth` and `maxWidth` called `type`. This can be used on columns that have an underlying integer value and will automatically use the maximum space that can be occupied for the specific type - e.g. a uint8 will result in a width of 3 (as 255 is the maximum value, holding a maximum of three digits).

I also added some leftover cleanups (mostly regarding the tests) from the initial PR - if it's too much, let me know and I'll move it to a separate PR.