### PR TITLE
cmd/kubectl-gadget: Don't pring warning messages to stdout

### DIFF
--- a/cmd/kubectl-gadget/utils/trace.go
+++ b/cmd/kubectl-gadget/utils/trace.go
@@ -1017,9 +1017,9 @@ func genericStreams(
 			err := ExecPod(client, nodeName, cmd,
 				postProcess.OutStreams[index], postProcess.ErrStreams[index])
 			if err == nil {
-				completion <- fmt.Sprintf("Trace completed on node %q\n", nodeName)
+				completion <- fmt.Sprintf("Trace completed on node %q", nodeName)
 			} else {
-				completion <- fmt.Sprintf("Error: failed to receive stream on node %q: %v\n", nodeName, err)
+				completion <- fmt.Sprintf("Error: failed to receive stream on node %q: %v", nodeName, err)
 			}
 		}(i.Spec.Node, i.ObjectMeta.Namespace, i.ObjectMeta.Name, index)
 	}
@@ -1041,7 +1041,7 @@ func genericStreams(
 			}
 			return nil
 		case msg := <-completion:
-			fmt.Printf("%s", msg)
+			fmt.Fprintln(os.Stderr, msg)
 			if atomic.AddInt32(&streamCount, -1) == 0 {
 				return nil
 			}


### PR DESCRIPTION
Print those messages to stderr instead to avoid an application parsing the output to fail.

This commit is a temporal solution until we investigate why those are printed making the integration tests to fail.
Details in https://github.com/kinvolk/inspektor-gadget/issues/1002.

