### PR TITLE
ci: Fix SPO deployment on AKS Cluster

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -171,13 +171,16 @@ func testMain(m *testing.M) int {
 
 	if !*doNotDeploySPO {
 		limitReplicas := false
+		patchWebhookConfig := false
 		bestEffortResourceMgmt := false
 		if *k8sDistro == K8sDistroMinikubeGH {
 			limitReplicas = true
 			bestEffortResourceMgmt = true
 		}
-
-		initCommands = append(initCommands, deploySPO(limitReplicas, bestEffortResourceMgmt))
+		if *k8sDistro == K8sDistroAKSUbuntu {
+			patchWebhookConfig = true
+		}
+		initCommands = append(initCommands, deploySPO(limitReplicas, patchWebhookConfig, bestEffortResourceMgmt))
 		cleanupCommands = append(cleanupCommands, cleanupSPO)
 	}
 


### PR DESCRIPTION
AKS mutates the spod webhook config resulting in SPO stuck in `UPDATING` state forever. This can result in timeout of `cleanupSPO` because of dangling finalizers. Since SPO is stuck on `UPDATING` state any resource we tried to clean might end up showing again when controller starts a new reconciliation loop. This patch makes sure SPO goes to `RUNNING` state allowing in-order cleanup.

Related https://github.com/Azure/AKS/issues/1771

### Before
SPO was stuck in `UPDATING` state during test run:
```
→ kubectl -n security-profiles-operator get spod 
NAME   STATE
spod   UPDATING
```

### After
SPO goes to `RUNNING` state during test run:
```
→ kubectl -n security-profiles-operator get spod 
NAME   STATE
spod   RUNNING
```

## Testing done
Running few times against an AKS cluster without any timeouts:
```
INTEGRATION_TESTS_PARAMS="-run TestAuditSeccomp -v" make IMAGE_TAG=latest KUBERNETES_DISTRIBUTION=aks-Ubuntu  KUBERNETES_ARCHITECTURE=amd64 integration-tests
```
