### PR TITLE
integration: Re-enable liveness probe on ARO

### DIFF
--- a/integration/command.go
+++ b/integration/command.go
@@ -72,9 +72,9 @@ type command struct {
 	started bool
 }
 
-func deployInspektorGadget(image, imagePullPolicy string, livenessProbe bool) *command {
-	cmd := fmt.Sprintf("$KUBECTL_GADGET deploy --image-pull-policy=%s --liveness-probe=%t  --debug",
-		imagePullPolicy, livenessProbe)
+func deployInspektorGadget(image, imagePullPolicy string) *command {
+	cmd := fmt.Sprintf("$KUBECTL_GADGET deploy --image-pull-policy=%s --debug",
+		imagePullPolicy)
 
 	if image != "" {
 		cmd = cmd + " --image=" + image

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -156,16 +156,10 @@ func testMain(m *testing.M) int {
 
 	if !*doNotDeployIG {
 		imagePullPolicy := "Always"
-		livenessProbe := true
-		// livenessProbe are causing some issues in the ARO integration cluster,
-		// see: https://github.com/kinvolk/inspektor-gadget/issues/799
-		if *k8sDistro == K8sDistroARO {
-			livenessProbe = false
-		}
 		if *k8sDistro == K8sDistroMinikubeGH {
 			imagePullPolicy = "Never"
 		}
-		deployCmd := deployInspektorGadget(*image, imagePullPolicy, livenessProbe)
+		deployCmd := deployInspektorGadget(*image, imagePullPolicy)
 		initCommands = append(initCommands, deployCmd)
 
 		cleanupCommands = append(cleanupCommands, cleanupInspektorGadget)


### PR DESCRIPTION
Revert b9db9360d8b8 ("integration: Disable liveness probes when running on ARO") given that https://github.com/kinvolk/inspektor-gadget/issues/799 is now fixed.

