### PR TITLE
trace/mount: Use columns library

### DIFF
--- a/cmd/common/trace/mount.go
+++ b/cmd/common/trace/mount.go
@@ -1,0 +1,27 @@
+// Copyright 2022 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package trace
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func NewMountCmd(runCmd func(*cobra.Command, []string) error) *cobra.Command {
+	return &cobra.Command{
+		Use:   "mount",
+		Short: "Trace mount and umount system calls",
+		RunE:  runCmd,
+	}
+}

--- a/cmd/kubectl-gadget/trace/mount.go
+++ b/cmd/kubectl-gadget/trace/mount.go
@@ -15,145 +15,34 @@
 package trace
 
 import (
-	"fmt"
-	"strings"
+	"github.com/spf13/cobra"
 
 	commontrace "github.com/kinvolk/inspektor-gadget/cmd/common/trace"
 	commonutils "github.com/kinvolk/inspektor-gadget/cmd/common/utils"
 	"github.com/kinvolk/inspektor-gadget/cmd/kubectl-gadget/utils"
-	"github.com/kinvolk/inspektor-gadget/pkg/gadgets/trace/mount/types"
-
-	"github.com/spf13/cobra"
+	mountTypes "github.com/kinvolk/inspektor-gadget/pkg/gadgets/trace/mount/types"
 )
 
-type MountParser struct {
-	commonutils.BaseParser[types.Event]
-}
-
 func newMountCmd() *cobra.Command {
-	commonFlags := &utils.CommonFlags{
-		OutputConfig: commonutils.OutputConfig{
-			// The columns that will be used in case the user does not specify
-			// which specific columns they want to print.
-			CustomColumns: []string{
-				"node",
-				"namespace",
-				"pod",
-				"container",
-				"comm",
-				"pid",
-				"tid",
-				"mnt_ns",
-				"call",
-			},
-		},
-	}
+	var commonFlags utils.CommonFlags
 
-	cmd := &cobra.Command{
-		Use:   "mount",
-		Short: "Trace mount and umount system calls",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			mountGadget := &TraceGadget[types.Event]{
-				name:        "mountsnoop",
-				commonFlags: commonFlags,
-				parser:      NewMountParser(&commonFlags.OutputConfig),
-			}
-
-			return mountGadget.Run()
-		},
-	}
-
-	utils.AddCommonFlags(cmd, commonFlags)
-
-	return cmd
-}
-
-func NewMountParser(outputConfig *commonutils.OutputConfig) commontrace.TraceParser[types.Event] {
-	columnsWidth := map[string]int{
-		"node":      -16,
-		"namespace": -16,
-		"pod":       -30,
-		"container": -16,
-		"pid":       -7,
-		"tid":       -7,
-		"mnt_ns":    -11,
-		"comm":      -16,
-		"op":        -6,
-		"ret":       -4,
-		"lat":       -8,
-		"fs":        -16,
-		"src":       -16,
-		"target":    -16,
-		"data":      -16,
-		"call":      -16,
-		"flags":     -24,
-	}
-
-	return &MountParser{
-		BaseParser: commonutils.NewBaseWidthParser[types.Event](columnsWidth, outputConfig),
-	}
-}
-
-func getCall(e *types.Event) string {
-	switch e.Operation {
-	case "mount":
-		format := `mount("%s", "%s", "%s", %s, "%s") = %d`
-		return fmt.Sprintf(format, e.Source, e.Target, e.Fs, strings.Join(e.Flags, " | "),
-			e.Data, e.Retval)
-	case "umount":
-		format := `umount("%s", %s) = %d`
-		return fmt.Sprintf(format, e.Target, strings.Join(e.Flags, " | "), e.Retval)
-	}
-
-	return ""
-}
-
-func (p *MountParser) TransformIntoColumns(event *types.Event) string {
-	var sb strings.Builder
-
-	for _, col := range p.OutputConfig.CustomColumns {
-		switch col {
-		case "node":
-			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Node))
-		case "namespace":
-			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Namespace))
-		case "pod":
-			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Pod))
-		case "container":
-			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Container))
-		case "pid":
-			sb.WriteString(fmt.Sprintf("%*d", p.ColumnsWidth[col], event.Pid))
-		case "tid":
-			sb.WriteString(fmt.Sprintf("%*d", p.ColumnsWidth[col], event.Tid))
-		case "mnt_ns":
-			sb.WriteString(fmt.Sprintf("%*d", p.ColumnsWidth[col], event.MountNsID))
-		case "comm":
-			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Comm))
-		case "op":
-			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Operation))
-		case "ret":
-			sb.WriteString(fmt.Sprintf("%*d", p.ColumnsWidth[col], event.Retval))
-		case "lat":
-			sb.WriteString(fmt.Sprintf("%*d", p.ColumnsWidth[col], event.Latency/1000))
-		case "fs":
-			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Fs))
-		case "src":
-			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Source))
-		case "target":
-			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Target))
-		case "data":
-			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Data))
-		case "call":
-			sb.WriteString(fmt.Sprintf("%-*s", p.ColumnsWidth[col], getCall(event)))
-		case "flags":
-			sb.WriteString(fmt.Sprintf("%s", strings.Join(event.Flags, " | ")))
-		default:
-			continue
+	runCmd := func(cmd *cobra.Command, args []string) error {
+		parser, err := commonutils.NewGadgetParserWithK8sInfo(&commonFlags.OutputConfig, mountTypes.GetColumns())
+		if err != nil {
+			return commonutils.WrapInErrParserCreate(err)
 		}
 
-		// Needed when field is larger than the predefined columnsWidth.
-		sb.WriteRune(' ')
+		mountGadget := &TraceGadget[mountTypes.Event]{
+			name:        "mountsnoop",
+			commonFlags: &commonFlags,
+			parser:      parser,
+		}
+
+		return mountGadget.Run()
 	}
 
