### PR TITLE
examples: Use syscall.SIGINT instead of os.Interrupt

### DIFF
--- a/examples/container-collection/container-collection.go
+++ b/examples/container-collection/container-collection.go
@@ -71,6 +71,6 @@ func main() {
 
 	// Graceful shutdown
 	exit := make(chan os.Signal, 1)
-	signal.Notify(exit, os.Interrupt, syscall.SIGTERM)
+	signal.Notify(exit, syscall.SIGINT, syscall.SIGTERM)
 	<-exit
 }

--- a/examples/gadgets/basic/top/file/file.go
+++ b/examples/gadgets/basic/top/file/file.go
@@ -75,6 +75,6 @@ func main() {
 
 	// Graceful shutdown
 	exit := make(chan os.Signal, 1)
-	signal.Notify(exit, os.Interrupt, syscall.SIGTERM)
+	signal.Notify(exit, syscall.SIGINT, syscall.SIGTERM)
 	<-exit
 }

--- a/examples/gadgets/basic/trace/dns/dns.go
+++ b/examples/gadgets/basic/trace/dns/dns.go
@@ -60,6 +60,6 @@ func main() {
 
 	// Graceful shutdown
 	exit := make(chan os.Signal, 1)
-	signal.Notify(exit, os.Interrupt, syscall.SIGTERM)
+	signal.Notify(exit, syscall.SIGINT, syscall.SIGTERM)
 	<-exit
 }

--- a/examples/gadgets/basic/trace/exec/exec.go
+++ b/examples/gadgets/basic/trace/exec/exec.go
@@ -51,6 +51,6 @@ func main() {
 
 	// Graceful shutdown
 	exit := make(chan os.Signal, 1)
-	signal.Notify(exit, os.Interrupt, syscall.SIGTERM)
+	signal.Notify(exit, syscall.SIGINT, syscall.SIGTERM)
 	<-exit
 }

--- a/examples/gadgets/parser/trace/exec/exec.go
+++ b/examples/gadgets/parser/trace/exec/exec.go
@@ -134,6 +134,6 @@ func main() {
 
 	// Graceful shutdown
 	exit := make(chan os.Signal, 1)
-	signal.Notify(exit, os.Interrupt, syscall.SIGTERM)
+	signal.Notify(exit, syscall.SIGINT, syscall.SIGTERM)
 	<-exit
 }

--- a/examples/gadgets/withfilter/trace/exec/exec.go
+++ b/examples/gadgets/withfilter/trace/exec/exec.go
@@ -123,6 +123,6 @@ func main() {
 
 	// Graceful shutdown
 	exit := make(chan os.Signal, 1)
-	signal.Notify(exit, os.Interrupt, syscall.SIGTERM)
+	signal.Notify(exit, syscall.SIGINT, syscall.SIGTERM)
 	<-exit
 }

--- a/examples/kube-container-collection/main.go
+++ b/examples/kube-container-collection/main.go
@@ -144,6 +144,6 @@ func main() {
 
 	// Graceful shutdown
 	exit := make(chan os.Signal, 1)
-	signal.Notify(exit, os.Interrupt, syscall.SIGTERM)
+	signal.Notify(exit, syscall.SIGINT, syscall.SIGTERM)
 	<-exit
 }

--- a/examples/runc-hook/main.go
+++ b/examples/runc-hook/main.go
@@ -239,6 +239,6 @@ func main() {
 
 	// Graceful shutdown
 	exit := make(chan os.Signal, 1)
-	signal.Notify(exit, os.Interrupt, syscall.SIGTERM)
+	signal.Notify(exit, syscall.SIGINT, syscall.SIGTERM)
 	<-exit
 }


### PR DESCRIPTION
Cosmetic change to only use syscall package for signals in the examples.

