### PR TITLE
integration: Add workaround for trace capabilities test on ARO

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -432,8 +432,10 @@ func TestCapabilities(t *testing.T) {
 	t.Parallel()
 
 	capabilitiesCmd := &command{
-		name:           "StartCapabilitiesGadget",
-		cmd:            fmt.Sprintf("$KUBECTL_GADGET trace capabilities -n %s", ns),
+		name: "StartCapabilitiesGadget",
+		// use --audit-only=false to make it work on ARO.
+		// See https://github.com/kinvolk/inspektor-gadget/issues/985 for more details.
+		cmd:            fmt.Sprintf("$KUBECTL_GADGET trace capabilities -n %s --audit-only=false", ns),
 		expectedRegexp: fmt.Sprintf(`%s\s+test-pod.*nice.*CAP_SYS_NICE`, ns),
 		startAndStop:   true,
 	}


### PR DESCRIPTION
Use --audit-only=false to avoid issue on ARO.

Ref https://github.com/kinvolk/inspektor-gadget/issues/985