-	return sb.String()
+	cmd := commontrace.NewMountCmd(runCmd)
+	utils.AddCommonFlags(cmd, &commonFlags)
+
+	return cmd
 }

--- a/docs/guides/trace/mount.md
+++ b/docs/guides/trace/mount.md
@@ -21,7 +21,7 @@ You can now use the gadget, but output will be empty:
 
 ```bash
 $ kubectl gadget trace mount
-NODE             NAMESPACE        POD              CONTAINER        COMM             PID     TID     MNT_NS      CALL
+NODE             NAMESPACE        POD              CONTAINER        COMM             PID     TID     MNTNS      CALL
 ```
 
 Indeed, it is waiting for `mount` and `umount` to be called.
@@ -40,7 +40,7 @@ command terminated with exit code 255
 Go back to *the first terminal* and see:
 
 ```bash
-NODE             NAMESPACE        POD              CONTAINER        COMM             PID     TID     MNT_NS      CALL
+NODE             NAMESPACE        POD              CONTAINER        COMM             PID     TID     MNTNS      CALL
 minikube         default          busybox-0        busybox-0        mount            12841   12841   4026532682  mount("/mnt", "/mnt", "ext3", MS_SILENT, "") = -2
 minikube         default          busybox-0        busybox-0        mount            12841   12841   4026532682  mount("/mnt", "/mnt", "ext2", MS_SILENT, "") = -2
 minikube         default          busybox-0        busybox-0        mount            12841   12841   4026532682  mount("/mnt", "/mnt", "ext4", MS_SILENT, "") = -2
@@ -65,7 +65,7 @@ NAME        READY   STATUS    RESTARTS   AGE     LABELS
 busybox-0   1/1     Running   0          2m9s    run=busybox-0
 busybox-1   1/1     Running   0          3m59s   run=busybox-1
 $ kubectl gadget trace mount --selector run=busybox-0
-NODE             NAMESPACE        POD              CONTAINER        COMM             PID     TID     MNT_NS      CALL
+NODE             NAMESPACE        POD              CONTAINER        COMM             PID     TID     MNTNS      CALL
 ```
 
 As you can see, the `--selector` option, and its `-l` shorthand awaits for pods labels as argument.
