### PR TITLE
Allow terminating ebpf-objects Make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ all: build local-gadget
 phony_explicit:
 
 ebpf-objects:
-	docker run --rm --name ebpf-object-builder --user $(shell id -u):$(shell id -g) -v $(shell pwd):/work ghcr.io/kinvolk/inspektor-gadget-ebpf-builder
+	docker run -it --rm --name ebpf-object-builder --user $(shell id -u):$(shell id -g) -v $(shell pwd):/work ghcr.io/kinvolk/inspektor-gadget-ebpf-builder
 
 ebpf-objects-outside-docker:
 	TARGET=arm64 go generate ./...


### PR DESCRIPTION
# Allow terminating ebpf-objects Make target

Hitting Ctrl+C doesn't work for `make ebpf-objects`. This fixes the problem by making the Docker command interactive.

## How to use

Run `make ebpf-objects`, hit Ctrl+C and ensure the command returns.

## Testing done

The above.