### PR TITLE
integration: Fix trace open tests

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -813,7 +813,7 @@ func TestOpensnoop(t *testing.T) {
 				e.UID = 0
 			}
 
-			return expectAllToMatch(output, normalize, expectedEntry)
+			return expectEntriesToMatch(output, normalize, expectedEntry)
 		},
 	}
 


### PR DESCRIPTION
It's possible that the tracer captures other events than the one we're expecting, hence we should use expectEntriesToMatch() instead of expectAllToMatch().

Example of failure:

```
2022-09-22T13:31:02.9530851Z     command.go:430: invalid command output(StartOpensnoopGadget): verifying output with custom function: unexpected output entry:
2022-09-22T13:31:02.9532458Z           &types.Event{
2022-09-22T13:31:02.9533177Z           	... // 2 identical fields
2022-09-22T13:31:02.9533832Z           	Pid:  0,
2022-09-22T13:31:02.9534421Z           	UID:  0,
2022-09-22T13:31:02.9535013Z         - 	Comm: "cat",
2022-09-22T13:31:02.9535714Z         + 	Comm: "runc:[2:INIT]",
2022-09-22T13:31:02.9536312Z         - 	Fd:   3,
2022-09-22T13:31:02.9536882Z         + 	Fd:   6,
2022-09-22T13:31:02.9537386Z         - 	Ret:  3,
2022-09-22T13:31:02.9537938Z         + 	Ret:  6,
2022-09-22T13:31:02.9538530Z           	Err:  0,
2022-09-22T13:31:02.9539212Z         - 	Path: "/dev/null",
2022-09-22T13:31:02.9539823Z         + 	Path: "/",
2022-09-22T13:31:02.9540326Z           }
```

(https://github.com/kinvolk/inspektor-gadget/actions/runs/3105690224/jobs/5031919245)

Fixes: 9b5f86e50a7b ("integration: Switch trace open tests to use json")