@@ -85,7 +85,7 @@ command terminated with exit code 255
 Go back to the first terminal, you should only see output related to `mount /foo /bar` as a result of using `--selector` options filtering the pods:
 
 ```bash
-NODE             NAMESPACE        POD              CONTAINER        COMM             PID     TID     MNT_NS      CALL
+NODE             NAMESPACE        POD              CONTAINER        COMM             PID     TID     MNTNS      CALL
 minikube         default          busybox-0        busybox-0        mount            14469   14469   4026532682  mount("/foo", "/bar", "ext3", MS_SILENT, "") = -2
 minikube         default          busybox-0        busybox-0        mount            14469   14469   4026532682  mount("/foo", "/bar", "ext2", MS_SILENT, "") = -2
 minikube         default          busybox-0        busybox-0        mount            14469   14469   4026532682  mount("/foo", "/bar", "ext4", MS_SILENT, "") = -2

--- a/integration/inspektor-gadget/integration_test.go
+++ b/integration/inspektor-gadget/integration_test.go
@@ -31,6 +31,7 @@ import (
 	capabilitiesTypes "github.com/kinvolk/inspektor-gadget/pkg/gadgets/trace/capabilities/types"
 	dnsTypes "github.com/kinvolk/inspektor-gadget/pkg/gadgets/trace/dns/types"
 	execTypes "github.com/kinvolk/inspektor-gadget/pkg/gadgets/trace/exec/types"
+	mountTypes "github.com/kinvolk/inspektor-gadget/pkg/gadgets/trace/mount/types"
 	openTypes "github.com/kinvolk/inspektor-gadget/pkg/gadgets/trace/open/types"
 	signalTypes "github.com/kinvolk/inspektor-gadget/pkg/gadgets/trace/signal/types"
 	tcpTypes "github.com/kinvolk/inspektor-gadget/pkg/gadgets/trace/tcp/types"
@@ -629,10 +630,33 @@ func TestMountsnoop(t *testing.T) {
 	t.Parallel()
 
 	mountsnoopCmd := &Command{
-		Name:           "StartMountsnoopGadget",
-		Cmd:            fmt.Sprintf("$KUBECTL_GADGET trace mount -n %s", ns),
-		ExpectedRegexp: fmt.Sprintf(`%s\s+test-pod\s+test-pod+\s+mount\s+\d+\s+\d+\s+\d+\s+mount\("/mnt", "/mnt", .*\) = -2`, ns),
-		StartAndStop:   true,
+		Name:         "StartMountsnoopGadget",
+		Cmd:          fmt.Sprintf("$KUBECTL_GADGET trace mount -n %s -o json", ns),
+		StartAndStop: true,
+		ExpectedOutputFn: func(output string) error {
+			expectedEntry := &mountTypes.Event{
+				Event:     BuildBaseEvent(ns),
+				Comm:      "mount",
+				Operation: "mount",
+				Retval:    -2,
+				Source:    "/mnt",
+				Target:    "/mnt",
+			}
+
+			normalize := func(e *mountTypes.Event) {
+				e.Node = ""
+				e.Pid = 0
+				e.Tid = 0
+				e.MountNsID = 0
+				e.Latency = 0
+				e.Fs = ""
+				e.Data = ""
+				e.Flags = nil
+				e.FlagsRaw = 0
+			}
+
+			return ExpectEntriesToMatch(output, normalize, expectedEntry)
+		},
 	}
 
 	commands := []*Command{


### PR DESCRIPTION
# trace/mount: Use columns library

The trace mount gadget now uses the columns library

See https://github.com/kinvolk/inspektor-gadget/issues/1003

## Testing done

Columnwidths are not the same as the old one. Currently it looks like this:
![image](https://user-images.githubusercontent.com/113581185/194031540-a514c511-83c2-42f2-9726-a99b88ce68fa.png)

