### PR TITLE
pkg/columns/formatter/textcolumns: Add a couple of helper functions

### DIFF
--- a/pkg/columns/formatter/textcolumns/output.go
+++ b/pkg/columns/formatter/textcolumns/output.go
@@ -15,6 +15,7 @@
 package textcolumns
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"reflect"
@@ -134,8 +135,15 @@ func (tf *TextColumnsFormatter[T]) FormatRowDivider() string {
 	return string([]rune(row.String())[:rowDividerLen])
 }
 
-// WriteTable writes header, divider and body with the current settings, where the body consists of the entries given
-// to the writer
+// FormatTable returns header, divider and the formatted entries with the current settings as a string
+func (tf *TextColumnsFormatter[T]) FormatTable(entries []*T) string {
+	buf := bytes.NewBuffer(nil)
+	_ = tf.WriteTable(buf, entries)
+	out := buf.Bytes()
+	return string(out[:len(out)-1])
+}
+
+// WriteTable writes header, divider nd the formatted entries with the current settings to writer
 func (tf *TextColumnsFormatter[T]) WriteTable(writer io.Writer, entries []*T) error {
 	_, err := writer.Write([]byte(tf.FormatHeader()))
 	if err != nil {

--- a/pkg/columns/formatter/textcolumns/scaler.go
+++ b/pkg/columns/formatter/textcolumns/scaler.go
@@ -307,6 +307,9 @@ func (tf *TextColumnsFormatter[T]) AdjustWidthsToContent(entries []*T, considerH
 		return
 	}
 
+	// Force RecalculateWidths() to run
+	tf.currentMaxWidth = -1
+
 	// We did our best, but let's resize to fit to maxWidth
 	tf.RecalculateWidths(maxWidth, force)
 }

--- a/pkg/columns/formatter/textcolumns/scaler.go
+++ b/pkg/columns/formatter/textcolumns/scaler.go
@@ -198,17 +198,27 @@ distributeLeftover:
 	tf.buildFillString()
 }
 
-// AdjustWidthsToScreen will try to get the width of the screen buffer and call RecalculateWidths with that value
+// GetTerminalWidth returns the width of the terminal (if one is in use) or 0 otherwise
+func GetTerminalWidth() int {
+	if !term.IsTerminal(int(os.Stdout.Fd())) {
+		return 0
+	}
+	terminalWidth, _, err := term.GetSize(0)
+	if err != nil {
+		return 0
+	}
+	return terminalWidth
+}
+
+// AdjustWidthsToScreen will try to get the width of the screen buffer and, if successful, call RecalculateWidths with
+// that value
 func (tf *TextColumnsFormatter[T]) AdjustWidthsToScreen() {
 	if !tf.options.AutoScale {
 		return
 	}
 
-	if !term.IsTerminal(int(os.Stdout.Fd())) {
-		return
-	}
-	terminalWidth, _, err := term.GetSize(0)
-	if err != nil {
+	terminalWidth := GetTerminalWidth()
+	if terminalWidth == 0 {
 		return
 	}
 

--- a/pkg/columns/formatter/textcolumns/scaler.go
+++ b/pkg/columns/formatter/textcolumns/scaler.go
@@ -297,6 +297,8 @@ func (tf *TextColumnsFormatter[T]) AdjustWidthsToContent(entries []*T, considerH
 		totalWidth += column.calculatedWidth
 	}
 
+	tf.buildFillString()
+
 	// Last but not least, add column dividers
 	totalWidth += len([]rune(tf.options.ColumnDivider)) * (len(tf.showColumns) - 1)
 

--- a/pkg/columns/formatter/textcolumns/textcolumns.go
+++ b/pkg/columns/formatter/textcolumns/textcolumns.go
@@ -108,6 +108,21 @@ func (tf *TextColumnsFormatter[T]) SetShowColumns(columns []string) {
 	tf.rebuild()
 }
 
+// SetAutoScale enables or disables the AutoScale option for the formatter. This will recalculate the widths.
+func (tf *TextColumnsFormatter[T]) SetAutoScale(enableAutoScale bool) {
+	tf.options.AutoScale = enableAutoScale
+	if enableAutoScale {
+		tf.rebuild()
+	} else {
+		// Set calculated width to configured widths
+		for _, column := range tf.columns {
+			column.calculatedWidth = column.col.Width
+			column.treatAsFixed = false
+		}
+		tf.buildFillString()
+	}
+}
+
 func (tf *TextColumnsFormatter[T]) rebuild() {
 	tf.buildFillString()
 	tf.currentMaxWidth = -1 // force recalculation

--- a/pkg/columns/formatter/textcolumns/textcolumns_test.go
+++ b/pkg/columns/formatter/textcolumns/textcolumns_test.go
@@ -15,7 +15,6 @@
 package textcolumns
 
 import (
-	"bytes"
 	"strings"
 	"testing"
 
@@ -39,7 +38,7 @@ var testEntries = []*testStruct{
 
 var testColumns = columns.MustCreateColumns[testStruct]().GetColumnMap()
 
-func TestTextColumnsFormatter_FormatEntry(t *testing.T) {
+func TestTextColumnsFormatter_FormatEntryAndTable(t *testing.T) {
 	expected := []string{
 		"Alice        32   1.74     1000 true    ",
 		"Bob          26   1.73     -200 true    ",
@@ -47,21 +46,21 @@ func TestTextColumnsFormatter_FormatEntry(t *testing.T) {
 		"",
 	}
 	formatter := NewFormatter(testColumns, WithRowDivider(DividerDash))
-	for i, entry := range testEntries {
-		if res := formatter.FormatEntry(entry); res != expected[i] {
-			t.Errorf("got %s, expected %s", res, expected[i])
-		}
-	}
 
-	b := bytes.NewBuffer(nil)
-	err := formatter.WriteTable(b, testEntries)
-	if err != nil {
-		t.Errorf("unexpected write error: %v", err)
-	}
-	out := b.String()
-	if out != strings.Join(append([]string{"NAME        AGE   SIZE  BALANCE CANDANCE", "————————————————————————————————————————"}, expected...), "\n")+"\n" {
-		t.Errorf("got %s", out)
-	}
+	t.Run("FormatEntry", func(t *testing.T) {
+		for i, entry := range testEntries {
+			if res := formatter.FormatEntry(entry); res != expected[i] {
+				t.Errorf("got %s, expected %s", res, expected[i])
+			}
+		}
+	})
+
+	t.Run("FormatTable", func(t *testing.T) {
+		out := formatter.FormatTable(testEntries)
+		if out != strings.Join(append([]string{"NAME        AGE   SIZE  BALANCE CANDANCE", "————————————————————————————————————————"}, expected...), "\n") {
+			t.Errorf("got %s", out)
+		}
+	})
 }
 
 func TestTextColumnsFormatter_FormatHeader(t *testing.T) {


### PR DESCRIPTION
This PR adds a couple of helper functions discussed [in this PR](https://github.com/kinvolk/inspektor-gadget/pull/980).

* `FormatTable()` to return a full table as string
* `SetAutoScale()` to enable/disable auto-scaling on demand
* `GetTerminalWidth()` to easily get the current width of the terminal

This PR also prevents a potential crash when using AdjustWidthsToContent().