### PR TITLE
integration-tests: Fix Opensnoop test again

### DIFF
--- a/integration/inspektor-gadget/integration_test.go
+++ b/integration/inspektor-gadget/integration_test.go
@@ -829,7 +829,7 @@ func TestOpensnoop(t *testing.T) {
 				e.UID = 0
 			}
 
-			return ExpectAllToMatch(output, normalize, expectedEntry)
+			return ExpectEntriesToMatch(output, normalize, expectedEntry)
 		},
 	}
 


### PR DESCRIPTION
During #946 it seems that we lost the fix introduced by #984 in rebase. This patch reintroduces the fix.

## Testing done
A manual run against the ARO cluster is passing now.
